### PR TITLE
Feat/resize

### DIFF
--- a/contract/README.md
+++ b/contract/README.md
@@ -87,14 +87,33 @@ enum Status {
     FINAL     // Ready to be closed
 }
 
-// Constants for participant indices
-uint256 constant CREATOR = 0; // Participant index for the channel creator
-uint256 constant BROKER = 1; // Participant index for the broker in clearnet context
-
 // Magic numbers for funding protocol
 uint32 constant CHANOPEN = 7877; // State.data value for funding stateHash
 uint32 constant CHANCLOSE = 7879; // State.data value for closing stateHash
 uint32 constant CHANRESIZE = 7883; // State.data value for resize stateHash
+```
+
+### `IComparable.sol`
+
+Interface for contracts that can determine ordering between states:
+
+```solidity
+interface IComparable {
+    /**
+     * @notice Compares two states to determine their relative ordering
+     * @dev Implementations should return:
+     *      -1 if candidate is less recent than previous
+     *       0 if candidate is equally recent as previous
+     *       1 if candidate is more recent than previous
+     * @param candidate The state being evaluated
+     * @param previous The reference state to compare against
+     * @return result The comparison result:
+     *         -1: candidate < previous (candidate is older)
+     *          0: candidate == previous (same recency)
+     *          1: candidate > previous (candidate is newer)
+     */
+    function compare(State calldata candidate, State calldata previous) external view returns (int8 result);
+}
 ```
 
 ### `IAdjudicator.sol`
@@ -142,17 +161,18 @@ interface IDeposit {
 }
 ```
 
-## `IChannel.sol` Interface
+### `IChannel.sol` Interface
 
 The main state channel interface implements:
 
 ```solidity
 interface IChannel {
-    event Created(bytes32 indexed channelId, Channel channel, Amount[] expected);
+    event Created(bytes32 indexed channelId, Channel channel, State initial);
     event Joined(bytes32 indexed channelId, uint256 index);
     event Opened(bytes32 indexed channelId);
     event Challenged(bytes32 indexed channelId, uint256 expiration);
     event Checkpointed(bytes32 indexed channelId);
+    event Resized(bytes32 indexed channelId, int256[] deltaAllocations);
     event Closed(bytes32 indexed channelId);
 
     /**
@@ -176,8 +196,10 @@ interface IChannel {
 
     /**
      * @notice Finalizes a channel with a mutually signed closing state
+     * @dev Requires all participants' signatures on a state with CHANCLOSE magic number,
+     *      or can be called after challenge period expires with the last valid state
      * @param channelId Unique identifier for the channel
-     * @param candidate The latest known valid state
+     * @param candidate The latest known valid state to be finalized
      * @param proofs Additional states required by the adjudicator to validate the candidate
      */
     function close(bytes32 channelId, State calldata candidate, State[] calldata proofs) external;
@@ -186,21 +208,16 @@ interface IChannel {
      * @notice All participants agree in setting a new allocation resulting in locking or unlocking funds
      * @dev Used for resizing channel allocations without withdrawing funds
      * @param channelId Unique identifier for the channel to resize
-     * @param candidate The latest known valid state
-     * @param proofs Additional states required by the adjudicator for validation
-     * @param ch Channel configuration (must match the existing channel)
-     * @param newFunding New allocation state with CHANRESIZE magic number
+     * @param candidate The latest known valid state for closing the current channel
      */
     function resize(
         bytes32 channelId,
-        State calldata candidate,
-        State[] calldata proofs,
-        Channel calldata ch,
-        State calldata newFunding
+        State calldata candidate
     ) external;
 
     /**
      * @notice Initiates or updates a challenge with a signed state
+     * @dev Starts a challenge period during which participants can respond with newer states
      * @param channelId Unique identifier for the channel
      * @param candidate The state being submitted as the latest valid state
      * @param proofs Additional states required by the adjudicator to validate the candidate
@@ -209,6 +226,7 @@ interface IChannel {
 
     /**
      * @notice Records a valid state on-chain without initiating a challenge
+     * @dev Used to establish on-chain proof of the latest state to prevent future disputes
      * @param channelId Unique identifier for the channel
      * @param candidate The state to checkpoint
      * @param proofs Additional states required by the adjudicator to validate the candidate

--- a/contract/README.md
+++ b/contract/README.md
@@ -94,6 +94,7 @@ uint256 constant BROKER = 1; // Participant index for the broker in clearnet con
 // Magic numbers for funding protocol
 uint32 constant CHANOPEN = 7877; // State.data value for funding stateHash
 uint32 constant CHANCLOSE = 7879; // State.data value for closing stateHash
+uint32 constant CHANRESIZE = 7883; // State.data value for resize stateHash
 ```
 
 ### `IAdjudicator.sol`
@@ -152,7 +153,7 @@ interface IChannel {
     event Opened(bytes32 indexed channelId);
     event Challenged(bytes32 indexed channelId, uint256 expiration);
     event Checkpointed(bytes32 indexed channelId);
-    event ChannelClosed(bytes32 indexed channelId);
+    event Closed(bytes32 indexed channelId);
 
     /**
      * @notice Creates a new channel and initializes funding
@@ -182,19 +183,20 @@ interface IChannel {
     function close(bytes32 channelId, State calldata candidate, State[] calldata proofs) external;
 
     /**
-     * @notice Closes an existing channel and creates a new one with updated parameters
-     * @param channelId Unique identifier for the channel to close
-     * @param candidate The latest known valid state for closing the current channel
-     * @param proofs Additional states required by the adjudicator for closing
-     * @param ch New channel configuration for the replacement channel
-     * @param initial Initial state for the new channel with CHANOPEN magic number
+     * @notice All participants agree in setting a new allocation resulting in locking or unlocking funds
+     * @dev Used for resizing channel allocations without withdrawing funds
+     * @param channelId Unique identifier for the channel to resize
+     * @param candidate The latest known valid state
+     * @param proofs Additional states required by the adjudicator for validation
+     * @param ch Channel configuration (must match the existing channel)
+     * @param newFunding New allocation state with CHANRESIZE magic number
      */
-    function reset(
+    function resize(
         bytes32 channelId,
         State calldata candidate,
         State[] calldata proofs,
         Channel calldata ch,
-        State calldata initial
+        State calldata newFunding
     ) external;
 
     /**

--- a/contract/src/Custody.sol
+++ b/contract/src/Custody.sol
@@ -5,7 +5,17 @@ import {IChannel} from "./interfaces/IChannel.sol";
 import {IDeposit} from "./interfaces/IDeposit.sol";
 import {IAdjudicator} from "./interfaces/IAdjudicator.sol";
 import {IComparable} from "./interfaces/IComparable.sol";
-import {Channel, State, Allocation, Status, Signature, Amount, CHANOPEN, CHANCLOSE, CHANRESIZE} from "./interfaces/Types.sol";
+import {
+    Channel,
+    State,
+    Allocation,
+    Status,
+    Signature,
+    Amount,
+    CHANOPEN,
+    CHANCLOSE,
+    CHANRESIZE
+} from "./interfaces/Types.sol";
 import {Utils} from "./Utils.sol";
 import {IERC20} from "lib/openzeppelin-contracts/contracts/interfaces/IERC20.sol";
 import {EnumerableSet} from "lib/openzeppelin-contracts/contracts/utils/structs/EnumerableSet.sol";
@@ -387,10 +397,7 @@ contract Custody is IChannel, IDeposit {
      * @param channelId Unique identifier for the channel to resize
      * @param candidate The state with CHANRESIZE magic number and resize amounts
      */
-    function resize(
-        bytes32 channelId,
-        State calldata candidate
-    ) external {
+    function resize(bytes32 channelId, State calldata candidate) external {
         Metadata storage meta = _channels[channelId];
 
         // Verify channel exists and is ACTIVE
@@ -417,8 +424,8 @@ contract Custody is IChannel, IDeposit {
     }
 
     function _requireCorrectAllocations(Allocation[] memory allocations) internal pure {
-        if(allocations.length != 2) revert InvalidState();
-        if(allocations[CREATOR].token != allocations[BROKER].token) revert InvalidState();
+        if (allocations.length != 2) revert InvalidState();
+        if (allocations[CREATOR].token != allocations[BROKER].token) revert InvalidState();
     }
 
     function _transfer(address token, address to, uint256 amount) internal {
@@ -531,7 +538,11 @@ contract Custody is IChannel, IDeposit {
         return IComparable(adjudicator).compare(candidate, previous) > 0;
     }
 
-    function _requireCorrectDelta(Amount[2] memory initialDeposit, Allocation[] memory finalAllocations, int256[] memory delta) internal pure {
+    function _requireCorrectDelta(
+        Amount[2] memory initialDeposit,
+        Allocation[] memory finalAllocations,
+        int256[] memory delta
+    ) internal pure {
         if (delta.length != 2) revert InvalidState();
 
         // separately check for each participant to guarantee each of them can afford the delta
@@ -540,7 +551,9 @@ contract Custody is IChannel, IDeposit {
             int256 finalBalanceSum = int256(initialBalanceSum) + delta[i];
             uint256 candidateBalanceSum = finalAllocations[i].amount;
 
-            if (finalBalanceSum != int256(candidateBalanceSum)) revert InsufficientBalance(candidateBalanceSum, uint256(finalBalanceSum));
+            if (finalBalanceSum != int256(candidateBalanceSum)) {
+                revert InsufficientBalance(candidateBalanceSum, uint256(finalBalanceSum));
+            }
         }
     }
 

--- a/contract/src/Custody.sol
+++ b/contract/src/Custody.sol
@@ -5,7 +5,18 @@ import {IChannel} from "./interfaces/IChannel.sol";
 import {IDeposit} from "./interfaces/IDeposit.sol";
 import {IAdjudicator} from "./interfaces/IAdjudicator.sol";
 import {IComparable} from "./interfaces/IComparable.sol";
-import {Channel, State, Allocation, Status, Signature, Amount, CHANOPEN, CHANCLOSE} from "./interfaces/Types.sol";
+import {
+    Channel,
+    State,
+    Allocation,
+    Status,
+    Signature,
+    Amount,
+    CHANOPEN,
+    CHANCLOSE,
+    CREATOR,
+    BROKER
+} from "./interfaces/Types.sol";
 import {Utils} from "./Utils.sol";
 import {IERC20} from "lib/openzeppelin-contracts/contracts/interfaces/IERC20.sol";
 import {EnumerableSet} from "lib/openzeppelin-contracts/contracts/utils/structs/EnumerableSet.sol";

--- a/contract/src/Custody.sol
+++ b/contract/src/Custody.sol
@@ -344,6 +344,7 @@ contract Custody is IChannel, IDeposit {
      * @param candidate The latest known valid state
      * @param proofs is an array of valid state required by the adjudicator
      */
+    // TODO: add responding to CHANOPEN, CHANRESIZE challenge (should NOT call `adjudicate`)
     function checkpoint(bytes32 channelId, State calldata candidate, State[] calldata proofs) external {
         Metadata storage meta = _channels[channelId];
 

--- a/contract/src/Custody.sol
+++ b/contract/src/Custody.sol
@@ -360,27 +360,11 @@ contract Custody is IChannel, IDeposit {
         emit Checkpointed(channelId);
     }
 
-    /**
-     * @notice Reset will close and open channel for resizing allocations
-     * @param channelId Unique identifier for the channel
-     * @param candidate The latest known valid state
-     * @param proofs An array of valid state required by the adjudicator
-     * @param newChannel New channel configuration (must have exactly 2 participants)
-     * @param newDeposit Initial State defined by the opener, containing the expected allocation
-     */
-    function reset(
-        bytes32 channelId,
-        State calldata candidate,
-        State[] calldata proofs,
-        Channel calldata newChannel,
-        State calldata newDeposit
-    ) external {
-        // First close the existing channel
-        close(channelId, candidate, proofs);
-
-        // Then open a new channel with the provided configuration
-        create(newChannel, newDeposit);
-    }
+    //TODO: Implement resize
+    // validate channel, state is signed by both participants
+    // calculate the delta of funding between by deduction
+    // call _transfer to reflect the newFunding state desired
+    // Set ACTIVE
 
     /**
      * @notice Internal function to close a channel and distribute funds

--- a/contract/src/Custody.sol
+++ b/contract/src/Custody.sol
@@ -5,18 +5,7 @@ import {IChannel} from "./interfaces/IChannel.sol";
 import {IDeposit} from "./interfaces/IDeposit.sol";
 import {IAdjudicator} from "./interfaces/IAdjudicator.sol";
 import {IComparable} from "./interfaces/IComparable.sol";
-import {
-    Channel,
-    State,
-    Allocation,
-    Status,
-    Signature,
-    Amount,
-    CHANOPEN,
-    CHANCLOSE,
-    CREATOR,
-    BROKER
-} from "./interfaces/Types.sol";
+import {Channel, State, Allocation, Status, Signature, Amount, CHANOPEN, CHANCLOSE} from "./interfaces/Types.sol";
 import {Utils} from "./Utils.sol";
 import {IERC20} from "lib/openzeppelin-contracts/contracts/interfaces/IERC20.sol";
 import {EnumerableSet} from "lib/openzeppelin-contracts/contracts/utils/structs/EnumerableSet.sol";

--- a/contract/src/interfaces/IChannel.sol
+++ b/contract/src/interfaces/IChannel.sol
@@ -81,18 +81,13 @@ interface IChannel {
     /**
      * @notice All participants agree in setting a new allocation resulting in locking or unlocking funds
      * @dev Used for resizing channel allocations without withdrawing funds
-     * @param channelId Unique identifier for the channel to close
+     * @param channelId Unique identifier for the channel to resize
      * @param candidate The latest known valid state for closing the current channel
-     * @param proofs Additional states required by the adjudicator for closing
-     * @param ch New channel configuration for the replacement channel
-     * @param newFunding new allocation state for the new channel with CHANRESIZE magic number
+     * NOTE: no `proof` here as `adjudicate(...)` is NOT called, because candidate state does NOT contain app-specific logic
      */
     function resize(
         bytes32 channelId,
-        State calldata candidate,
-        State[] calldata proofs,
-        Channel calldata ch,
-        State calldata newFunding
+        State calldata candidate
     ) external;
 
     /**

--- a/contract/src/interfaces/IChannel.sol
+++ b/contract/src/interfaces/IChannel.sol
@@ -95,10 +95,7 @@ interface IChannel {
      * NOTE: while the aforementioned in NOT implemented, participants should sign the candidate with `resize` only
      * after they have checked that the resize is possible, based on the previously known valid state.
      */
-    function resize(
-        bytes32 channelId,
-        State calldata candidate
-    ) external;
+    function resize(bytes32 channelId, State calldata candidate) external;
 
     /**
      * @notice Initiates or updates a challenge with a signed state

--- a/contract/src/interfaces/IChannel.sol
+++ b/contract/src/interfaces/IChannel.sol
@@ -47,7 +47,7 @@ interface IChannel {
      * @notice Emitted when a channel is closed and funds are distributed
      * @param channelId Unique identifier for the channel
      */
-    event ChannelClosed(bytes32 indexed channelId);
+    event Closed(bytes32 indexed channelId);
 
     /**
      * @notice Creates a new channel and initializes funding
@@ -79,20 +79,20 @@ interface IChannel {
     function close(bytes32 channelId, State calldata candidate, State[] calldata proofs) external;
 
     /**
-     * @notice Closes an existing channel and creates a new one with updated parameters
-     * @dev Used for resizing channel allocations without fully withdrawing funds
+     * @notice All participants agree in setting a new allocation resulting in locking or unlocking funds
+     * @dev Used for resizing channel allocations without withdrawing funds
      * @param channelId Unique identifier for the channel to close
      * @param candidate The latest known valid state for closing the current channel
      * @param proofs Additional states required by the adjudicator for closing
      * @param ch New channel configuration for the replacement channel
-     * @param initial Initial state for the new channel with CHANOPEN magic number
+     * @param newFunding new allocation state for the new channel with CHANRESIZE magic number
      */
-    function reset(
+    function resize(
         bytes32 channelId,
         State calldata candidate,
         State[] calldata proofs,
         Channel calldata ch,
-        State calldata initial
+        State calldata newFunding
     ) external;
 
     /**

--- a/contract/src/interfaces/IChannel.sol
+++ b/contract/src/interfaces/IChannel.sol
@@ -44,6 +44,12 @@ interface IChannel {
     event Checkpointed(bytes32 indexed channelId);
 
     /**
+     * @notice Emitted when a channel is resized
+     * @param channelId Unique identifier for the channel
+     */
+    event Resized(bytes32 indexed channelId, int256[] deltaAllocations);
+
+    /**
      * @notice Emitted when a channel is closed and funds are distributed
      * @param channelId Unique identifier for the channel
      */

--- a/contract/src/interfaces/IChannel.sol
+++ b/contract/src/interfaces/IChannel.sol
@@ -90,6 +90,10 @@ interface IChannel {
      * @param channelId Unique identifier for the channel to resize
      * @param candidate The latest known valid state for closing the current channel
      * NOTE: no `proof` here as `adjudicate(...)` is NOT called, because candidate state does NOT contain app-specific logic
+     * TODO: On the other hand, `proof` can be used as a safeguard against an impossible resize, i.e. guaranteeing that
+     * there is enough funds in `proof` (should be state before candidate) to support the resize (delta).
+     * NOTE: while the aforementioned in NOT implemented, participants should sign the candidate with `resize` only
+     * after they have checked that the resize is possible, based on the previously known valid state.
      */
     function resize(
         bytes32 channelId,

--- a/contract/src/interfaces/Types.sol
+++ b/contract/src/interfaces/Types.sol
@@ -72,3 +72,4 @@ enum Status {
 // Magic numbers for funding protocol
 uint32 constant CHANOPEN = 7877; // State.data value for funding stateHash
 uint32 constant CHANCLOSE = 7879; // State.data value for closing stateHash
+uint32 constant CHANRESIZE = 7883; // State.data value for resize stateHash

--- a/contract/test/Custody.t.sol
+++ b/contract/test/Custody.t.sol
@@ -9,7 +9,17 @@ import {ECDSA} from "lib/openzeppelin-contracts/contracts/utils/cryptography/ECD
 
 import {TestUtils} from "./TestUtils.sol";
 import {Custody} from "../src/Custody.sol";
-import {Channel, State, Allocation, Signature, Status, Amount, CHANOPEN, CHANCLOSE, CHANRESIZE} from "../src/interfaces/Types.sol";
+import {
+    Channel,
+    State,
+    Allocation,
+    Signature,
+    Status,
+    Amount,
+    CHANOPEN,
+    CHANCLOSE,
+    CHANRESIZE
+} from "../src/interfaces/Types.sol";
 import {Utils} from "../src/Utils.sol";
 
 import {FlagAdjudicator} from "./mocks/FlagAdjudicator.sol";
@@ -690,7 +700,7 @@ contract CustodyTest is Test {
         // Create resize data with magic number and resize amounts
         int256[] memory resizeAmounts = new int256[](2);
         resizeAmounts[0] = int256(DEPOSIT_AMOUNT); // Increase host's deposit by DEPOSIT_AMOUNT
-        resizeAmounts[1] = -int256(DEPOSIT_AMOUNT/2); // Decrease guest's deposit by DEPOSIT_AMOUNT/2
+        resizeAmounts[1] = -int256(DEPOSIT_AMOUNT / 2); // Decrease guest's deposit by DEPOSIT_AMOUNT/2
         resizeState.data = abi.encode(CHANRESIZE, resizeAmounts);
 
         // Update allocations to match the resize
@@ -730,7 +740,9 @@ contract CustodyTest is Test {
         assertEq(guestLocked, DEPOSIT_AMOUNT / 2, "Guest should still have DEPOSIT_AMOUNT/2 locked");
 
         uint256 guestBalance = token.balanceOf(guest);
-        assertEq(guestBalance, INITIAL_BALANCE - DEPOSIT_AMOUNT * 3 / 2, "Guest should have correct tokens after withdrawal");
+        assertEq(
+            guestBalance, INITIAL_BALANCE - DEPOSIT_AMOUNT * 3 / 2, "Guest should have correct tokens after withdrawal"
+        );
     }
 
     // ==== 7. Separate Depositor and Participant Addresses ====

--- a/contract/test/Custody.t.sol
+++ b/contract/test/Custody.t.sol
@@ -9,7 +9,7 @@ import {ECDSA} from "lib/openzeppelin-contracts/contracts/utils/cryptography/ECD
 
 import {TestUtils} from "./TestUtils.sol";
 import {Custody} from "../src/Custody.sol";
-import {Channel, State, Allocation, Signature, Status, Amount, CHANOPEN, CHANCLOSE} from "../src/interfaces/Types.sol";
+import {Channel, State, Allocation, Signature, Status, Amount, CHANOPEN, CHANCLOSE, CHANRESIZE} from "../src/interfaces/Types.sol";
 import {Utils} from "../src/Utils.sol";
 
 import {FlagAdjudicator} from "./mocks/FlagAdjudicator.sol";
@@ -652,9 +652,9 @@ contract CustodyTest is Test {
         vm.stopPrank();
     }
 
-    // ==== 6. Reset Function ====
+    // ==== 6. Resize Function ====
 
-    function test_Reset() public {
+    function test_Resize() public {
         // 1. Create and fund a channel
         Channel memory chan = createTestChannel();
         State memory initialState = createInitialState();
@@ -676,49 +676,42 @@ contract CustodyTest is Test {
         vm.prank(guest);
         custody.join(channelId, 1, guestSig);
 
-        // 2. Create a final state for closing
-        State memory finalState = createClosingState();
+        // 2. Create a resize state with CHANRESIZE magic number
+        State memory resizeState = initialState;
 
-        // Both sign the final state
-        Signature memory hostFinalSig = signState(chan, finalState, hostPrivKey);
-        Signature memory guestFinalSig = signState(chan, finalState, guestPrivKey);
+        // Create resize data with magic number and resize amounts
+        int256[] memory resizeAmounts = new int256[](2);
+        resizeAmounts[0] = int256(DEPOSIT_AMOUNT); // Increase host's deposit by DEPOSIT_AMOUNT
+        resizeAmounts[1] = -int256(DEPOSIT_AMOUNT/2); // Decrease guest's deposit by DEPOSIT_AMOUNT/2
+        resizeState.data = abi.encode(CHANRESIZE, resizeAmounts);
 
-        Signature[] memory finalSigs = new Signature[](2);
-        finalSigs[0] = hostFinalSig;
-        finalSigs[1] = guestFinalSig;
-        finalState.sigs = finalSigs;
+        // Update allocations to match the resize
+        resizeState.allocations[0].amount = DEPOSIT_AMOUNT * 2; // Host now has 2x initial amount
+        resizeState.allocations[1].amount = DEPOSIT_AMOUNT / 2; // Guest now has half initial amount
 
-        // 3. Create new channel config with different nonce
-        address[] memory participants = new address[](2);
-        participants[0] = host;
-        participants[1] = guest;
+        // Both sign the resize state
+        Signature memory hostResizeSig = signState(chan, resizeState, hostPrivKey);
+        Signature memory guestResizeSig = signState(chan, resizeState, guestPrivKey);
 
-        Channel memory newChan = Channel({
-            participants: participants,
-            adjudicator: address(adjudicator),
-            challenge: CHALLENGE_DURATION,
-            nonce: NONCE + 1
-        });
+        Signature[] memory resizeSigs = new Signature[](2);
+        resizeSigs[0] = hostResizeSig;
+        resizeSigs[1] = guestResizeSig;
+        resizeState.sigs = resizeSigs;
 
-        // 4. Create new initial state for the new channel
-        State memory newInitialState = createInitialState();
-
-        // Host signs new initial state
-        Signature memory hostNewSig = signState(newChan, newInitialState, hostPrivKey);
-        Signature[] memory newHostSigs = new Signature[](1);
-        newHostSigs[0] = hostNewSig;
-        newInitialState.sigs = newHostSigs;
-
-        // 5. Reset the channel
+        // 3. Resize the channel
         vm.prank(host);
-        custody.reset(channelId, finalState, new State[](0), newChan, newInitialState);
+        custody.resize(channelId, resizeState);
 
-        // 6. Verify old channel is closed and new one is open
+        // 4. Verify channel has been resized correctly
         bytes32[] memory hostChannels = custody.getAccountChannels(host);
-        assertEq(hostChannels.length, 1, "Host should have 1 channel after reset");
+        assertEq(hostChannels.length, 1, "Host should still have 1 channel after resize");
 
-        bytes32 newChannelId = Utils.getChannelId(newChan);
-        assertEq(hostChannels[0], newChannelId, "Host's channel should be the new one");
+        // Check locked amounts have been updated correctly
+        (, uint256 hostLocked,) = custody.getAccountInfo(host, address(token));
+        (, uint256 guestLocked,) = custody.getAccountInfo(guest, address(token));
+
+        assertEq(hostLocked, DEPOSIT_AMOUNT * 2, "Host's locked tokens should be doubled");
+        assertEq(guestLocked, DEPOSIT_AMOUNT / 2, "Guest's locked tokens should be halved");
     }
 
     // ==== 7. Separate Depositor and Participant Addresses ====


### PR DESCRIPTION
This PR mainly replaces `reset(...)` with `resize(...)` in Custody.sol, and updates a corresponding test.

`resize(...)` takes a `channelId` and a `candidate`, which contains:
- UPDATED allocations
- `CHANRESIZE` magic num AND `AMOUNTS[]` (should have a length of 2) of allocations deltas.

`resize(...)` logic:
- perform checks on a channel
- checks that `candidate` is unanimously signed
- check that `initialDeposit` + delta = `candidate.allocations`
- for each amount in delta:
    - if it is < 0, then unlocks funds from the channel
    - if it is > 0, locks more funds (if available) to the channel