### PR TITLE
Make challengeDuration optional and default to 0, aligning with type definition

### DIFF
--- a/sdk/src/client/index.ts
+++ b/sdk/src/client/index.ts
@@ -38,7 +38,6 @@ export class NitroliteClient {
         if (!config.publicClient) throw new Errors.MissingParameterError("publicClient");
         if (!config.walletClient) throw new Errors.MissingParameterError("walletClient");
         if (!config.walletClient.account) throw new Errors.MissingParameterError("walletClient.account");
-        if (!config.challengeDuration) throw new Errors.MissingParameterError("challengeDuration");
         if (!config.addresses?.custody) throw new Errors.MissingParameterError("addresses.custody");
         if (!config.addresses?.adjudicator) throw new Errors.MissingParameterError("addresses.adjudicator");
         if (!config.addresses?.guestAddress) throw new Errors.MissingParameterError("addresses.guestAddress");
@@ -51,7 +50,7 @@ export class NitroliteClient {
         this.stateWalletClient = config.stateWalletClient ?? config.walletClient;
         this.account = config.walletClient.account;
         this.addresses = config.addresses;
-        this.challengeDuration = config.challengeDuration;
+        this.challengeDuration = config.challengeDuration || BigInt(0);
         this.chainId = config.chainId;
 
         this.nitroliteService = new NitroliteService(this.publicClient, this.addresses, this.walletClient, this.account);


### PR DESCRIPTION
## Refactor: Make `challengeDuration` optional and default to 0, aligning with type definition

This PR updates the `NitroliteClient` to make the `challengeDuration` configuration parameter truly optional, defaulting to `BigInt(0)` as originally intended and documented in the type definitions.

### Problem

Previously, although the type definition for `NitroliteClientConfig` indicated `challengeDuration` as optional with a default of 0 seconds, the client constructor would throw a `MissingParameterError` if it wasn't explicitly provided. This created a discrepancy between the documented type and the actual behavior.

### Solution

- The explicit check for `challengeDuration` in the constructor has been removed.
- The `challengeDuration` property is now assigned `config.challengeDuration || BigInt(0)`, ensuring it defaults to `0` if not supplied.

This change resolves the inconsistency and aligns the client's behavior with the documented type, providing a more predictable and developer-friendly experience.
