### PR TITLE
feat: add ability to deposit in existing virtual apps as well as join a newly created app

### DIFF
--- a/clearnode/app_session.go
+++ b/clearnode/app_session.go
@@ -3,26 +3,37 @@ package main
 import (
 	"time"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/lib/pq"
 )
 
 // AppSession represents a virtual payment application session between participants
 type AppSession struct {
-	ID                 uint           `gorm:"primaryKey"`
-	Protocol           string         `gorm:"column:protocol;default:'NitroRPC/0.2';not null"`
-	SessionID          string         `gorm:"column:session_id;not null;uniqueIndex"`
-	Challenge          uint64         `gorm:"column:challenge;"`
-	Nonce              uint64         `gorm:"column:nonce;not null"`
-	ParticipantWallets pq.StringArray `gorm:"type:text[];column:participants;not null"`
-	Weights            pq.Int64Array  `gorm:"type:integer[];column:weights"`
-	SessionData        string         `gorm:"column:session_data;type:text;not null"`
-	Quorum             uint64         `gorm:"column:quorum;default:100"`
-	Version            uint64         `gorm:"column:version;default:1"`
-	Status             ChannelStatus  `gorm:"column:status;not null"`
-	CreatedAt          time.Time
-	UpdatedAt          time.Time
+	ID           uint           `gorm:"primaryKey"`
+	Protocol     string         `gorm:"column:protocol;default:'NitroRPC/0.2';not null"`
+	SessionID    string         `gorm:"column:session_id;not null;uniqueIndex"`
+	Challenge    uint64         `gorm:"column:challenge;"`
+	Nonce        uint64         `gorm:"column:nonce;not null"`
+	Participants pq.StringArray `gorm:"type:text[];column:participants;not null"`
+	Weights      pq.Int64Array  `gorm:"type:integer[];column:weights"`
+	SessionData  string         `gorm:"column:session_data;type:text;not null"`
+	Quorum       uint64         `gorm:"column:quorum;default:100"`
+	Version      uint64         `gorm:"column:version;default:1"`
+	Status       ChannelStatus  `gorm:"column:status;not null"`
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
 }
 
 func (AppSession) TableName() string {
 	return "app_sessions"
+}
+
+// isAppSessionID checks if the given string is a valid AppSessionID
+func isAppSessionID(appSessionID string) bool {
+	// AppSessionID is a hex string of 64 characters prefixed with "0x"
+	if len(appSessionID) != 66 {
+		return false
+	}
+	_, err := hexutil.Decode(appSessionID)
+	return err == nil
 }

--- a/clearnode/app_session_service_test.go
+++ b/clearnode/app_session_service_test.go
@@ -40,16 +40,16 @@ func TestAppSessionService_CreateApplication(t *testing.T) {
 
 		params := &CreateAppSessionParams{
 			Definition: AppDefinition{
-				Protocol:           "test-proto",
-				ParticipantWallets: []string{userAddressA.Hex(), userAddressB.Hex()},
-				Weights:            []int64{1, 1},
-				Quorum:             2,
-				Challenge:          60,
-				Nonce:              uint64(time.Now().Unix()),
+				Protocol:     "test-proto",
+				Participants: []string{userAddressA.Hex(), userAddressB.Hex()},
+				Weights:      []int64{1, 1},
+				Quorum:       2,
+				Challenge:    60,
+				Nonce:        uint64(time.Now().Unix()),
 			},
 			Allocations: []AppAllocation{
-				{ParticipantWallet: userAddressA.Hex(), AssetSymbol: "usdc", Amount: decimal.NewFromInt(100)},
-				{ParticipantWallet: userAddressB.Hex(), AssetSymbol: "usdc", Amount: decimal.NewFromInt(200)},
+				{Participant: userAddressA.Hex(), AssetSymbol: "usdc", Amount: decimal.NewFromInt(100)},
+				{Participant: userAddressB.Hex(), AssetSymbol: "usdc", Amount: decimal.NewFromInt(200)},
 			},
 		}
 		rpcSigners := map[string]struct{}{
@@ -113,14 +113,14 @@ func TestAppSessionService_CreateApplication(t *testing.T) {
 		service := NewAppSessionService(db)
 		params := &CreateAppSessionParams{
 			Definition: AppDefinition{
-				Protocol:           "test-proto",
-				ParticipantWallets: []string{userAddressA.Hex(), userAddressB.Hex()},
-				Weights:            []int64{1, 0},
-				Quorum:             1,
-				Nonce:              uint64(time.Now().Unix()),
+				Protocol:     "test-proto",
+				Participants: []string{userAddressA.Hex(), userAddressB.Hex()},
+				Weights:      []int64{1, 0},
+				Quorum:       1,
+				Nonce:        uint64(time.Now().Unix()),
 			},
 			Allocations: []AppAllocation{
-				{ParticipantWallet: userAddressA.Hex(), AssetSymbol: "usdc", Amount: decimal.NewFromInt(100)},
+				{Participant: userAddressA.Hex(), AssetSymbol: "usdc", Amount: decimal.NewFromInt(100)},
 			},
 		}
 		rpcSigners := map[string]struct{}{userAddressA.Hex(): {}}
@@ -144,14 +144,14 @@ func TestAppSessionService_CreateApplication(t *testing.T) {
 		service := NewAppSessionService(db)
 		params := &CreateAppSessionParams{
 			Definition: AppDefinition{
-				Protocol:           "test-proto",
-				ParticipantWallets: []string{userAddressA.Hex(), userAddressB.Hex()},
-				Weights:            []int64{1, 0},
-				Quorum:             1,
-				Nonce:              uint64(time.Now().Unix()),
+				Protocol:     "test-proto",
+				Participants: []string{userAddressA.Hex(), userAddressB.Hex()},
+				Weights:      []int64{1, 0},
+				Quorum:       1,
+				Nonce:        uint64(time.Now().Unix()),
 			},
 			Allocations: []AppAllocation{
-				{ParticipantWallet: userAddressA.Hex(), AssetSymbol: "usdc", Amount: decimal.NewFromInt(100)},
+				{Participant: userAddressA.Hex(), AssetSymbol: "usdc", Amount: decimal.NewFromInt(100)},
 			},
 		}
 		rpcSigners := map[string]struct{}{userAddressA.Hex(): {}}
@@ -171,14 +171,14 @@ func TestAppSessionService_CreateApplication(t *testing.T) {
 		service := NewAppSessionService(db)
 		params := &CreateAppSessionParams{
 			Definition: AppDefinition{
-				Protocol:           "test-proto",
-				ParticipantWallets: []string{userAddressA.Hex(), userAddressB.Hex()},
-				Weights:            []int64{1, 0},
-				Quorum:             1,
-				Nonce:              uint64(time.Now().Unix()),
+				Protocol:     "test-proto",
+				Participants: []string{userAddressA.Hex(), userAddressB.Hex()},
+				Weights:      []int64{1, 0},
+				Quorum:       1,
+				Nonce:        uint64(time.Now().Unix()),
 			},
 			Allocations: []AppAllocation{
-				{ParticipantWallet: userAddressA.Hex(), AssetSymbol: "usdc", Amount: decimal.NewFromInt(-50)},
+				{Participant: userAddressA.Hex(), AssetSymbol: "usdc", Amount: decimal.NewFromInt(-50)},
 			},
 		}
 		rpcSigners := map[string]struct{}{userAddressA.Hex(): {}}
@@ -203,13 +203,13 @@ func TestAppSessionService_SubmitAppState(t *testing.T) {
 
 		service := NewAppSessionService(db)
 		session := &AppSession{
-			SessionID:          "test-session",
-			Protocol:           "test-proto",
-			ParticipantWallets: []string{userAddressA.Hex(), userAddressB.Hex()},
-			Weights:            []int64{1, 1},
-			Quorum:             2,
-			Status:             ChannelStatusOpen,
-			Version:            1,
+			SessionID:    "test-session",
+			Protocol:     "test-proto",
+			Participants: []string{userAddressA.Hex(), userAddressB.Hex()},
+			Weights:      []int64{1, 1},
+			Quorum:       2,
+			Status:       ChannelStatusOpen,
+			Version:      1,
 		}
 		require.NoError(t, db.Create(session).Error)
 		sessionAccountID := NewAccountID(session.SessionID)
@@ -220,8 +220,8 @@ func TestAppSessionService_SubmitAppState(t *testing.T) {
 		params := &SubmitAppStateParams{
 			AppSessionID: session.SessionID,
 			Allocations: []AppAllocation{
-				{ParticipantWallet: userAddressA.Hex(), AssetSymbol: "usdc", Amount: decimal.NewFromInt(50)},
-				{ParticipantWallet: userAddressB.Hex(), AssetSymbol: "usdc", Amount: decimal.NewFromInt(50)},
+				{Participant: userAddressA.Hex(), AssetSymbol: "usdc", Amount: decimal.NewFromInt(50)},
+				{Participant: userAddressB.Hex(), AssetSymbol: "usdc", Amount: decimal.NewFromInt(50)},
 			},
 		}
 
@@ -253,13 +253,13 @@ func TestAppSessionService_SubmitAppState(t *testing.T) {
 
 		service := NewAppSessionService(db)
 		session := &AppSession{
-			SessionID:          "test-session-negative",
-			Protocol:           "test-proto",
-			ParticipantWallets: []string{userAddressA.Hex(), userAddressB.Hex()},
-			Weights:            []int64{1, 1},
-			Quorum:             2,
-			Status:             ChannelStatusOpen,
-			Version:            1,
+			SessionID:    "test-session-negative",
+			Protocol:     "test-proto",
+			Participants: []string{userAddressA.Hex(), userAddressB.Hex()},
+			Weights:      []int64{1, 1},
+			Quorum:       2,
+			Status:       ChannelStatusOpen,
+			Version:      1,
 		}
 		require.NoError(t, db.Create(session).Error)
 		sessionAccountID := NewAccountID(session.SessionID)
@@ -270,8 +270,8 @@ func TestAppSessionService_SubmitAppState(t *testing.T) {
 		params := &SubmitAppStateParams{
 			AppSessionID: session.SessionID,
 			Allocations: []AppAllocation{
-				{ParticipantWallet: userAddressA.Hex(), AssetSymbol: "usdc", Amount: decimal.NewFromInt(-50)},
-				{ParticipantWallet: userAddressB.Hex(), AssetSymbol: "usdc", Amount: decimal.NewFromInt(150)},
+				{Participant: userAddressA.Hex(), AssetSymbol: "usdc", Amount: decimal.NewFromInt(-50)},
+				{Participant: userAddressB.Hex(), AssetSymbol: "usdc", Amount: decimal.NewFromInt(150)},
 			},
 		}
 
@@ -308,13 +308,13 @@ func TestAppSessionService_CloseApplication(t *testing.T) {
 		service.SetPublishBalanceUpdateCallback(publishBalanceUpdate)
 
 		session := &AppSession{
-			SessionID:          "test-session-close",
-			Protocol:           "test-proto",
-			ParticipantWallets: []string{userAddressA.Hex(), userAddressB.Hex()},
-			Weights:            []int64{1, 1},
-			Quorum:             2,
-			Status:             ChannelStatusOpen,
-			Version:            1,
+			SessionID:    "test-session-close",
+			Protocol:     "test-proto",
+			Participants: []string{userAddressA.Hex(), userAddressB.Hex()},
+			Weights:      []int64{1, 1},
+			Quorum:       2,
+			Status:       ChannelStatusOpen,
+			Version:      1,
 		}
 		require.NoError(t, db.Create(session).Error)
 		sessionAccountID := NewAccountID(session.SessionID)
@@ -327,8 +327,8 @@ func TestAppSessionService_CloseApplication(t *testing.T) {
 		params := &CloseAppSessionParams{
 			AppSessionID: session.SessionID,
 			Allocations: []AppAllocation{
-				{ParticipantWallet: userAddressA.Hex(), AssetSymbol: "usdc", Amount: decimal.NewFromInt(100)},
-				{ParticipantWallet: userAddressB.Hex(), AssetSymbol: "usdc", Amount: decimal.NewFromInt(200)},
+				{Participant: userAddressA.Hex(), AssetSymbol: "usdc", Amount: decimal.NewFromInt(100)},
+				{Participant: userAddressB.Hex(), AssetSymbol: "usdc", Amount: decimal.NewFromInt(200)},
 			},
 		}
 		rpcSigners := map[string]struct{}{
@@ -394,13 +394,13 @@ func TestAppSessionService_CloseApplication(t *testing.T) {
 		service.SetPublishBalanceUpdateCallback(publishBalanceUpdate)
 
 		session := &AppSession{
-			SessionID:          "test-session-close",
-			Protocol:           "test-proto",
-			ParticipantWallets: []string{userAddressA.Hex(), userAddressB.Hex()},
-			Weights:            []int64{1, 1},
-			Quorum:             2,
-			Status:             ChannelStatusOpen,
-			Version:            1,
+			SessionID:    "test-session-close",
+			Protocol:     "test-proto",
+			Participants: []string{userAddressA.Hex(), userAddressB.Hex()},
+			Weights:      []int64{1, 1},
+			Quorum:       2,
+			Status:       ChannelStatusOpen,
+			Version:      1,
 		}
 		require.NoError(t, db.Create(session).Error)
 		sessionAccountID := NewAccountID(session.SessionID)
@@ -413,8 +413,8 @@ func TestAppSessionService_CloseApplication(t *testing.T) {
 		params := &CloseAppSessionParams{
 			AppSessionID: session.SessionID,
 			Allocations: []AppAllocation{
-				{ParticipantWallet: userAddressA.Hex(), AssetSymbol: "usdc", Amount: decimal.NewFromInt(0)},
-				{ParticipantWallet: userAddressB.Hex(), AssetSymbol: "usdc", Amount: decimal.NewFromInt(0)},
+				{Participant: userAddressA.Hex(), AssetSymbol: "usdc", Amount: decimal.NewFromInt(0)},
+				{Participant: userAddressB.Hex(), AssetSymbol: "usdc", Amount: decimal.NewFromInt(0)},
 			},
 		}
 		rpcSigners := map[string]struct{}{
@@ -448,13 +448,13 @@ func TestAppSessionService_CloseApplication(t *testing.T) {
 
 		service := NewAppSessionService(db)
 		session := &AppSession{
-			SessionID:          "test-session-close-negative",
-			Protocol:           "test-proto",
-			ParticipantWallets: []string{userAddressA.Hex(), userAddressB.Hex()},
-			Weights:            []int64{1, 1},
-			Quorum:             2,
-			Status:             ChannelStatusOpen,
-			Version:            1,
+			SessionID:    "test-session-close-negative",
+			Protocol:     "test-proto",
+			Participants: []string{userAddressA.Hex(), userAddressB.Hex()},
+			Weights:      []int64{1, 1},
+			Quorum:       2,
+			Status:       ChannelStatusOpen,
+			Version:      1,
 		}
 		require.NoError(t, db.Create(session).Error)
 		sessionAccountID := NewAccountID(session.SessionID)
@@ -467,8 +467,8 @@ func TestAppSessionService_CloseApplication(t *testing.T) {
 		params := &CloseAppSessionParams{
 			AppSessionID: session.SessionID,
 			Allocations: []AppAllocation{
-				{ParticipantWallet: userAddressA.Hex(), AssetSymbol: "usdc", Amount: decimal.NewFromInt(-100)},
-				{ParticipantWallet: userAddressB.Hex(), AssetSymbol: "usdc", Amount: decimal.NewFromInt(400)},
+				{Participant: userAddressA.Hex(), AssetSymbol: "usdc", Amount: decimal.NewFromInt(-100)},
+				{Participant: userAddressB.Hex(), AssetSymbol: "usdc", Amount: decimal.NewFromInt(400)},
 			},
 		}
 		rpcSigners := map[string]struct{}{

--- a/clearnode/docs/API.md
+++ b/clearnode/docs/API.md
@@ -375,7 +375,15 @@ Retrieves the user's tag, which can be used for transfer operations. The tag is 
 
 This method allows a user to transfer assets from their unified balance to another account. The user must have sufficient funds for each asset being transferred. The operation will fail if any of the specified assets have insufficient funds.
 
-User may specify the `destination` (wallet address) or `destination_user_tag` (user tag) to identify the recipient. `destination_user_tag` is used if and only if the `destination` field is empty.
+User may specify the `destination` (wallet address or app_session_id) or `destination_user_tag` (user tag) to identify the recipient. `destination_user_tag` is used if and only if the `destination` field is empty.
+
+**Deposit to App Sessions:**
+When transferring to an app session the system validates:
+- The app session must be open
+- The user must be a participant in the session
+- The session version is automatically incremented upon successful deposit
+
+**Request (Transfer to another user's unified account):**
 
 CAUTION: Invalid destination address may result in loss of funds.
 Currently, `Transfer` supports ledger account of another user as destination (wallet address is identifier).
@@ -400,7 +408,7 @@ Currently, `Transfer` supports ledger account of another user as destination (wa
   "sig": ["0x9876fedcba..."]
 }
 
-// OR
+// OR (transfer by user tag)
 
 {
   "req": [1, "transfer", [{
@@ -413,6 +421,21 @@ Currently, `Transfer` supports ledger account of another user as destination (wa
       {
         "asset": "eth",
         "amount": "0.1"
+      }
+    ]
+  }], 1619123456789],
+  "sig": ["0x9876fedcba..."]
+}
+
+// OR (deposit into virtual app)
+
+{
+  "req": [1, "transfer", [{
+    "destination": "0x3456789012abcdef...", // App session ID
+    "allocations": [
+      {
+        "asset": "usdc",
+        "amount": "100.0"
       }
     ]
   }], 1619123456789],

--- a/clearnode/rpc_router_callback.go
+++ b/clearnode/rpc_router_callback.go
@@ -51,33 +51,3 @@ func (r *RPCRouter) SendTransferNotification(destinationWallet string, transferr
 	r.Node.Notify(destinationWallet, "tr", transferredAllocations)
 	r.lg.Info("transfer notification sent", "userID", destinationWallet, "transferred allocations", transferredAllocations)
 }
-
-// SendApplicationUpdate sends application update to all participants in the app session
-func (r *RPCRouter) SendApplicationUpdate(appSession AppSession, allocations []AppAllocation) {
-	for _, participant := range appSession.Participants {
-		walletAddress := participant
-		if wallet := GetWalletBySigner(participant); wallet != "" {
-			walletAddress = wallet
-		}
-
-		appUpdate := struct {
-			SessionID   string          `json:"session_id"`
-			Allocations []AppAllocation `json:"allocations"`
-			AppVersion  uint64          `json:"app_version"`
-			// More fields can be added as needed
-		}{
-			SessionID:   appSession.SessionID,
-			Allocations: allocations,
-			AppVersion:  appSession.Version,
-		}
-
-		r.Node.Notify(walletAddress, "app_upd", appUpdate)
-		r.lg.Info("app update sent",
-			"userID", walletAddress,
-			"participant", participant,
-			"sessionID", appSession.SessionID,
-			"version", appSession.Version,
-			"allocations", allocations,
-		)
-	}
-}

--- a/clearnode/rpc_router_callback.go
+++ b/clearnode/rpc_router_callback.go
@@ -51,3 +51,33 @@ func (r *RPCRouter) SendTransferNotification(destinationWallet string, transferr
 	r.Node.Notify(destinationWallet, "tr", transferredAllocations)
 	r.lg.Info("transfer notification sent", "userID", destinationWallet, "transferred allocations", transferredAllocations)
 }
+
+// SendApplicationUpdate sends application update to all participants in the app session
+func (r *RPCRouter) SendApplicationUpdate(appSession AppSession, allocations []AppAllocation) {
+	for _, participant := range appSession.Participants {
+		walletAddress := participant
+		if wallet := GetWalletBySigner(participant); wallet != "" {
+			walletAddress = wallet
+		}
+
+		appUpdate := struct {
+			SessionID   string          `json:"session_id"`
+			Allocations []AppAllocation `json:"allocations"`
+			AppVersion  uint64          `json:"app_version"`
+			// More fields can be added as needed
+		}{
+			SessionID:   appSession.SessionID,
+			Allocations: allocations,
+			AppVersion:  appSession.Version,
+		}
+
+		r.Node.Notify(walletAddress, "app_upd", appUpdate)
+		r.lg.Info("app update sent",
+			"userID", walletAddress,
+			"participant", participant,
+			"sessionID", appSession.SessionID,
+			"version", appSession.Version,
+			"allocations", allocations,
+		)
+	}
+}

--- a/clearnode/rpc_router_public.go
+++ b/clearnode/rpc_router_public.go
@@ -29,12 +29,12 @@ type GetAppDefinitionParams struct {
 }
 
 type AppDefinition struct {
-	Protocol           string   `json:"protocol"`
-	ParticipantWallets []string `json:"participants"`
-	Weights            []int64  `json:"weights"` // Signature weight for each participant.
-	Quorum             uint64   `json:"quorum"`
-	Challenge          uint64   `json:"challenge"`
-	Nonce              uint64   `json:"nonce"`
+	Protocol     string   `json:"protocol"`
+	Participants []string `json:"participants"`
+	Weights      []int64  `json:"weights"` // Signature weight for each participant.
+	Quorum       uint64   `json:"quorum"`
+	Challenge    uint64   `json:"challenge"`
+	Nonce        uint64   `json:"nonce"`
 }
 
 type GetAppSessionParams struct {
@@ -215,12 +215,12 @@ func (r *RPCRouter) HandleGetAppDefinition(c *RPCContext) {
 	}
 
 	c.Succeed(req.Method, AppDefinition{
-		Protocol:           vApp.Protocol,
-		ParticipantWallets: vApp.ParticipantWallets,
-		Weights:            vApp.Weights,
-		Quorum:             vApp.Quorum,
-		Challenge:          vApp.Challenge,
-		Nonce:              vApp.Nonce,
+		Protocol:     vApp.Protocol,
+		Participants: vApp.Participants,
+		Weights:      vApp.Weights,
+		Quorum:       vApp.Quorum,
+		Challenge:    vApp.Challenge,
+		Nonce:        vApp.Nonce,
 	})
 	logger.Info("application definition retrieved", "sessionID", params.AppSessionID)
 }
@@ -248,18 +248,18 @@ func (r *RPCRouter) HandleGetAppSessions(c *RPCContext) {
 	resp := make([]AppSessionResponse, len(sessions))
 	for i, session := range sessions {
 		resp[i] = AppSessionResponse{
-			AppSessionID:       session.SessionID,
-			Status:             string(session.Status),
-			ParticipantWallets: session.ParticipantWallets,
-			SessionData:        session.SessionData,
-			Protocol:           session.Protocol,
-			Challenge:          session.Challenge,
-			Weights:            session.Weights,
-			Quorum:             session.Quorum,
-			Version:            session.Version,
-			Nonce:              session.Nonce,
-			CreatedAt:          session.CreatedAt.Format(time.RFC3339),
-			UpdatedAt:          session.UpdatedAt.Format(time.RFC3339),
+			AppSessionID: session.SessionID,
+			Status:       string(session.Status),
+			Participants: session.Participants,
+			SessionData:  session.SessionData,
+			Protocol:     session.Protocol,
+			Challenge:    session.Challenge,
+			Weights:      session.Weights,
+			Quorum:       session.Quorum,
+			Version:      session.Version,
+			Nonce:        session.Nonce,
+			CreatedAt:    session.CreatedAt.Format(time.RFC3339),
+			UpdatedAt:    session.UpdatedAt.Format(time.RFC3339),
 		}
 	}
 

--- a/clearnode/rpc_router_public_test.go
+++ b/clearnode/rpc_router_public_test.go
@@ -433,13 +433,13 @@ func TestRPCRouterHandleGetAppDefinition_Success(t *testing.T) {
 
 	// Seed an AppSession
 	session := AppSession{
-		SessionID:          "0xSess123",
-		ParticipantWallets: []string{"0xA", "0xB"},
-		Protocol:           "proto",
-		Weights:            []int64{10, 20},
-		Quorum:             15,
-		Challenge:          30,
-		Nonce:              99,
+		SessionID:    "0xSess123",
+		Participants: []string{"0xA", "0xB"},
+		Protocol:     "proto",
+		Weights:      []int64{10, 20},
+		Quorum:       15,
+		Challenge:    30,
+		Nonce:        99,
 	}
 	require.NoError(t, router.DB.Create(&session).Error)
 
@@ -469,7 +469,7 @@ func TestRPCRouterHandleGetAppDefinition_Success(t *testing.T) {
 	def, ok := res.Params[0].(AppDefinition)
 	require.True(t, ok)
 	assert.Equal(t, session.Protocol, def.Protocol)
-	assert.EqualValues(t, session.ParticipantWallets, def.ParticipantWallets)
+	assert.EqualValues(t, session.Participants, def.Participants)
 	assert.EqualValues(t, session.Weights, def.Weights)
 	assert.Equal(t, session.Quorum, def.Quorum)
 	assert.Equal(t, session.Challenge, def.Challenge)
@@ -543,46 +543,46 @@ func TestRPCRouterHandleGetAppSessions(t *testing.T) {
 	baseTime := time.Now().Add(-24 * time.Hour)
 	sessions := []AppSession{
 		{
-			SessionID:          "0xSession1",
-			ParticipantWallets: []string{participantAddr, "0xParticipant2"},
-			SessionData:        `{"key":"value"}`,
-			Status:             ChannelStatusOpen,
-			Protocol:           "test-app-1",
-			Challenge:          60,
-			Weights:            []int64{50, 50},
-			Quorum:             75,
-			Nonce:              1,
-			Version:            1,
-			CreatedAt:          baseTime,
-			UpdatedAt:          baseTime,
+			SessionID:    "0xSession1",
+			Participants: []string{participantAddr, "0xParticipant2"},
+			SessionData:  `{"key":"value"}`,
+			Status:       ChannelStatusOpen,
+			Protocol:     "test-app-1",
+			Challenge:    60,
+			Weights:      []int64{50, 50},
+			Quorum:       75,
+			Nonce:        1,
+			Version:      1,
+			CreatedAt:    baseTime,
+			UpdatedAt:    baseTime,
 		},
 		{
-			SessionID:          "0xSession2",
-			ParticipantWallets: []string{participantAddr, "0xParticipant3"},
-			SessionData:        `{"key":"value"}`,
-			Status:             ChannelStatusClosed,
-			Protocol:           "test-app-2",
-			Challenge:          120,
-			Weights:            []int64{30, 70},
-			Quorum:             80,
-			Nonce:              2,
-			Version:            2,
-			CreatedAt:          baseTime.Add(1 * time.Hour),
-			UpdatedAt:          baseTime.Add(1 * time.Hour),
+			SessionID:    "0xSession2",
+			Participants: []string{participantAddr, "0xParticipant3"},
+			SessionData:  `{"key":"value"}`,
+			Status:       ChannelStatusClosed,
+			Protocol:     "test-app-2",
+			Challenge:    120,
+			Weights:      []int64{30, 70},
+			Quorum:       80,
+			Nonce:        2,
+			Version:      2,
+			CreatedAt:    baseTime.Add(1 * time.Hour),
+			UpdatedAt:    baseTime.Add(1 * time.Hour),
 		},
 		{
-			SessionID:          "0xSession3",
-			ParticipantWallets: []string{"0xParticipant4", "0xParticipant5"},
-			SessionData:        `{"key":"value"}`,
-			Status:             ChannelStatusOpen,
-			Protocol:           "test-app-3",
-			Challenge:          90,
-			Weights:            []int64{40, 60},
-			Quorum:             60,
-			Nonce:              3,
-			Version:            3,
-			CreatedAt:          baseTime.Add(2 * time.Hour),
-			UpdatedAt:          baseTime.Add(2 * time.Hour),
+			SessionID:    "0xSession3",
+			Participants: []string{"0xParticipant4", "0xParticipant5"},
+			SessionData:  `{"key":"value"}`,
+			Status:       ChannelStatusOpen,
+			Protocol:     "test-app-3",
+			Challenge:    90,
+			Weights:      []int64{40, 60},
+			Quorum:       60,
+			Nonce:        3,
+			Version:      3,
+			CreatedAt:    baseTime.Add(2 * time.Hour),
+			UpdatedAt:    baseTime.Add(2 * time.Hour),
 		},
 	}
 
@@ -688,17 +688,17 @@ func TestRPCRouterHandleGetAppSessions_Pagination(t *testing.T) {
 	}
 
 	testSessions := []AppSession{
-		{Nonce: 11, ParticipantWallets: []string{"0xParticipant11"}, Status: ChannelStatusOpen},
-		{Nonce: 10, ParticipantWallets: []string{"0xParticipant10"}, Status: ChannelStatusOpen},
-		{Nonce: 9, ParticipantWallets: []string{"0xParticipant9"}, Status: ChannelStatusOpen},
-		{Nonce: 8, ParticipantWallets: []string{"0xParticipant8"}, Status: ChannelStatusOpen},
-		{Nonce: 7, ParticipantWallets: []string{"0xParticipant7"}, Status: ChannelStatusOpen},
-		{Nonce: 6, ParticipantWallets: []string{"0xParticipant6"}, Status: ChannelStatusOpen},
-		{Nonce: 5, ParticipantWallets: []string{"0xParticipant5"}, Status: ChannelStatusOpen},
-		{Nonce: 4, ParticipantWallets: []string{"0xParticipant4"}, Status: ChannelStatusOpen},
-		{Nonce: 3, ParticipantWallets: []string{"0xParticipant3"}, Status: ChannelStatusOpen},
-		{Nonce: 2, ParticipantWallets: []string{"0xParticipant2"}, Status: ChannelStatusOpen},
-		{Nonce: 1, ParticipantWallets: []string{"0xParticipant1"}, Status: ChannelStatusOpen},
+		{Nonce: 11, Participants: []string{"0xParticipant11"}, Status: ChannelStatusOpen},
+		{Nonce: 10, Participants: []string{"0xParticipant10"}, Status: ChannelStatusOpen},
+		{Nonce: 9, Participants: []string{"0xParticipant9"}, Status: ChannelStatusOpen},
+		{Nonce: 8, Participants: []string{"0xParticipant8"}, Status: ChannelStatusOpen},
+		{Nonce: 7, Participants: []string{"0xParticipant7"}, Status: ChannelStatusOpen},
+		{Nonce: 6, Participants: []string{"0xParticipant6"}, Status: ChannelStatusOpen},
+		{Nonce: 5, Participants: []string{"0xParticipant5"}, Status: ChannelStatusOpen},
+		{Nonce: 4, Participants: []string{"0xParticipant4"}, Status: ChannelStatusOpen},
+		{Nonce: 3, Participants: []string{"0xParticipant3"}, Status: ChannelStatusOpen},
+		{Nonce: 2, Participants: []string{"0xParticipant2"}, Status: ChannelStatusOpen},
+		{Nonce: 1, Participants: []string{"0xParticipant1"}, Status: ChannelStatusOpen},
 	}
 
 	for i := range testSessions {


### PR DESCRIPTION
The changes are in the HandleTransfer method. Other changes are just cosmetic.

Most importantly, no changes to RPC :)

Use cases:
- One user can create an app session. specifying participants and setting their allocations to 0, and providing only his signature.
- Other participants can deposit their allocations by calling transfer(destination: app_session_id) and providing only their signature.
- Any participant of an app can always deposit more funds via transfer(destination: app_session_id).

One thing I'd like to clarify and discuss is the way we notify frontend about the update. Probably each participant of the app session should receive a notification.