### PR TITLE
feat: RPC interface update

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@erc7824/nitrolite",
-    "version": "0.0.4",
+    "version": "0.1.3",
     "description": "The Nitrolite SDK empowers developers to build high-performance, scalable web3 applications using state channels. It's designed to provide near-instant transactions and significantly improved user experiences by minimizing direct blockchain interactions.",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/sdk/test/client/index.test.ts
+++ b/sdk/test/client/index.test.ts
@@ -7,7 +7,9 @@ import { Allocation, Channel, StateIntent } from "../../src/client/types";
 
 describe("NitroliteClient", () => {
     let client: NitroliteClient;
-    const mockPublicClient = {} as any;
+    const mockPublicClient = {
+        waitForTransactionReceipt: jest.fn().mockResolvedValue({ status: "success" })
+    } as any;
     const mockAccount = { address: "0xOWNER" as Address };
     const mockWalletClient = { account: mockAccount } as any;
     const mockAddresses = {
@@ -100,6 +102,7 @@ describe("NitroliteClient", () => {
         test("success", async () => {
             const channel: Channel = {
                 participants: ["0x0", "0x1"], // List of participants in the channel [Host, Guest]
+                chainId: chainId, // Chain ID of the network
                 adjudicator: mockAddresses.adjudicator, // Address of the contract that validates final states
                 challenge: challengeDuration, // Duration in seconds for challenge period
                 nonce: 1n, // Unique per channel with same participants and adjudicator

--- a/sdk/test/rpc/nitrolite.test.ts
+++ b/sdk/test/rpc/nitrolite.test.ts
@@ -11,7 +11,7 @@ describe("NitroliteRPC", () => {
         (console.error as jest.Mock).mockRestore();
     });
     describe("createRequest", () => {
-        test("should create a valid request message without intent", () => {
+        test("should create a valid request message", () => {
             const requestId = 12345;
             const method = "test_method";
             const params = ["param1", "param2"];
@@ -21,21 +21,6 @@ describe("NitroliteRPC", () => {
 
             expect(result).toEqual({
                 req: [requestId, method, params, timestamp],
-            });
-        });
-
-        test("should create a valid request message with intent", () => {
-            const requestId = 12345;
-            const method = "test_method";
-            const params = ["param1", "param2"];
-            const timestamp = 1619876543210;
-            const intent = [1, 2, 3];
-
-            const result = NitroliteRPC.createRequest(requestId, method, params, timestamp, intent);
-
-            expect(result).toEqual({
-                req: [requestId, method, params, timestamp],
-                int: intent,
             });
         });
 
@@ -63,24 +48,7 @@ describe("NitroliteRPC", () => {
 
             expect(result).toEqual({
                 req: [requestId, method, params, timestamp],
-                acc: accountId,
-            });
-        });
-
-        test("should create a valid application request message with intent", () => {
-            const requestId = 12345;
-            const method = "test_method";
-            const params = ["param1", "param2"];
-            const timestamp = 1619876543210;
-            const accountId = "0xaccountId" as Hex;
-            const intent = [1, 2, 3];
-
-            const result = NitroliteRPC.createAppRequest(requestId, method, params, timestamp, accountId, intent);
-
-            expect(result).toEqual({
-                req: [requestId, method, params, timestamp],
-                acc: accountId,
-                int: intent,
+                sid: accountId,
             });
         });
     });
@@ -120,10 +88,10 @@ describe("NitroliteRPC", () => {
             });
         });
 
-        test("should parse a valid response message with acc field", () => {
+        test("should parse a valid response message with sid field", () => {
             const responseObj = {
                 res: [12345, "test_method", ["result1", "result2"], 1619876543210],
-                acc: "0xaccountId" as Hex,
+                sid: "0xaccountId" as Hex,
             };
 
             const result = NitroliteRPC.parseResponse(responseObj);
@@ -134,26 +102,7 @@ describe("NitroliteRPC", () => {
                 requestId: 12345,
                 method: "test_method",
                 data: ["result1", "result2"],
-                acc: "0xaccountId",
-                timestamp: 1619876543210,
-            });
-        });
-
-        test("should parse a valid response message with intent", () => {
-            const responseObj = {
-                res: [12345, "test_method", ["result1", "result2"], 1619876543210],
-                int: [1, 2, 3],
-            };
-
-            const result = NitroliteRPC.parseResponse(responseObj);
-
-            expect(result).toEqual({
-                isValid: true,
-                isError: false,
-                requestId: 12345,
-                method: "test_method",
-                data: ["result1", "result2"],
-                int: [1, 2, 3],
+                sid: "0xaccountId",
                 timestamp: 1619876543210,
             });
         });


### PR DESCRIPTION
## v0.1.0

> **Heads-up:** This release **breaks** compatibility with any code that still relies on
> `acc` or `int`.  Make sure to follow the migration notes before upgrading.

### ✨ Added
- **`createGetChannelsMessage`** message creator for fetching channel information.  

### ⚙️ Changed
- **RPC interface**
  - Replaced top-level `acc` with `sid` (session ID) everywhere.
  - Removed the deprecated `int` (intent) field.
  - Updated `CreateAppSessionRequest`, `CloseAppSessionRequest`, and `ResizeChannel`
    to use the new field names and allocation structure.
- **Type definitions** (`sdk/src/rpc/types.ts`)
  - Deleted `Intent`.
  - Added `AppSessionAllocation`.
  - Renamed:
    - `acc` → `sid`
    - `app_id` → `app_session_id`
- **API layer** (`sdk/src/rpc/api.ts`)
  - Function signatures now match the refactored RPC schema.
  - Exports new `createGetChannelsMessage` helper.
- **RPC helpers** (`sdk/src/rpc/nitrolite.ts`)
  - Dropped all intent-related logic.
  - `create*` / `parse*` helpers now rely solely on `sid`.

### 🗑️ Removed
- All intent-specific code paths and corresponding tests.

---

### 🚀 Migration Guide

1. **Update your payloads**  
   Change every occurrence of `acc` to `sid` and delete any `int` fields.

2. **Adjust**  
   - Replace `Intent` usages with the new allocation model (`AppSessionAllocation`).  
   - Switch `app_id` → `app_session_id` in your code.

4. **Run your test suite**  
   Expect renamed arguments (`sid`) and remove intent-related assertions.

---
