### PR TITLE
refactor(clearnode): define `Signature []byte` type

### DIFF
--- a/clearnode/nitrolite/signature.go
+++ b/clearnode/nitrolite/signature.go
@@ -2,14 +2,39 @@ package nitrolite
 
 import (
 	"crypto/ecdsa"
+	"encoding/json"
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
+type Signature []byte
+
+func (s Signature) MarshalJSON() ([]byte, error) {
+	return json.Marshal(hexutil.Encode(s))
+}
+
+func (s *Signature) UnmarshalJSON(data []byte) error {
+	var hexStr string
+	if err := json.Unmarshal(data, &hexStr); err != nil {
+		return err
+	}
+	decoded, err := hexutil.Decode(hexStr)
+	if err != nil {
+		return err
+	}
+	*s = decoded
+	return nil
+}
+
+func (s Signature) String() string {
+	return hexutil.Encode(s)
+}
+
 // Sign hashes the provided data using Keccak256 and signs it with the given private key.
-func Sign(data []byte, privateKey *ecdsa.PrivateKey) ([]byte, error) {
+func Sign(data []byte, privateKey *ecdsa.PrivateKey) (Signature, error) {
 	if privateKey == nil {
 		return nil, fmt.Errorf("private key is nil")
 	}
@@ -28,7 +53,7 @@ func Sign(data []byte, privateKey *ecdsa.PrivateKey) ([]byte, error) {
 }
 
 // Verify checks if the signature on the provided data was created by the given address.
-func Verify(data []byte, sig []byte, address common.Address) (bool, error) {
+func Verify(data []byte, sig Signature, address common.Address) (bool, error) {
 	dataHash := crypto.Keccak256Hash(data)
 
 	pubKeyRaw, err := crypto.Ecrecover(dataHash.Bytes(), sig)

--- a/clearnode/rpc.go
+++ b/clearnode/rpc.go
@@ -9,10 +9,10 @@ import (
 
 // RPCMessage represents a complete message in the RPC protocol, including data and signatures
 type RPCMessage struct {
-	Req          *RPCData `json:"req,omitempty" validate:"required_without=Res,excluded_with=Res"`
-	Res          *RPCData `json:"res,omitempty" validate:"required_without=Req,excluded_with=Req"`
-	AppSessionID string   `json:"sid,omitempty"`
-	Sig          []string `json:"sig"`
+	Req          *RPCData    `json:"req,omitempty" validate:"required_without=Res,excluded_with=Res"`
+	Res          *RPCData    `json:"res,omitempty" validate:"required_without=Req,excluded_with=Req"`
+	AppSessionID string      `json:"sid,omitempty"`
+	Sig          []Signature `json:"sig"`
 }
 
 // ParseRPCMessage parses a JSON string into an RPCMessage
@@ -100,6 +100,6 @@ func CreateResponse(id uint64, method string, responseParams []any) *RPCMessage 
 			Params:    responseParams,
 			Timestamp: uint64(time.Now().UnixMilli()),
 		},
-		Sig: []string{},
+		Sig: []Signature{},
 	}
 }

--- a/clearnode/rpc_node.go
+++ b/clearnode/rpc_node.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/go-playground/validator/v10"
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
@@ -357,7 +356,7 @@ func prepareRawRPCResponse(signer *Signer, data *RPCData) ([]byte, error) {
 
 	responseMessage := &RPCMessage{
 		Res: data,
-		Sig: []string{hexutil.Encode(signature)},
+		Sig: []Signature{signature},
 	}
 	resMessageBytes, err := json.Marshal(responseMessage)
 	if err != nil {

--- a/clearnode/rpc_node_test.go
+++ b/clearnode/rpc_node_test.go
@@ -191,7 +191,7 @@ func TestRPCNode(t *testing.T) {
 
 		reqMsg := &RPCMessage{
 			Req: reqData,
-			Sig: []string{},
+			Sig: []Signature{},
 		}
 
 		// Send request

--- a/clearnode/rpc_router_auth.go
+++ b/clearnode/rpc_router_auth.go
@@ -244,7 +244,7 @@ func (r *RPCRouter) handleAuthJWTVerify(ctx context.Context, authParams AuthVeri
 }
 
 // handleAuthJWTVerify verifies the challenge signature and returns the policy, response data and rpc error message.
-func (r *RPCRouter) handleAuthSigVerify(ctx context.Context, sig string, authParams AuthVerifyParams) (*Policy, any, string) {
+func (r *RPCRouter) handleAuthSigVerify(ctx context.Context, sig Signature, authParams AuthVerifyParams) (*Policy, any, string) {
 	logger := LoggerFromContext(ctx)
 
 	challenge, err := r.AuthManager.GetChallenge(authParams.Challenge)

--- a/clearnode/rpc_router_private.go
+++ b/clearnode/rpc_router_private.go
@@ -83,7 +83,7 @@ type ResizeChannelResponse struct {
 	Version     uint64       `json:"version"`
 	Allocations []Allocation `json:"allocations"`
 	StateHash   string       `json:"state_hash"`
-	Signature   []byte       `json:"server_signature"`
+	Signature   Signature    `json:"server_signature"`
 }
 
 type Allocation struct {
@@ -104,7 +104,7 @@ type CloseChannelResponse struct {
 	StateData        string       `json:"state_data"`
 	FinalAllocations []Allocation `json:"allocations"`
 	StateHash        string       `json:"state_hash"`
-	Signature        []byte       `json:"server_signature"`
+	Signature        Signature    `json:"server_signature"`
 }
 
 type ChannelResponse struct {

--- a/clearnode/rpc_router_private_test.go
+++ b/clearnode/rpc_router_private_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
@@ -38,7 +37,7 @@ func TestRPCRouterHandleGetLedgerBalances(t *testing.T) {
 				Params:    []any{json.RawMessage(paramsJSON)},
 				Timestamp: uint64(time.Now().Unix()),
 			},
-			Sig: []string{"dummy-signature"},
+			Sig: []Signature{Signature([]byte("0xdummySignature"))},
 		},
 	}
 
@@ -197,7 +196,7 @@ func TestRPCRouterHandleGetUserTag(t *testing.T) {
 		// 2) Sign rawReq directly
 		sigBytes, err := userSigner.Sign(rawReq)
 		require.NoError(t, err)
-		c.Message.Sig = []string{hexutil.Encode(sigBytes)}
+		c.Message.Sig = []Signature{sigBytes}
 
 		// Call handler
 		router.HandleGetUserTag(c)
@@ -245,7 +244,7 @@ func TestRPCRouterHandleGetUserTag(t *testing.T) {
 		// 2) Sign rawReq directly
 		sigBytes, err := userSigner.Sign(rawReq)
 		require.NoError(t, err)
-		c.Message.Sig = []string{hexutil.Encode(sigBytes)}
+		c.Message.Sig = []Signature{sigBytes}
 
 		// Call handler
 		router.HandleGetUserTag(c)
@@ -312,7 +311,7 @@ func TestRPCRouterHandleTransfer(t *testing.T) {
 		// 2) Sign rawReq directly
 		sigBytes, err := senderSigner.Sign(rawReq)
 		require.NoError(t, err)
-		c.Message.Sig = []string{hexutil.Encode(sigBytes)}
+		c.Message.Sig = []Signature{sigBytes}
 
 		// Call handler
 		router.HandleTransfer(c)
@@ -401,7 +400,7 @@ func TestRPCRouterHandleTransfer(t *testing.T) {
 		require.NoError(t, GetWalletLedger(db, senderAddr).Record(senderAccountID, "usdc", decimal.NewFromInt(1000)))
 		require.NoError(t, GetWalletLedger(db, senderAddr).Record(senderAccountID, "eth", decimal.NewFromInt(5)))
 
-		// Setup user tag for receipient
+		// Setup user tag for recipient
 		recipientTag, err := GenerateOrRetrieveUserTag(db, recipientAddr.Hex())
 		require.NoError(t, err)
 
@@ -437,7 +436,7 @@ func TestRPCRouterHandleTransfer(t *testing.T) {
 		// 2) Sign rawReq directly
 		sigBytes, err := senderSigner.Sign(rawReq)
 		require.NoError(t, err)
-		c.Message.Sig = []string{hexutil.Encode(sigBytes)}
+		c.Message.Sig = []Signature{sigBytes}
 
 		// Call handler
 		router.HandleTransfer(c)
@@ -521,7 +520,7 @@ func TestRPCRouterHandleTransfer(t *testing.T) {
 		// 2) Sign rawReq directly
 		sigBytes, err := senderSigner.Sign(rawReq)
 		require.NoError(t, err)
-		c.Message.Sig = []string{hexutil.Encode(sigBytes)}
+		c.Message.Sig = []Signature{sigBytes}
 
 		// Call handler
 		router.HandleTransfer(c)
@@ -577,7 +576,7 @@ func TestRPCRouterHandleTransfer(t *testing.T) {
 		// 2) Sign rawReq directly
 		sigBytes, err := senderSigner.Sign(rawReq)
 		require.NoError(t, err)
-		c.Message.Sig = []string{hexutil.Encode(sigBytes)}
+		c.Message.Sig = []Signature{sigBytes}
 
 		// Call handler
 		router.HandleTransfer(c)
@@ -633,7 +632,7 @@ func TestRPCRouterHandleTransfer(t *testing.T) {
 		// 2) Sign rawReq directly
 		sigBytes, err := senderSigner.Sign(rawReq)
 		require.NoError(t, err)
-		c.Message.Sig = []string{hexutil.Encode(sigBytes)}
+		c.Message.Sig = []Signature{sigBytes}
 
 		// Call handler
 		router.HandleTransfer(c)
@@ -684,7 +683,7 @@ func TestRPCRouterHandleTransfer(t *testing.T) {
 		// 2) Sign rawReq directly
 		sigBytes, err := senderSigner.Sign(rawReq)
 		require.NoError(t, err)
-		c.Message.Sig = []string{hexutil.Encode(sigBytes)}
+		c.Message.Sig = []Signature{sigBytes}
 
 		// Call handler
 		router.HandleTransfer(c)
@@ -740,7 +739,7 @@ func TestRPCRouterHandleTransfer(t *testing.T) {
 		// 2) Sign rawReq directly
 		sigBytes, err := senderSigner.Sign(rawReq)
 		require.NoError(t, err)
-		c.Message.Sig = []string{hexutil.Encode(sigBytes)}
+		c.Message.Sig = []Signature{sigBytes}
 
 		// Call handler
 		router.HandleTransfer(c)
@@ -796,7 +795,7 @@ func TestRPCRouterHandleTransfer(t *testing.T) {
 		// 2) Sign rawReq directly
 		sigBytes, err := senderSigner.Sign(rawReq)
 		require.NoError(t, err)
-		c.Message.Sig = []string{hexutil.Encode(sigBytes)}
+		c.Message.Sig = []Signature{sigBytes}
 
 		// Call handler
 		router.HandleTransfer(c)
@@ -854,7 +853,7 @@ func TestRPCRouterHandleTransfer(t *testing.T) {
 		wrongSigner := Signer{privateKey: wrongKey}
 		sigBytes, err := wrongSigner.Sign(rawReq)
 		require.NoError(t, err)
-		c.Message.Sig = []string{hexutil.Encode(sigBytes)}
+		c.Message.Sig = []Signature{sigBytes}
 
 		// Call handler
 		router.HandleTransfer(c)
@@ -942,7 +941,7 @@ func TestRPCRouterHandleCreateAppSession(t *testing.T) {
 		require.NoError(t, err)
 		sigB, err := signerB.Sign(rawReq)
 		require.NoError(t, err)
-		c.Message.Sig = []string{hexutil.Encode(sigA), hexutil.Encode(sigB)}
+		c.Message.Sig = []Signature{sigA, sigB}
 
 		// Call handler
 		router.HandleCreateApplication(c)
@@ -1038,7 +1037,7 @@ func TestRPCRouterHandleCreateAppSession(t *testing.T) {
 		require.NoError(t, err)
 		sigB, err := signerB.Sign(rawReq)
 		require.NoError(t, err)
-		c.Message.Sig = []string{hexutil.Encode(sigA), hexutil.Encode(sigB)}
+		c.Message.Sig = []Signature{sigA, sigB}
 
 		// Call handler
 		router.HandleCreateApplication(c)
@@ -1129,7 +1128,7 @@ func TestRPCRouterHandleSubmitAppState(t *testing.T) {
 		// 2) Sign rawReq directly
 		sigBytes, err := signer.Sign(rawReq)
 		require.NoError(t, err)
-		c.Message.Sig = []string{hexutil.Encode(sigBytes)}
+		c.Message.Sig = []Signature{sigBytes}
 
 		// Call handler
 		router.HandleSubmitAppState(c)
@@ -1235,7 +1234,7 @@ func TestRPCRouterHandleCloseApplication(t *testing.T) {
 	// 2) Sign rawReq directly
 	sigBytes, err := signer.Sign(rawReq)
 	require.NoError(t, err)
-	c.Message.Sig = []string{hexutil.Encode(sigBytes)}
+	c.Message.Sig = []Signature{sigBytes}
 
 	// Call handler
 	router.HandleCloseApplication(c)
@@ -1334,7 +1333,7 @@ func TestRPCRouterHandleResizeChannel(t *testing.T) {
 		// 2) Sign rawReq directly
 		sigBytes, err := signer.Sign(rawReq)
 		require.NoError(t, err)
-		c.Message.Sig = []string{hexutil.Encode(sigBytes)}
+		c.Message.Sig = []Signature{sigBytes}
 
 		// Call handler
 		router.HandleResizeChannel(c)
@@ -1424,7 +1423,7 @@ func TestRPCRouterHandleResizeChannel(t *testing.T) {
 		// 2) Sign rawReq directly
 		sigBytes, err := signer.Sign(rawReq)
 		require.NoError(t, err)
-		c.Message.Sig = []string{hexutil.Encode(sigBytes)}
+		c.Message.Sig = []Signature{sigBytes}
 
 		// Call handler
 		router.HandleResizeChannel(c)
@@ -1480,7 +1479,7 @@ func TestRPCRouterHandleResizeChannel(t *testing.T) {
 		// 2) Sign rawReq directly
 		sigBytes, err := signer.Sign(rawReq)
 		require.NoError(t, err)
-		c.Message.Sig = []string{hexutil.Encode(sigBytes)}
+		c.Message.Sig = []Signature{sigBytes}
 
 		// Call handler
 		router.HandleResizeChannel(c)
@@ -1544,7 +1543,7 @@ func TestRPCRouterHandleResizeChannel(t *testing.T) {
 		// 2) Sign rawReq directly
 		sigBytes, err := signer.Sign(rawReq)
 		require.NoError(t, err)
-		c.Message.Sig = []string{hexutil.Encode(sigBytes)}
+		c.Message.Sig = []Signature{sigBytes}
 
 		// Call handler
 		router.HandleResizeChannel(c)
@@ -1608,7 +1607,7 @@ func TestRPCRouterHandleResizeChannel(t *testing.T) {
 		// 2) Sign rawReq directly
 		sigBytes, err := signer.Sign(rawReq)
 		require.NoError(t, err)
-		c.Message.Sig = []string{hexutil.Encode(sigBytes)}
+		c.Message.Sig = []Signature{sigBytes}
 
 		// Call handler
 		router.HandleResizeChannel(c)
@@ -1683,7 +1682,7 @@ func TestRPCRouterHandleResizeChannel(t *testing.T) {
 		// 2) Sign rawReq directly
 		sigBytes, err := signer.Sign(rawReq)
 		require.NoError(t, err)
-		c.Message.Sig = []string{hexutil.Encode(sigBytes)}
+		c.Message.Sig = []Signature{sigBytes}
 
 		// Call handler
 		router.HandleResizeChannel(c)
@@ -1753,7 +1752,7 @@ func TestRPCRouterHandleResizeChannel(t *testing.T) {
 		// 2) Sign rawReq directly
 		sigBytes, err := signer.Sign(rawReq)
 		require.NoError(t, err)
-		c.Message.Sig = []string{hexutil.Encode(sigBytes)}
+		c.Message.Sig = []Signature{sigBytes}
 
 		// Call handler
 		router.HandleResizeChannel(c)
@@ -1821,7 +1820,7 @@ func TestRPCRouterHandleResizeChannel(t *testing.T) {
 		// 2) Sign rawReq directly
 		sigBytes, err := signer.Sign(rawReq)
 		require.NoError(t, err)
-		c.Message.Sig = []string{hexutil.Encode(sigBytes)}
+		c.Message.Sig = []Signature{sigBytes}
 
 		// Call handler
 		router.HandleResizeChannel(c)
@@ -1893,7 +1892,7 @@ func TestRPCRouterHandleResizeChannel(t *testing.T) {
 		// 2) Sign rawReq directly
 		sigBytes, err := signer.Sign(rawReq)
 		require.NoError(t, err)
-		c.Message.Sig = []string{hexutil.Encode(sigBytes)}
+		c.Message.Sig = []Signature{sigBytes}
 
 		// Call handler
 		router.HandleResizeChannel(c)
@@ -1967,7 +1966,7 @@ func TestRPCRouterHandleResizeChannel(t *testing.T) {
 		// 2) Sign rawReq directly
 		sigBytes, err := signer.Sign(rawReq)
 		require.NoError(t, err)
-		c.Message.Sig = []string{hexutil.Encode(sigBytes)}
+		c.Message.Sig = []Signature{sigBytes}
 
 		// Call handler
 		router.HandleResizeChannel(c)
@@ -2035,7 +2034,7 @@ func TestRPCRouterHandleResizeChannel(t *testing.T) {
 		// 2) Sign rawReq directly
 		sigBytes, err := signer.Sign(rawReq)
 		require.NoError(t, err)
-		c.Message.Sig = []string{hexutil.Encode(sigBytes)}
+		c.Message.Sig = []Signature{sigBytes}
 
 		// Call handler
 		router.HandleResizeChannel(c)
@@ -2104,7 +2103,7 @@ func TestRPCRouterHandleResizeChannel(t *testing.T) {
 		// 2) Sign rawReq directly with wrong signer
 		sigBytes, err := wrongSigner.Sign(rawReq)
 		require.NoError(t, err)
-		c.Message.Sig = []string{hexutil.Encode(sigBytes)}
+		c.Message.Sig = []Signature{sigBytes}
 
 		// Call handler
 		router.HandleResizeChannel(c)
@@ -2174,7 +2173,7 @@ func TestRPCRouterHandleResizeChannel(t *testing.T) {
 		// 2) Sign rawReq directly
 		sigBytes, err := signer.Sign(rawReq)
 		require.NoError(t, err)
-		c.Message.Sig = []string{hexutil.Encode(sigBytes)}
+		c.Message.Sig = []Signature{sigBytes}
 
 		// Call handler
 		router.HandleResizeChannel(c)
@@ -2256,7 +2255,7 @@ func TestRPCRouterHandleResizeChannel(t *testing.T) {
 		// 2) Sign rawReq directly
 		sigBytes, err := signer.Sign(rawReq)
 		require.NoError(t, err)
-		c.Message.Sig = []string{hexutil.Encode(sigBytes)}
+		c.Message.Sig = []Signature{sigBytes}
 
 		// Call handler
 		router.HandleResizeChannel(c)
@@ -2355,7 +2354,7 @@ func TestRPCRouterHandleResizeChannel(t *testing.T) {
 		// 2) Sign rawReq directly
 		sigBytes, err := signer.Sign(rawReq)
 		require.NoError(t, err)
-		c.Message.Sig = []string{hexutil.Encode(sigBytes)}
+		c.Message.Sig = []Signature{sigBytes}
 
 		// Call handler
 		router.HandleResizeChannel(c)
@@ -2451,7 +2450,7 @@ func TestRPCRouterHandleCloseChannel(t *testing.T) {
 		// 2) Sign rawReq directly
 		sigBytes, err := signer.Sign(rawReq)
 		require.NoError(t, err)
-		c.Message.Sig = []string{hexutil.Encode(sigBytes)}
+		c.Message.Sig = []Signature{sigBytes}
 
 		// Call handler
 		router.HandleCloseChannel(c)
@@ -2545,7 +2544,7 @@ func TestRPCRouterHandleCloseChannel(t *testing.T) {
 		// 2) Sign rawReq directly
 		sigBytes, err := signer.Sign(rawReq)
 		require.NoError(t, err)
-		c.Message.Sig = []string{hexutil.Encode(sigBytes)}
+		c.Message.Sig = []Signature{sigBytes}
 
 		// Call handler
 		router.HandleCloseChannel(c)

--- a/clearnode/rpc_router_public_test.go
+++ b/clearnode/rpc_router_public_test.go
@@ -26,7 +26,7 @@ func TestRPCRouterHandlePing(t *testing.T) {
 				Params:    []any{nil},
 				Timestamp: uint64(time.Now().Unix()),
 			},
-			Sig: []string{"dummy-signature"},
+			Sig: []Signature{Signature([]byte("dummy-signature"))},
 		},
 	}
 
@@ -74,7 +74,7 @@ func TestRPCRouterHandleGetConfig(t *testing.T) {
 				Params:    []any{},
 				Timestamp: uint64(time.Now().Unix()),
 			},
-			Sig: []string{"dummy-signature"},
+			Sig: []Signature{Signature([]byte("dummy-signature"))},
 		},
 	}
 
@@ -159,7 +159,7 @@ func TestRPCRouterHandleGetAssets(t *testing.T) {
 						Params:    []any{json.RawMessage(paramsJSON)},
 						Timestamp: uint64(time.Now().Unix()),
 					},
-					Sig: []string{"dummy-signature"},
+					Sig: []Signature{Signature([]byte("dummy-signature"))},
 				},
 			}
 
@@ -304,7 +304,7 @@ func TestRPCRouterHandleGetChannels(t *testing.T) {
 						Params:    []any{json.RawMessage(paramsJSON)},
 						Timestamp: uint64(time.Now().Unix()),
 					},
-					Sig: []string{"dummy-signature"},
+					Sig: []Signature{Signature([]byte("dummy-signature"))},
 				},
 			}
 
@@ -405,7 +405,7 @@ func TestRPCRouterHandleGetChannels_Pagination(t *testing.T) {
 						Params:    []any{json.RawMessage(paramsJSON)},
 						Timestamp: uint64(time.Now().Unix()),
 					},
-					Sig: []string{"dummy-signature"},
+					Sig: []Signature{Signature([]byte("dummy-signature"))},
 				},
 			}
 
@@ -651,7 +651,7 @@ func TestRPCRouterHandleGetAppSessions(t *testing.T) {
 						Params:    []any{json.RawMessage(paramsJSON)},
 						Timestamp: uint64(time.Now().Unix()),
 					},
-					Sig: []string{"dummy-signature"},
+					Sig: []Signature{Signature([]byte("dummy-signature"))},
 				},
 			}
 
@@ -756,7 +756,7 @@ func TestRPCRouterHandleGetAppSessions_Pagination(t *testing.T) {
 						Params:    []any{json.RawMessage(paramsJSON)},
 						Timestamp: uint64(time.Now().Unix()),
 					},
-					Sig: []string{"dummy-signature"},
+					Sig: []Signature{Signature([]byte("dummy-signature"))},
 				},
 			}
 
@@ -919,7 +919,7 @@ func TestRPCRouterHandleGetLedgerEntries(t *testing.T) {
 						Params:    []any{json.RawMessage(paramsJSON)},
 						Timestamp: uint64(time.Now().Unix()),
 					},
-					Sig: []string{"dummy-signature"},
+					Sig: []Signature{Signature([]byte("dummy-signature"))},
 				},
 			}
 
@@ -1021,7 +1021,7 @@ func TestRPCRouterHandleGetLedgerEntries_Pagination(t *testing.T) {
 						Params:    []any{json.RawMessage(paramsJSON)},
 						Timestamp: uint64(time.Now().Unix()),
 					},
-					Sig: []string{"dummy-signature"},
+					Sig: []Signature{Signature([]byte("dummy-signature"))},
 				},
 			}
 

--- a/clearnode/rpc_store.go
+++ b/clearnode/rpc_store.go
@@ -36,10 +36,19 @@ func NewRPCStore(db *gorm.DB) *RPCStore {
 }
 
 // StoreMessage stores an RPC message in the database
-func (s *RPCStore) StoreMessage(sender string, req *RPCData, reqSig []string, resBytes []byte, resSig []string) error {
+func (s *RPCStore) StoreMessage(sender string, req *RPCData, reqSigs []Signature, resBytes []byte, resSigs []Signature) error {
 	paramsBytes, err := json.Marshal(req.Params)
 	if err != nil {
 		return err
+	}
+
+	reqSigStrs := make([]string, len(reqSigs))
+	for i, sig := range reqSigs {
+		reqSigStrs[i] = sig.String()
+	}
+	resSigStrs := make([]string, len(resSigs))
+	for i, sig := range resSigs {
+		resSigStrs[i] = sig.String()
 	}
 
 	msg := &RPCRecord{
@@ -48,8 +57,8 @@ func (s *RPCStore) StoreMessage(sender string, req *RPCData, reqSig []string, re
 		Method:    req.Method,
 		Params:    paramsBytes,
 		Response:  resBytes,
-		ReqSig:    reqSig,
-		ResSig:    resSig,
+		ReqSig:    reqSigStrs,
+		ResSig:    resSigStrs,
 		Timestamp: req.Timestamp,
 	}
 

--- a/clearnode/rpc_store_test.go
+++ b/clearnode/rpc_store_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -39,9 +40,9 @@ func TestRPCStoreStoreMessage(t *testing.T) {
 		"key1": "value1",
 		"key2": 42,
 	}
-	reqSig := []string{"sig1", "sig2"}
+	reqSig := []Signature{Signature(hexutil.MustDecode("0x1234")), Signature(hexutil.MustDecode("0x4567"))}
 	resBytes := []byte(`{"result": "ok"}`)
-	resSig := []string{"resSig1"}
+	resSig := []Signature{Signature(hexutil.MustDecode("0x4321"))}
 
 	// Create RPCData
 	req := &RPCData{
@@ -69,8 +70,18 @@ func TestRPCStoreStoreMessage(t *testing.T) {
 	assert.Equal(t, reqID, record.ReqID)
 	assert.Equal(t, method, record.Method)
 	assert.Equal(t, timestamp, record.Timestamp)
-	assert.ElementsMatch(t, reqSig, record.ReqSig)
-	assert.ElementsMatch(t, resSig, record.ResSig)
+
+	reqSigStrs := make([]string, len(reqSig))
+	for i, sig := range reqSig {
+		reqSigStrs[i] = sig.String()
+	}
+	assert.ElementsMatch(t, reqSigStrs, record.ReqSig)
+
+	resSigStrs := make([]string, len(resSig))
+	for i, sig := range resSig {
+		resSigStrs[i] = sig.String()
+	}
+	assert.ElementsMatch(t, resSigStrs, record.ResSig)
 	assert.Equal(t, resBytes, record.Response)
 
 	// Verify params were stored correctly
@@ -83,7 +94,7 @@ func TestRPCStoreStoreMessage(t *testing.T) {
 	// Extract the first element which is our original map
 	storedParams := storedParamsArray[0]
 	assert.Equal(t, "value1", storedParams["key1"])
-	assert.Equal(t, float64(42), storedParams["key2"]) // JSON unmarshals numbers as float64
+	assert.Equal(t, float64(42), storedParams["key2"]) // JSON unmarshal numbers as float64
 }
 
 // TestRPCStoreGetMessages tests retrieving RPC messages with pagination
@@ -224,11 +235,11 @@ func TestRPCStoreStoreMessageError(t *testing.T) {
 		Params:    []any{make(chan int)}, // Channels cannot be marshalled to JSON
 		Timestamp: uint64(time.Now().Unix()),
 	}
-	reqSig := []string{"sig1"}
+	reqSig := []Signature{Signature([]byte("sig1"))}
 	resBytes := []byte(`{"result": "ok"}`)
-	resSig := []string{"resSig1"}
+	resSig := []Signature{Signature([]byte("resSig1"))}
 
-	// Attempt to store the message, should fail due to unmarshalable params
+	// Attempt to store the message, should fail due to unmarshal-able params
 	err := store.StoreMessage(sender, req, reqSig, resBytes, resSig)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "json")

--- a/clearnode/rpc_test.go
+++ b/clearnode/rpc_test.go
@@ -16,7 +16,7 @@ func TestRPCMessageValidate(t *testing.T) {
 			Params:    []any{"param1", 2},
 			Timestamp: uint64(time.Now().Unix()),
 		},
-		Sig: []string{"0x1234567890abcdef"},
+		Sig: []Signature{Signature([]byte("0x1234567890abcdef"))},
 	}
 
 	if err := validate.Struct(rpcMsg); err != nil {

--- a/clearnode/signer_test.go
+++ b/clearnode/signer_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestEIPSignature(t *testing.T) {
@@ -12,6 +14,9 @@ func TestEIPSignature(t *testing.T) {
 			Amount: "0",
 		},
 	}
+	signature, err := hexutil.Decode("0xe758880bc3d75e9433e0f50c9b40712b0bcf90f437a8c42ba6f8a5a3d144a5ce4b10b020c4eb728323daad49c4cc6329eaa45e3ea88c95d76e55b982f6a0a8741b")
+	assert.NoError(t, err)
+
 	recoveredSigner, err := RecoverAddressFromEip712Signature(
 		"0x21f7d1f35979b125f6f7918fc16cb9101e5882d7",
 		"a9d5b4fd-ef30-4bb6-b9b6-4f2778f004fd",
@@ -21,7 +26,7 @@ func TestEIPSignature(t *testing.T) {
 		"console",
 		"0x21f7d1f35979b125f6f7918fc16cb9101e5882d7",
 		"1748608702",
-		"0xe758880bc3d75e9433e0f50c9b40712b0bcf90f437a8c42ba6f8a5a3d144a5ce4b10b020c4eb728323daad49c4cc6329eaa45e3ea88c95d76e55b982f6a0a8741b",
+		signature,
 	)
 
 	assert.Equal(t, recoveredSigner, "0x21F7D1F35979B125f6F7918fC16Cb9101e5882d7")

--- a/sdk/src/abis/generated.ts
+++ b/sdk/src/abis/generated.ts
@@ -1,1733 +1,1514 @@
 // Auto-generated file. Do not edit manually.
 export const custodyAbi = [
     {
-        type: 'function',
-        name: 'challenge',
-        inputs: [
+        "type": "constructor",
+        "inputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "challenge",
+        "inputs": [
             {
-                name: 'channelId',
-                type: 'bytes32',
-                internalType: 'bytes32',
+                "name": "channelId",
+                "type": "bytes32",
+                "internalType": "bytes32"
             },
             {
-                name: 'candidate',
-                type: 'tuple',
-                internalType: 'struct State',
-                components: [
+                "name": "candidate",
+                "type": "tuple",
+                "internalType": "struct State",
+                "components": [
                     {
-                        name: 'intent',
-                        type: 'uint8',
-                        internalType: 'enum StateIntent',
+                        "name": "intent",
+                        "type": "uint8",
+                        "internalType": "enum StateIntent"
                     },
                     {
-                        name: 'version',
-                        type: 'uint256',
-                        internalType: 'uint256',
+                        "name": "version",
+                        "type": "uint256",
+                        "internalType": "uint256"
                     },
                     {
-                        name: 'data',
-                        type: 'bytes',
-                        internalType: 'bytes',
+                        "name": "data",
+                        "type": "bytes",
+                        "internalType": "bytes"
                     },
                     {
-                        name: 'allocations',
-                        type: 'tuple[]',
-                        internalType: 'struct Allocation[]',
-                        components: [
+                        "name": "allocations",
+                        "type": "tuple[]",
+                        "internalType": "struct Allocation[]",
+                        "components": [
                             {
-                                name: 'destination',
-                                type: 'address',
-                                internalType: 'address',
+                                "name": "destination",
+                                "type": "address",
+                                "internalType": "address"
                             },
                             {
-                                name: 'token',
-                                type: 'address',
-                                internalType: 'address',
+                                "name": "token",
+                                "type": "address",
+                                "internalType": "address"
                             },
                             {
-                                name: 'amount',
-                                type: 'uint256',
-                                internalType: 'uint256',
-                            },
-                        ],
+                                "name": "amount",
+                                "type": "uint256",
+                                "internalType": "uint256"
+                            }
+                        ]
                     },
                     {
-                        name: 'sigs',
-                        type: 'tuple[]',
-                        internalType: 'struct Signature[]',
-                        components: [
-                            {
-                                name: 'v',
-                                type: 'uint8',
-                                internalType: 'uint8',
-                            },
-                            {
-                                name: 'r',
-                                type: 'bytes32',
-                                internalType: 'bytes32',
-                            },
-                            {
-                                name: 's',
-                                type: 'bytes32',
-                                internalType: 'bytes32',
-                            },
-                        ],
-                    },
-                ],
+                        "name": "sigs",
+                        "type": "bytes[]",
+                        "internalType": "bytes[]"
+                    }
+                ]
             },
             {
-                name: 'proofs',
-                type: 'tuple[]',
-                internalType: 'struct State[]',
-                components: [
+                "name": "proofs",
+                "type": "tuple[]",
+                "internalType": "struct State[]",
+                "components": [
                     {
-                        name: 'intent',
-                        type: 'uint8',
-                        internalType: 'enum StateIntent',
+                        "name": "intent",
+                        "type": "uint8",
+                        "internalType": "enum StateIntent"
                     },
                     {
-                        name: 'version',
-                        type: 'uint256',
-                        internalType: 'uint256',
+                        "name": "version",
+                        "type": "uint256",
+                        "internalType": "uint256"
                     },
                     {
-                        name: 'data',
-                        type: 'bytes',
-                        internalType: 'bytes',
+                        "name": "data",
+                        "type": "bytes",
+                        "internalType": "bytes"
                     },
                     {
-                        name: 'allocations',
-                        type: 'tuple[]',
-                        internalType: 'struct Allocation[]',
-                        components: [
+                        "name": "allocations",
+                        "type": "tuple[]",
+                        "internalType": "struct Allocation[]",
+                        "components": [
                             {
-                                name: 'destination',
-                                type: 'address',
-                                internalType: 'address',
+                                "name": "destination",
+                                "type": "address",
+                                "internalType": "address"
                             },
                             {
-                                name: 'token',
-                                type: 'address',
-                                internalType: 'address',
+                                "name": "token",
+                                "type": "address",
+                                "internalType": "address"
                             },
                             {
-                                name: 'amount',
-                                type: 'uint256',
-                                internalType: 'uint256',
-                            },
-                        ],
+                                "name": "amount",
+                                "type": "uint256",
+                                "internalType": "uint256"
+                            }
+                        ]
                     },
                     {
-                        name: 'sigs',
-                        type: 'tuple[]',
-                        internalType: 'struct Signature[]',
-                        components: [
-                            {
-                                name: 'v',
-                                type: 'uint8',
-                                internalType: 'uint8',
-                            },
-                            {
-                                name: 'r',
-                                type: 'bytes32',
-                                internalType: 'bytes32',
-                            },
-                            {
-                                name: 's',
-                                type: 'bytes32',
-                                internalType: 'bytes32',
-                            },
-                        ],
-                    },
-                ],
+                        "name": "sigs",
+                        "type": "bytes[]",
+                        "internalType": "bytes[]"
+                    }
+                ]
             },
             {
-                name: 'challengerSig',
-                type: 'tuple',
-                internalType: 'struct Signature',
-                components: [
-                    {
-                        name: 'v',
-                        type: 'uint8',
-                        internalType: 'uint8',
-                    },
-                    {
-                        name: 'r',
-                        type: 'bytes32',
-                        internalType: 'bytes32',
-                    },
-                    {
-                        name: 's',
-                        type: 'bytes32',
-                        internalType: 'bytes32',
-                    },
-                ],
-            },
+                "name": "challengerSig",
+                "type": "bytes",
+                "internalType": "bytes"
+            }
         ],
-        outputs: [],
-        stateMutability: 'nonpayable',
+        "outputs": [],
+        "stateMutability": "nonpayable"
     },
     {
-        type: 'function',
-        name: 'checkpoint',
-        inputs: [
+        "type": "function",
+        "name": "checkpoint",
+        "inputs": [
             {
-                name: 'channelId',
-                type: 'bytes32',
-                internalType: 'bytes32',
+                "name": "channelId",
+                "type": "bytes32",
+                "internalType": "bytes32"
             },
             {
-                name: 'candidate',
-                type: 'tuple',
-                internalType: 'struct State',
-                components: [
+                "name": "candidate",
+                "type": "tuple",
+                "internalType": "struct State",
+                "components": [
                     {
-                        name: 'intent',
-                        type: 'uint8',
-                        internalType: 'enum StateIntent',
+                        "name": "intent",
+                        "type": "uint8",
+                        "internalType": "enum StateIntent"
                     },
                     {
-                        name: 'version',
-                        type: 'uint256',
-                        internalType: 'uint256',
+                        "name": "version",
+                        "type": "uint256",
+                        "internalType": "uint256"
                     },
                     {
-                        name: 'data',
-                        type: 'bytes',
-                        internalType: 'bytes',
+                        "name": "data",
+                        "type": "bytes",
+                        "internalType": "bytes"
                     },
                     {
-                        name: 'allocations',
-                        type: 'tuple[]',
-                        internalType: 'struct Allocation[]',
-                        components: [
+                        "name": "allocations",
+                        "type": "tuple[]",
+                        "internalType": "struct Allocation[]",
+                        "components": [
                             {
-                                name: 'destination',
-                                type: 'address',
-                                internalType: 'address',
+                                "name": "destination",
+                                "type": "address",
+                                "internalType": "address"
                             },
                             {
-                                name: 'token',
-                                type: 'address',
-                                internalType: 'address',
+                                "name": "token",
+                                "type": "address",
+                                "internalType": "address"
                             },
                             {
-                                name: 'amount',
-                                type: 'uint256',
-                                internalType: 'uint256',
-                            },
-                        ],
+                                "name": "amount",
+                                "type": "uint256",
+                                "internalType": "uint256"
+                            }
+                        ]
                     },
                     {
-                        name: 'sigs',
-                        type: 'tuple[]',
-                        internalType: 'struct Signature[]',
-                        components: [
-                            {
-                                name: 'v',
-                                type: 'uint8',
-                                internalType: 'uint8',
-                            },
-                            {
-                                name: 'r',
-                                type: 'bytes32',
-                                internalType: 'bytes32',
-                            },
-                            {
-                                name: 's',
-                                type: 'bytes32',
-                                internalType: 'bytes32',
-                            },
-                        ],
-                    },
-                ],
+                        "name": "sigs",
+                        "type": "bytes[]",
+                        "internalType": "bytes[]"
+                    }
+                ]
             },
             {
-                name: 'proofs',
-                type: 'tuple[]',
-                internalType: 'struct State[]',
-                components: [
+                "name": "proofs",
+                "type": "tuple[]",
+                "internalType": "struct State[]",
+                "components": [
                     {
-                        name: 'intent',
-                        type: 'uint8',
-                        internalType: 'enum StateIntent',
+                        "name": "intent",
+                        "type": "uint8",
+                        "internalType": "enum StateIntent"
                     },
                     {
-                        name: 'version',
-                        type: 'uint256',
-                        internalType: 'uint256',
+                        "name": "version",
+                        "type": "uint256",
+                        "internalType": "uint256"
                     },
                     {
-                        name: 'data',
-                        type: 'bytes',
-                        internalType: 'bytes',
+                        "name": "data",
+                        "type": "bytes",
+                        "internalType": "bytes"
                     },
                     {
-                        name: 'allocations',
-                        type: 'tuple[]',
-                        internalType: 'struct Allocation[]',
-                        components: [
+                        "name": "allocations",
+                        "type": "tuple[]",
+                        "internalType": "struct Allocation[]",
+                        "components": [
                             {
-                                name: 'destination',
-                                type: 'address',
-                                internalType: 'address',
+                                "name": "destination",
+                                "type": "address",
+                                "internalType": "address"
                             },
                             {
-                                name: 'token',
-                                type: 'address',
-                                internalType: 'address',
+                                "name": "token",
+                                "type": "address",
+                                "internalType": "address"
                             },
                             {
-                                name: 'amount',
-                                type: 'uint256',
-                                internalType: 'uint256',
-                            },
-                        ],
+                                "name": "amount",
+                                "type": "uint256",
+                                "internalType": "uint256"
+                            }
+                        ]
                     },
                     {
-                        name: 'sigs',
-                        type: 'tuple[]',
-                        internalType: 'struct Signature[]',
-                        components: [
-                            {
-                                name: 'v',
-                                type: 'uint8',
-                                internalType: 'uint8',
-                            },
-                            {
-                                name: 'r',
-                                type: 'bytes32',
-                                internalType: 'bytes32',
-                            },
-                            {
-                                name: 's',
-                                type: 'bytes32',
-                                internalType: 'bytes32',
-                            },
-                        ],
-                    },
-                ],
-            },
+                        "name": "sigs",
+                        "type": "bytes[]",
+                        "internalType": "bytes[]"
+                    }
+                ]
+            }
         ],
-        outputs: [],
-        stateMutability: 'nonpayable',
+        "outputs": [],
+        "stateMutability": "nonpayable"
     },
     {
-        type: 'function',
-        name: 'close',
-        inputs: [
+        "type": "function",
+        "name": "close",
+        "inputs": [
             {
-                name: 'channelId',
-                type: 'bytes32',
-                internalType: 'bytes32',
+                "name": "channelId",
+                "type": "bytes32",
+                "internalType": "bytes32"
             },
             {
-                name: 'candidate',
-                type: 'tuple',
-                internalType: 'struct State',
-                components: [
+                "name": "candidate",
+                "type": "tuple",
+                "internalType": "struct State",
+                "components": [
                     {
-                        name: 'intent',
-                        type: 'uint8',
-                        internalType: 'enum StateIntent',
+                        "name": "intent",
+                        "type": "uint8",
+                        "internalType": "enum StateIntent"
                     },
                     {
-                        name: 'version',
-                        type: 'uint256',
-                        internalType: 'uint256',
+                        "name": "version",
+                        "type": "uint256",
+                        "internalType": "uint256"
                     },
                     {
-                        name: 'data',
-                        type: 'bytes',
-                        internalType: 'bytes',
+                        "name": "data",
+                        "type": "bytes",
+                        "internalType": "bytes"
                     },
                     {
-                        name: 'allocations',
-                        type: 'tuple[]',
-                        internalType: 'struct Allocation[]',
-                        components: [
+                        "name": "allocations",
+                        "type": "tuple[]",
+                        "internalType": "struct Allocation[]",
+                        "components": [
                             {
-                                name: 'destination',
-                                type: 'address',
-                                internalType: 'address',
+                                "name": "destination",
+                                "type": "address",
+                                "internalType": "address"
                             },
                             {
-                                name: 'token',
-                                type: 'address',
-                                internalType: 'address',
+                                "name": "token",
+                                "type": "address",
+                                "internalType": "address"
                             },
                             {
-                                name: 'amount',
-                                type: 'uint256',
-                                internalType: 'uint256',
-                            },
-                        ],
+                                "name": "amount",
+                                "type": "uint256",
+                                "internalType": "uint256"
+                            }
+                        ]
                     },
                     {
-                        name: 'sigs',
-                        type: 'tuple[]',
-                        internalType: 'struct Signature[]',
-                        components: [
-                            {
-                                name: 'v',
-                                type: 'uint8',
-                                internalType: 'uint8',
-                            },
-                            {
-                                name: 'r',
-                                type: 'bytes32',
-                                internalType: 'bytes32',
-                            },
-                            {
-                                name: 's',
-                                type: 'bytes32',
-                                internalType: 'bytes32',
-                            },
-                        ],
-                    },
-                ],
+                        "name": "sigs",
+                        "type": "bytes[]",
+                        "internalType": "bytes[]"
+                    }
+                ]
             },
             {
-                name: '',
-                type: 'tuple[]',
-                internalType: 'struct State[]',
-                components: [
+                "name": "",
+                "type": "tuple[]",
+                "internalType": "struct State[]",
+                "components": [
                     {
-                        name: 'intent',
-                        type: 'uint8',
-                        internalType: 'enum StateIntent',
+                        "name": "intent",
+                        "type": "uint8",
+                        "internalType": "enum StateIntent"
                     },
                     {
-                        name: 'version',
-                        type: 'uint256',
-                        internalType: 'uint256',
+                        "name": "version",
+                        "type": "uint256",
+                        "internalType": "uint256"
                     },
                     {
-                        name: 'data',
-                        type: 'bytes',
-                        internalType: 'bytes',
+                        "name": "data",
+                        "type": "bytes",
+                        "internalType": "bytes"
                     },
                     {
-                        name: 'allocations',
-                        type: 'tuple[]',
-                        internalType: 'struct Allocation[]',
-                        components: [
+                        "name": "allocations",
+                        "type": "tuple[]",
+                        "internalType": "struct Allocation[]",
+                        "components": [
                             {
-                                name: 'destination',
-                                type: 'address',
-                                internalType: 'address',
+                                "name": "destination",
+                                "type": "address",
+                                "internalType": "address"
                             },
                             {
-                                name: 'token',
-                                type: 'address',
-                                internalType: 'address',
+                                "name": "token",
+                                "type": "address",
+                                "internalType": "address"
                             },
                             {
-                                name: 'amount',
-                                type: 'uint256',
-                                internalType: 'uint256',
-                            },
-                        ],
+                                "name": "amount",
+                                "type": "uint256",
+                                "internalType": "uint256"
+                            }
+                        ]
                     },
                     {
-                        name: 'sigs',
-                        type: 'tuple[]',
-                        internalType: 'struct Signature[]',
-                        components: [
-                            {
-                                name: 'v',
-                                type: 'uint8',
-                                internalType: 'uint8',
-                            },
-                            {
-                                name: 'r',
-                                type: 'bytes32',
-                                internalType: 'bytes32',
-                            },
-                            {
-                                name: 's',
-                                type: 'bytes32',
-                                internalType: 'bytes32',
-                            },
-                        ],
-                    },
-                ],
-            },
+                        "name": "sigs",
+                        "type": "bytes[]",
+                        "internalType": "bytes[]"
+                    }
+                ]
+            }
         ],
-        outputs: [],
-        stateMutability: 'nonpayable',
+        "outputs": [],
+        "stateMutability": "nonpayable"
     },
     {
-        type: 'function',
-        name: 'create',
-        inputs: [
+        "type": "function",
+        "name": "create",
+        "inputs": [
             {
-                name: 'ch',
-                type: 'tuple',
-                internalType: 'struct Channel',
-                components: [
+                "name": "ch",
+                "type": "tuple",
+                "internalType": "struct Channel",
+                "components": [
                     {
-                        name: 'participants',
-                        type: 'address[]',
-                        internalType: 'address[]',
+                        "name": "participants",
+                        "type": "address[]",
+                        "internalType": "address[]"
                     },
                     {
-                        name: 'adjudicator',
-                        type: 'address',
-                        internalType: 'address',
+                        "name": "adjudicator",
+                        "type": "address",
+                        "internalType": "address"
                     },
                     {
-                        name: 'challenge',
-                        type: 'uint64',
-                        internalType: 'uint64',
+                        "name": "challenge",
+                        "type": "uint64",
+                        "internalType": "uint64"
                     },
                     {
-                        name: 'nonce',
-                        type: 'uint64',
-                        internalType: 'uint64',
-                    },
-                ],
+                        "name": "nonce",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                    }
+                ]
             },
             {
-                name: 'initial',
-                type: 'tuple',
-                internalType: 'struct State',
-                components: [
+                "name": "initial",
+                "type": "tuple",
+                "internalType": "struct State",
+                "components": [
                     {
-                        name: 'intent',
-                        type: 'uint8',
-                        internalType: 'enum StateIntent',
+                        "name": "intent",
+                        "type": "uint8",
+                        "internalType": "enum StateIntent"
                     },
                     {
-                        name: 'version',
-                        type: 'uint256',
-                        internalType: 'uint256',
+                        "name": "version",
+                        "type": "uint256",
+                        "internalType": "uint256"
                     },
                     {
-                        name: 'data',
-                        type: 'bytes',
-                        internalType: 'bytes',
+                        "name": "data",
+                        "type": "bytes",
+                        "internalType": "bytes"
                     },
                     {
-                        name: 'allocations',
-                        type: 'tuple[]',
-                        internalType: 'struct Allocation[]',
-                        components: [
+                        "name": "allocations",
+                        "type": "tuple[]",
+                        "internalType": "struct Allocation[]",
+                        "components": [
                             {
-                                name: 'destination',
-                                type: 'address',
-                                internalType: 'address',
+                                "name": "destination",
+                                "type": "address",
+                                "internalType": "address"
                             },
                             {
-                                name: 'token',
-                                type: 'address',
-                                internalType: 'address',
+                                "name": "token",
+                                "type": "address",
+                                "internalType": "address"
                             },
                             {
-                                name: 'amount',
-                                type: 'uint256',
-                                internalType: 'uint256',
-                            },
-                        ],
+                                "name": "amount",
+                                "type": "uint256",
+                                "internalType": "uint256"
+                            }
+                        ]
                     },
                     {
-                        name: 'sigs',
-                        type: 'tuple[]',
-                        internalType: 'struct Signature[]',
-                        components: [
-                            {
-                                name: 'v',
-                                type: 'uint8',
-                                internalType: 'uint8',
-                            },
-                            {
-                                name: 'r',
-                                type: 'bytes32',
-                                internalType: 'bytes32',
-                            },
-                            {
-                                name: 's',
-                                type: 'bytes32',
-                                internalType: 'bytes32',
-                            },
-                        ],
-                    },
-                ],
-            },
+                        "name": "sigs",
+                        "type": "bytes[]",
+                        "internalType": "bytes[]"
+                    }
+                ]
+            }
         ],
-        outputs: [
+        "outputs": [
             {
-                name: 'channelId',
-                type: 'bytes32',
-                internalType: 'bytes32',
-            },
+                "name": "channelId",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
         ],
-        stateMutability: 'nonpayable',
+        "stateMutability": "nonpayable"
     },
     {
-        type: 'function',
-        name: 'deposit',
-        inputs: [
+        "type": "function",
+        "name": "deposit",
+        "inputs": [
             {
-                name: 'account',
-                type: 'address',
-                internalType: 'address',
+                "name": "account",
+                "type": "address",
+                "internalType": "address"
             },
             {
-                name: 'token',
-                type: 'address',
-                internalType: 'address',
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
             },
             {
-                name: 'amount',
-                type: 'uint256',
-                internalType: 'uint256',
-            },
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
         ],
-        outputs: [],
-        stateMutability: 'payable',
+        "outputs": [],
+        "stateMutability": "payable"
     },
     {
-        type: 'function',
-        name: 'depositAndCreate',
-        inputs: [
+        "type": "function",
+        "name": "depositAndCreate",
+        "inputs": [
             {
-                name: 'token',
-                type: 'address',
-                internalType: 'address',
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
             },
             {
-                name: 'amount',
-                type: 'uint256',
-                internalType: 'uint256',
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256"
             },
             {
-                name: 'ch',
-                type: 'tuple',
-                internalType: 'struct Channel',
-                components: [
+                "name": "ch",
+                "type": "tuple",
+                "internalType": "struct Channel",
+                "components": [
                     {
-                        name: 'participants',
-                        type: 'address[]',
-                        internalType: 'address[]',
+                        "name": "participants",
+                        "type": "address[]",
+                        "internalType": "address[]"
                     },
                     {
-                        name: 'adjudicator',
-                        type: 'address',
-                        internalType: 'address',
+                        "name": "adjudicator",
+                        "type": "address",
+                        "internalType": "address"
                     },
                     {
-                        name: 'challenge',
-                        type: 'uint64',
-                        internalType: 'uint64',
+                        "name": "challenge",
+                        "type": "uint64",
+                        "internalType": "uint64"
                     },
                     {
-                        name: 'nonce',
-                        type: 'uint64',
-                        internalType: 'uint64',
-                    },
-                ],
+                        "name": "nonce",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                    }
+                ]
             },
             {
-                name: 'initial',
-                type: 'tuple',
-                internalType: 'struct State',
-                components: [
+                "name": "initial",
+                "type": "tuple",
+                "internalType": "struct State",
+                "components": [
                     {
-                        name: 'intent',
-                        type: 'uint8',
-                        internalType: 'enum StateIntent',
+                        "name": "intent",
+                        "type": "uint8",
+                        "internalType": "enum StateIntent"
                     },
                     {
-                        name: 'version',
-                        type: 'uint256',
-                        internalType: 'uint256',
+                        "name": "version",
+                        "type": "uint256",
+                        "internalType": "uint256"
                     },
                     {
-                        name: 'data',
-                        type: 'bytes',
-                        internalType: 'bytes',
+                        "name": "data",
+                        "type": "bytes",
+                        "internalType": "bytes"
                     },
                     {
-                        name: 'allocations',
-                        type: 'tuple[]',
-                        internalType: 'struct Allocation[]',
-                        components: [
+                        "name": "allocations",
+                        "type": "tuple[]",
+                        "internalType": "struct Allocation[]",
+                        "components": [
                             {
-                                name: 'destination',
-                                type: 'address',
-                                internalType: 'address',
+                                "name": "destination",
+                                "type": "address",
+                                "internalType": "address"
                             },
                             {
-                                name: 'token',
-                                type: 'address',
-                                internalType: 'address',
+                                "name": "token",
+                                "type": "address",
+                                "internalType": "address"
                             },
                             {
-                                name: 'amount',
-                                type: 'uint256',
-                                internalType: 'uint256',
-                            },
-                        ],
+                                "name": "amount",
+                                "type": "uint256",
+                                "internalType": "uint256"
+                            }
+                        ]
                     },
                     {
-                        name: 'sigs',
-                        type: 'tuple[]',
-                        internalType: 'struct Signature[]',
-                        components: [
-                            {
-                                name: 'v',
-                                type: 'uint8',
-                                internalType: 'uint8',
-                            },
-                            {
-                                name: 'r',
-                                type: 'bytes32',
-                                internalType: 'bytes32',
-                            },
-                            {
-                                name: 's',
-                                type: 'bytes32',
-                                internalType: 'bytes32',
-                            },
-                        ],
-                    },
-                ],
-            },
+                        "name": "sigs",
+                        "type": "bytes[]",
+                        "internalType": "bytes[]"
+                    }
+                ]
+            }
         ],
-        outputs: [
+        "outputs": [
             {
-                name: '',
-                type: 'bytes32',
-                internalType: 'bytes32',
-            },
+                "name": "",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
         ],
-        stateMutability: 'payable',
+        "stateMutability": "payable"
     },
     {
-        type: 'function',
-        name: 'getAccountsBalances',
-        inputs: [
+        "type": "function",
+        "name": "eip712Domain",
+        "inputs": [],
+        "outputs": [
             {
-                name: 'accounts',
-                type: 'address[]',
-                internalType: 'address[]',
+                "name": "fields",
+                "type": "bytes1",
+                "internalType": "bytes1"
             },
             {
-                name: 'tokens',
-                type: 'address[]',
-                internalType: 'address[]',
+                "name": "name",
+                "type": "string",
+                "internalType": "string"
             },
+            {
+                "name": "version",
+                "type": "string",
+                "internalType": "string"
+            },
+            {
+                "name": "chainId",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "verifyingContract",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "salt",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            },
+            {
+                "name": "extensions",
+                "type": "uint256[]",
+                "internalType": "uint256[]"
+            }
         ],
-        outputs: [
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "getAccountsBalances",
+        "inputs": [
             {
-                name: '',
-                type: 'uint256[][]',
-                internalType: 'uint256[][]',
+                "name": "accounts",
+                "type": "address[]",
+                "internalType": "address[]"
             },
+            {
+                "name": "tokens",
+                "type": "address[]",
+                "internalType": "address[]"
+            }
         ],
-        stateMutability: 'view',
-    },
-    {
-        type: 'function',
-        name: 'getChannelBalances',
-        inputs: [
+        "outputs": [
             {
-                name: 'channelId',
-                type: 'bytes32',
-                internalType: 'bytes32',
-            },
-            {
-                name: 'tokens',
-                type: 'address[]',
-                internalType: 'address[]',
-            },
+                "name": "",
+                "type": "uint256[][]",
+                "internalType": "uint256[][]"
+            }
         ],
-        outputs: [
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "getChannelBalances",
+        "inputs": [
             {
-                name: 'balances',
-                type: 'uint256[]',
-                internalType: 'uint256[]',
+                "name": "channelId",
+                "type": "bytes32",
+                "internalType": "bytes32"
             },
+            {
+                "name": "tokens",
+                "type": "address[]",
+                "internalType": "address[]"
+            }
         ],
-        stateMutability: 'view',
-    },
-    {
-        type: 'function',
-        name: 'getChannelData',
-        inputs: [
+        "outputs": [
             {
-                name: 'channelId',
-                type: 'bytes32',
-                internalType: 'bytes32',
-            },
+                "name": "balances",
+                "type": "uint256[]",
+                "internalType": "uint256[]"
+            }
         ],
-        outputs: [
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "getChannelData",
+        "inputs": [
             {
-                name: 'channel',
-                type: 'tuple',
-                internalType: 'struct Channel',
-                components: [
-                    {
-                        name: 'participants',
-                        type: 'address[]',
-                        internalType: 'address[]',
-                    },
-                    {
-                        name: 'adjudicator',
-                        type: 'address',
-                        internalType: 'address',
-                    },
-                    {
-                        name: 'challenge',
-                        type: 'uint64',
-                        internalType: 'uint64',
-                    },
-                    {
-                        name: 'nonce',
-                        type: 'uint64',
-                        internalType: 'uint64',
-                    },
-                ],
-            },
-            {
-                name: 'status',
-                type: 'uint8',
-                internalType: 'enum ChannelStatus',
-            },
-            {
-                name: 'wallets',
-                type: 'address[]',
-                internalType: 'address[]',
-            },
-            {
-                name: 'challengeExpiry',
-                type: 'uint256',
-                internalType: 'uint256',
-            },
-            {
-                name: 'lastValidState',
-                type: 'tuple',
-                internalType: 'struct State',
-                components: [
-                    {
-                        name: 'intent',
-                        type: 'uint8',
-                        internalType: 'enum StateIntent',
-                    },
-                    {
-                        name: 'version',
-                        type: 'uint256',
-                        internalType: 'uint256',
-                    },
-                    {
-                        name: 'data',
-                        type: 'bytes',
-                        internalType: 'bytes',
-                    },
-                    {
-                        name: 'allocations',
-                        type: 'tuple[]',
-                        internalType: 'struct Allocation[]',
-                        components: [
-                            {
-                                name: 'destination',
-                                type: 'address',
-                                internalType: 'address',
-                            },
-                            {
-                                name: 'token',
-                                type: 'address',
-                                internalType: 'address',
-                            },
-                            {
-                                name: 'amount',
-                                type: 'uint256',
-                                internalType: 'uint256',
-                            },
-                        ],
-                    },
-                    {
-                        name: 'sigs',
-                        type: 'tuple[]',
-                        internalType: 'struct Signature[]',
-                        components: [
-                            {
-                                name: 'v',
-                                type: 'uint8',
-                                internalType: 'uint8',
-                            },
-                            {
-                                name: 'r',
-                                type: 'bytes32',
-                                internalType: 'bytes32',
-                            },
-                            {
-                                name: 's',
-                                type: 'bytes32',
-                                internalType: 'bytes32',
-                            },
-                        ],
-                    },
-                ],
-            },
+                "name": "channelId",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
         ],
-        stateMutability: 'view',
-    },
-    {
-        type: 'function',
-        name: 'getOpenChannels',
-        inputs: [
+        "outputs": [
             {
-                name: 'accounts',
-                type: 'address[]',
-                internalType: 'address[]',
+                "name": "channel",
+                "type": "tuple",
+                "internalType": "struct Channel",
+                "components": [
+                    {
+                        "name": "participants",
+                        "type": "address[]",
+                        "internalType": "address[]"
+                    },
+                    {
+                        "name": "adjudicator",
+                        "type": "address",
+                        "internalType": "address"
+                    },
+                    {
+                        "name": "challenge",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                    },
+                    {
+                        "name": "nonce",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                    }
+                ]
             },
+            {
+                "name": "status",
+                "type": "uint8",
+                "internalType": "enum ChannelStatus"
+            },
+            {
+                "name": "wallets",
+                "type": "address[]",
+                "internalType": "address[]"
+            },
+            {
+                "name": "challengeExpiry",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "lastValidState",
+                "type": "tuple",
+                "internalType": "struct State",
+                "components": [
+                    {
+                        "name": "intent",
+                        "type": "uint8",
+                        "internalType": "enum StateIntent"
+                    },
+                    {
+                        "name": "version",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "data",
+                        "type": "bytes",
+                        "internalType": "bytes"
+                    },
+                    {
+                        "name": "allocations",
+                        "type": "tuple[]",
+                        "internalType": "struct Allocation[]",
+                        "components": [
+                            {
+                                "name": "destination",
+                                "type": "address",
+                                "internalType": "address"
+                            },
+                            {
+                                "name": "token",
+                                "type": "address",
+                                "internalType": "address"
+                            },
+                            {
+                                "name": "amount",
+                                "type": "uint256",
+                                "internalType": "uint256"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "sigs",
+                        "type": "bytes[]",
+                        "internalType": "bytes[]"
+                    }
+                ]
+            }
         ],
-        outputs: [
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "getOpenChannels",
+        "inputs": [
             {
-                name: '',
-                type: 'bytes32[][]',
-                internalType: 'bytes32[][]',
-            },
+                "name": "accounts",
+                "type": "address[]",
+                "internalType": "address[]"
+            }
         ],
-        stateMutability: 'view',
-    },
-    {
-        type: 'function',
-        name: 'join',
-        inputs: [
+        "outputs": [
             {
-                name: 'channelId',
-                type: 'bytes32',
-                internalType: 'bytes32',
-            },
-            {
-                name: 'index',
-                type: 'uint256',
-                internalType: 'uint256',
-            },
-            {
-                name: 'sig',
-                type: 'tuple',
-                internalType: 'struct Signature',
-                components: [
-                    {
-                        name: 'v',
-                        type: 'uint8',
-                        internalType: 'uint8',
-                    },
-                    {
-                        name: 'r',
-                        type: 'bytes32',
-                        internalType: 'bytes32',
-                    },
-                    {
-                        name: 's',
-                        type: 'bytes32',
-                        internalType: 'bytes32',
-                    },
-                ],
-            },
+                "name": "",
+                "type": "bytes32[][]",
+                "internalType": "bytes32[][]"
+            }
         ],
-        outputs: [
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "join",
+        "inputs": [
             {
-                name: '',
-                type: 'bytes32',
-                internalType: 'bytes32',
+                "name": "channelId",
+                "type": "bytes32",
+                "internalType": "bytes32"
             },
+            {
+                "name": "index",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "sig",
+                "type": "bytes",
+                "internalType": "bytes"
+            }
         ],
-        stateMutability: 'nonpayable',
-    },
-    {
-        type: 'function',
-        name: 'resize',
-        inputs: [
+        "outputs": [
             {
-                name: 'channelId',
-                type: 'bytes32',
-                internalType: 'bytes32',
-            },
-            {
-                name: 'candidate',
-                type: 'tuple',
-                internalType: 'struct State',
-                components: [
-                    {
-                        name: 'intent',
-                        type: 'uint8',
-                        internalType: 'enum StateIntent',
-                    },
-                    {
-                        name: 'version',
-                        type: 'uint256',
-                        internalType: 'uint256',
-                    },
-                    {
-                        name: 'data',
-                        type: 'bytes',
-                        internalType: 'bytes',
-                    },
-                    {
-                        name: 'allocations',
-                        type: 'tuple[]',
-                        internalType: 'struct Allocation[]',
-                        components: [
-                            {
-                                name: 'destination',
-                                type: 'address',
-                                internalType: 'address',
-                            },
-                            {
-                                name: 'token',
-                                type: 'address',
-                                internalType: 'address',
-                            },
-                            {
-                                name: 'amount',
-                                type: 'uint256',
-                                internalType: 'uint256',
-                            },
-                        ],
-                    },
-                    {
-                        name: 'sigs',
-                        type: 'tuple[]',
-                        internalType: 'struct Signature[]',
-                        components: [
-                            {
-                                name: 'v',
-                                type: 'uint8',
-                                internalType: 'uint8',
-                            },
-                            {
-                                name: 'r',
-                                type: 'bytes32',
-                                internalType: 'bytes32',
-                            },
-                            {
-                                name: 's',
-                                type: 'bytes32',
-                                internalType: 'bytes32',
-                            },
-                        ],
-                    },
-                ],
-            },
-            {
-                name: 'proofs',
-                type: 'tuple[]',
-                internalType: 'struct State[]',
-                components: [
-                    {
-                        name: 'intent',
-                        type: 'uint8',
-                        internalType: 'enum StateIntent',
-                    },
-                    {
-                        name: 'version',
-                        type: 'uint256',
-                        internalType: 'uint256',
-                    },
-                    {
-                        name: 'data',
-                        type: 'bytes',
-                        internalType: 'bytes',
-                    },
-                    {
-                        name: 'allocations',
-                        type: 'tuple[]',
-                        internalType: 'struct Allocation[]',
-                        components: [
-                            {
-                                name: 'destination',
-                                type: 'address',
-                                internalType: 'address',
-                            },
-                            {
-                                name: 'token',
-                                type: 'address',
-                                internalType: 'address',
-                            },
-                            {
-                                name: 'amount',
-                                type: 'uint256',
-                                internalType: 'uint256',
-                            },
-                        ],
-                    },
-                    {
-                        name: 'sigs',
-                        type: 'tuple[]',
-                        internalType: 'struct Signature[]',
-                        components: [
-                            {
-                                name: 'v',
-                                type: 'uint8',
-                                internalType: 'uint8',
-                            },
-                            {
-                                name: 'r',
-                                type: 'bytes32',
-                                internalType: 'bytes32',
-                            },
-                            {
-                                name: 's',
-                                type: 'bytes32',
-                                internalType: 'bytes32',
-                            },
-                        ],
-                    },
-                ],
-            },
+                "name": "",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
         ],
-        outputs: [],
-        stateMutability: 'nonpayable',
+        "stateMutability": "nonpayable"
     },
     {
-        type: 'function',
-        name: 'withdraw',
-        inputs: [
+        "type": "function",
+        "name": "resize",
+        "inputs": [
             {
-                name: 'token',
-                type: 'address',
-                internalType: 'address',
+                "name": "channelId",
+                "type": "bytes32",
+                "internalType": "bytes32"
             },
             {
-                name: 'amount',
-                type: 'uint256',
-                internalType: 'uint256',
+                "name": "candidate",
+                "type": "tuple",
+                "internalType": "struct State",
+                "components": [
+                    {
+                        "name": "intent",
+                        "type": "uint8",
+                        "internalType": "enum StateIntent"
+                    },
+                    {
+                        "name": "version",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "data",
+                        "type": "bytes",
+                        "internalType": "bytes"
+                    },
+                    {
+                        "name": "allocations",
+                        "type": "tuple[]",
+                        "internalType": "struct Allocation[]",
+                        "components": [
+                            {
+                                "name": "destination",
+                                "type": "address",
+                                "internalType": "address"
+                            },
+                            {
+                                "name": "token",
+                                "type": "address",
+                                "internalType": "address"
+                            },
+                            {
+                                "name": "amount",
+                                "type": "uint256",
+                                "internalType": "uint256"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "sigs",
+                        "type": "bytes[]",
+                        "internalType": "bytes[]"
+                    }
+                ]
             },
+            {
+                "name": "proofs",
+                "type": "tuple[]",
+                "internalType": "struct State[]",
+                "components": [
+                    {
+                        "name": "intent",
+                        "type": "uint8",
+                        "internalType": "enum StateIntent"
+                    },
+                    {
+                        "name": "version",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "data",
+                        "type": "bytes",
+                        "internalType": "bytes"
+                    },
+                    {
+                        "name": "allocations",
+                        "type": "tuple[]",
+                        "internalType": "struct Allocation[]",
+                        "components": [
+                            {
+                                "name": "destination",
+                                "type": "address",
+                                "internalType": "address"
+                            },
+                            {
+                                "name": "token",
+                                "type": "address",
+                                "internalType": "address"
+                            },
+                            {
+                                "name": "amount",
+                                "type": "uint256",
+                                "internalType": "uint256"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "sigs",
+                        "type": "bytes[]",
+                        "internalType": "bytes[]"
+                    }
+                ]
+            }
         ],
-        outputs: [],
-        stateMutability: 'nonpayable',
+        "outputs": [],
+        "stateMutability": "nonpayable"
     },
     {
-        type: 'event',
-        name: 'Challenged',
-        inputs: [
+        "type": "function",
+        "name": "withdraw",
+        "inputs": [
             {
-                name: 'channelId',
-                type: 'bytes32',
-                indexed: true,
-                internalType: 'bytes32',
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
             },
             {
-                name: 'state',
-                type: 'tuple',
-                indexed: false,
-                internalType: 'struct State',
-                components: [
-                    {
-                        name: 'intent',
-                        type: 'uint8',
-                        internalType: 'enum StateIntent',
-                    },
-                    {
-                        name: 'version',
-                        type: 'uint256',
-                        internalType: 'uint256',
-                    },
-                    {
-                        name: 'data',
-                        type: 'bytes',
-                        internalType: 'bytes',
-                    },
-                    {
-                        name: 'allocations',
-                        type: 'tuple[]',
-                        internalType: 'struct Allocation[]',
-                        components: [
-                            {
-                                name: 'destination',
-                                type: 'address',
-                                internalType: 'address',
-                            },
-                            {
-                                name: 'token',
-                                type: 'address',
-                                internalType: 'address',
-                            },
-                            {
-                                name: 'amount',
-                                type: 'uint256',
-                                internalType: 'uint256',
-                            },
-                        ],
-                    },
-                    {
-                        name: 'sigs',
-                        type: 'tuple[]',
-                        internalType: 'struct Signature[]',
-                        components: [
-                            {
-                                name: 'v',
-                                type: 'uint8',
-                                internalType: 'uint8',
-                            },
-                            {
-                                name: 'r',
-                                type: 'bytes32',
-                                internalType: 'bytes32',
-                            },
-                            {
-                                name: 's',
-                                type: 'bytes32',
-                                internalType: 'bytes32',
-                            },
-                        ],
-                    },
-                ],
-            },
-            {
-                name: 'expiration',
-                type: 'uint256',
-                indexed: false,
-                internalType: 'uint256',
-            },
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
         ],
-        anonymous: false,
+        "outputs": [],
+        "stateMutability": "nonpayable"
     },
     {
-        type: 'event',
-        name: 'Checkpointed',
-        inputs: [
+        "type": "event",
+        "name": "Challenged",
+        "inputs": [
             {
-                name: 'channelId',
-                type: 'bytes32',
-                indexed: true,
-                internalType: 'bytes32',
+                "name": "channelId",
+                "type": "bytes32",
+                "indexed": true,
+                "internalType": "bytes32"
             },
             {
-                name: 'state',
-                type: 'tuple',
-                indexed: false,
-                internalType: 'struct State',
-                components: [
+                "name": "state",
+                "type": "tuple",
+                "indexed": false,
+                "internalType": "struct State",
+                "components": [
                     {
-                        name: 'intent',
-                        type: 'uint8',
-                        internalType: 'enum StateIntent',
+                        "name": "intent",
+                        "type": "uint8",
+                        "internalType": "enum StateIntent"
                     },
                     {
-                        name: 'version',
-                        type: 'uint256',
-                        internalType: 'uint256',
+                        "name": "version",
+                        "type": "uint256",
+                        "internalType": "uint256"
                     },
                     {
-                        name: 'data',
-                        type: 'bytes',
-                        internalType: 'bytes',
+                        "name": "data",
+                        "type": "bytes",
+                        "internalType": "bytes"
                     },
                     {
-                        name: 'allocations',
-                        type: 'tuple[]',
-                        internalType: 'struct Allocation[]',
-                        components: [
+                        "name": "allocations",
+                        "type": "tuple[]",
+                        "internalType": "struct Allocation[]",
+                        "components": [
                             {
-                                name: 'destination',
-                                type: 'address',
-                                internalType: 'address',
+                                "name": "destination",
+                                "type": "address",
+                                "internalType": "address"
                             },
                             {
-                                name: 'token',
-                                type: 'address',
-                                internalType: 'address',
+                                "name": "token",
+                                "type": "address",
+                                "internalType": "address"
                             },
                             {
-                                name: 'amount',
-                                type: 'uint256',
-                                internalType: 'uint256',
-                            },
-                        ],
+                                "name": "amount",
+                                "type": "uint256",
+                                "internalType": "uint256"
+                            }
+                        ]
                     },
                     {
-                        name: 'sigs',
-                        type: 'tuple[]',
-                        internalType: 'struct Signature[]',
-                        components: [
-                            {
-                                name: 'v',
-                                type: 'uint8',
-                                internalType: 'uint8',
-                            },
-                            {
-                                name: 'r',
-                                type: 'bytes32',
-                                internalType: 'bytes32',
-                            },
-                            {
-                                name: 's',
-                                type: 'bytes32',
-                                internalType: 'bytes32',
-                            },
-                        ],
-                    },
-                ],
+                        "name": "sigs",
+                        "type": "bytes[]",
+                        "internalType": "bytes[]"
+                    }
+                ]
             },
+            {
+                "name": "expiration",
+                "type": "uint256",
+                "indexed": false,
+                "internalType": "uint256"
+            }
         ],
-        anonymous: false,
+        "anonymous": false
     },
     {
-        type: 'event',
-        name: 'Closed',
-        inputs: [
+        "type": "event",
+        "name": "Checkpointed",
+        "inputs": [
             {
-                name: 'channelId',
-                type: 'bytes32',
-                indexed: true,
-                internalType: 'bytes32',
+                "name": "channelId",
+                "type": "bytes32",
+                "indexed": true,
+                "internalType": "bytes32"
             },
             {
-                name: 'finalState',
-                type: 'tuple',
-                indexed: false,
-                internalType: 'struct State',
-                components: [
+                "name": "state",
+                "type": "tuple",
+                "indexed": false,
+                "internalType": "struct State",
+                "components": [
                     {
-                        name: 'intent',
-                        type: 'uint8',
-                        internalType: 'enum StateIntent',
+                        "name": "intent",
+                        "type": "uint8",
+                        "internalType": "enum StateIntent"
                     },
                     {
-                        name: 'version',
-                        type: 'uint256',
-                        internalType: 'uint256',
+                        "name": "version",
+                        "type": "uint256",
+                        "internalType": "uint256"
                     },
                     {
-                        name: 'data',
-                        type: 'bytes',
-                        internalType: 'bytes',
+                        "name": "data",
+                        "type": "bytes",
+                        "internalType": "bytes"
                     },
                     {
-                        name: 'allocations',
-                        type: 'tuple[]',
-                        internalType: 'struct Allocation[]',
-                        components: [
+                        "name": "allocations",
+                        "type": "tuple[]",
+                        "internalType": "struct Allocation[]",
+                        "components": [
                             {
-                                name: 'destination',
-                                type: 'address',
-                                internalType: 'address',
+                                "name": "destination",
+                                "type": "address",
+                                "internalType": "address"
                             },
                             {
-                                name: 'token',
-                                type: 'address',
-                                internalType: 'address',
+                                "name": "token",
+                                "type": "address",
+                                "internalType": "address"
                             },
                             {
-                                name: 'amount',
-                                type: 'uint256',
-                                internalType: 'uint256',
-                            },
-                        ],
+                                "name": "amount",
+                                "type": "uint256",
+                                "internalType": "uint256"
+                            }
+                        ]
                     },
                     {
-                        name: 'sigs',
-                        type: 'tuple[]',
-                        internalType: 'struct Signature[]',
-                        components: [
-                            {
-                                name: 'v',
-                                type: 'uint8',
-                                internalType: 'uint8',
-                            },
-                            {
-                                name: 'r',
-                                type: 'bytes32',
-                                internalType: 'bytes32',
-                            },
-                            {
-                                name: 's',
-                                type: 'bytes32',
-                                internalType: 'bytes32',
-                            },
-                        ],
-                    },
-                ],
-            },
+                        "name": "sigs",
+                        "type": "bytes[]",
+                        "internalType": "bytes[]"
+                    }
+                ]
+            }
         ],
-        anonymous: false,
+        "anonymous": false
     },
     {
-        type: 'event',
-        name: 'Created',
-        inputs: [
+        "type": "event",
+        "name": "Closed",
+        "inputs": [
             {
-                name: 'channelId',
-                type: 'bytes32',
-                indexed: true,
-                internalType: 'bytes32',
+                "name": "channelId",
+                "type": "bytes32",
+                "indexed": true,
+                "internalType": "bytes32"
             },
             {
-                name: 'wallet',
-                type: 'address',
-                indexed: true,
-                internalType: 'address',
-            },
-            {
-                name: 'channel',
-                type: 'tuple',
-                indexed: false,
-                internalType: 'struct Channel',
-                components: [
+                "name": "finalState",
+                "type": "tuple",
+                "indexed": false,
+                "internalType": "struct State",
+                "components": [
                     {
-                        name: 'participants',
-                        type: 'address[]',
-                        internalType: 'address[]',
+                        "name": "intent",
+                        "type": "uint8",
+                        "internalType": "enum StateIntent"
                     },
                     {
-                        name: 'adjudicator',
-                        type: 'address',
-                        internalType: 'address',
+                        "name": "version",
+                        "type": "uint256",
+                        "internalType": "uint256"
                     },
                     {
-                        name: 'challenge',
-                        type: 'uint64',
-                        internalType: 'uint64',
+                        "name": "data",
+                        "type": "bytes",
+                        "internalType": "bytes"
                     },
                     {
-                        name: 'nonce',
-                        type: 'uint64',
-                        internalType: 'uint64',
-                    },
-                ],
-            },
-            {
-                name: 'initial',
-                type: 'tuple',
-                indexed: false,
-                internalType: 'struct State',
-                components: [
-                    {
-                        name: 'intent',
-                        type: 'uint8',
-                        internalType: 'enum StateIntent',
-                    },
-                    {
-                        name: 'version',
-                        type: 'uint256',
-                        internalType: 'uint256',
-                    },
-                    {
-                        name: 'data',
-                        type: 'bytes',
-                        internalType: 'bytes',
-                    },
-                    {
-                        name: 'allocations',
-                        type: 'tuple[]',
-                        internalType: 'struct Allocation[]',
-                        components: [
+                        "name": "allocations",
+                        "type": "tuple[]",
+                        "internalType": "struct Allocation[]",
+                        "components": [
                             {
-                                name: 'destination',
-                                type: 'address',
-                                internalType: 'address',
+                                "name": "destination",
+                                "type": "address",
+                                "internalType": "address"
                             },
                             {
-                                name: 'token',
-                                type: 'address',
-                                internalType: 'address',
+                                "name": "token",
+                                "type": "address",
+                                "internalType": "address"
                             },
                             {
-                                name: 'amount',
-                                type: 'uint256',
-                                internalType: 'uint256',
-                            },
-                        ],
+                                "name": "amount",
+                                "type": "uint256",
+                                "internalType": "uint256"
+                            }
+                        ]
                     },
                     {
-                        name: 'sigs',
-                        type: 'tuple[]',
-                        internalType: 'struct Signature[]',
-                        components: [
-                            {
-                                name: 'v',
-                                type: 'uint8',
-                                internalType: 'uint8',
-                            },
-                            {
-                                name: 'r',
-                                type: 'bytes32',
-                                internalType: 'bytes32',
-                            },
-                            {
-                                name: 's',
-                                type: 'bytes32',
-                                internalType: 'bytes32',
-                            },
-                        ],
+                        "name": "sigs",
+                        "type": "bytes[]",
+                        "internalType": "bytes[]"
+                    }
+                ]
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "Created",
+        "inputs": [
+            {
+                "name": "channelId",
+                "type": "bytes32",
+                "indexed": true,
+                "internalType": "bytes32"
+            },
+            {
+                "name": "wallet",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            },
+            {
+                "name": "channel",
+                "type": "tuple",
+                "indexed": false,
+                "internalType": "struct Channel",
+                "components": [
+                    {
+                        "name": "participants",
+                        "type": "address[]",
+                        "internalType": "address[]"
                     },
-                ],
+                    {
+                        "name": "adjudicator",
+                        "type": "address",
+                        "internalType": "address"
+                    },
+                    {
+                        "name": "challenge",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                    },
+                    {
+                        "name": "nonce",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                    }
+                ]
             },
+            {
+                "name": "initial",
+                "type": "tuple",
+                "indexed": false,
+                "internalType": "struct State",
+                "components": [
+                    {
+                        "name": "intent",
+                        "type": "uint8",
+                        "internalType": "enum StateIntent"
+                    },
+                    {
+                        "name": "version",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "data",
+                        "type": "bytes",
+                        "internalType": "bytes"
+                    },
+                    {
+                        "name": "allocations",
+                        "type": "tuple[]",
+                        "internalType": "struct Allocation[]",
+                        "components": [
+                            {
+                                "name": "destination",
+                                "type": "address",
+                                "internalType": "address"
+                            },
+                            {
+                                "name": "token",
+                                "type": "address",
+                                "internalType": "address"
+                            },
+                            {
+                                "name": "amount",
+                                "type": "uint256",
+                                "internalType": "uint256"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "sigs",
+                        "type": "bytes[]",
+                        "internalType": "bytes[]"
+                    }
+                ]
+            }
         ],
-        anonymous: false,
+        "anonymous": false
     },
     {
-        type: 'event',
-        name: 'Deposited',
-        inputs: [
+        "type": "event",
+        "name": "Deposited",
+        "inputs": [
             {
-                name: 'wallet',
-                type: 'address',
-                indexed: true,
-                internalType: 'address',
+                "name": "wallet",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
             },
             {
-                name: 'token',
-                type: 'address',
-                indexed: true,
-                internalType: 'address',
+                "name": "token",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
             },
             {
-                name: 'amount',
-                type: 'uint256',
-                indexed: false,
-                internalType: 'uint256',
-            },
+                "name": "amount",
+                "type": "uint256",
+                "indexed": false,
+                "internalType": "uint256"
+            }
         ],
-        anonymous: false,
+        "anonymous": false
     },
     {
-        type: 'event',
-        name: 'Joined',
-        inputs: [
+        "type": "event",
+        "name": "EIP712DomainChanged",
+        "inputs": [],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "Joined",
+        "inputs": [
             {
-                name: 'channelId',
-                type: 'bytes32',
-                indexed: true,
-                internalType: 'bytes32',
+                "name": "channelId",
+                "type": "bytes32",
+                "indexed": true,
+                "internalType": "bytes32"
             },
             {
-                name: 'index',
-                type: 'uint256',
-                indexed: false,
-                internalType: 'uint256',
-            },
+                "name": "index",
+                "type": "uint256",
+                "indexed": false,
+                "internalType": "uint256"
+            }
         ],
-        anonymous: false,
+        "anonymous": false
     },
     {
-        type: 'event',
-        name: 'Opened',
-        inputs: [
+        "type": "event",
+        "name": "Opened",
+        "inputs": [
             {
-                name: 'channelId',
-                type: 'bytes32',
-                indexed: true,
-                internalType: 'bytes32',
-            },
+                "name": "channelId",
+                "type": "bytes32",
+                "indexed": true,
+                "internalType": "bytes32"
+            }
         ],
-        anonymous: false,
+        "anonymous": false
     },
     {
-        type: 'event',
-        name: 'Resized',
-        inputs: [
+        "type": "event",
+        "name": "Resized",
+        "inputs": [
             {
-                name: 'channelId',
-                type: 'bytes32',
-                indexed: true,
-                internalType: 'bytes32',
+                "name": "channelId",
+                "type": "bytes32",
+                "indexed": true,
+                "internalType": "bytes32"
             },
             {
-                name: 'deltaAllocations',
-                type: 'int256[]',
-                indexed: false,
-                internalType: 'int256[]',
-            },
+                "name": "deltaAllocations",
+                "type": "int256[]",
+                "indexed": false,
+                "internalType": "int256[]"
+            }
         ],
-        anonymous: false,
+        "anonymous": false
     },
     {
-        type: 'event',
-        name: 'Withdrawn',
-        inputs: [
+        "type": "event",
+        "name": "Withdrawn",
+        "inputs": [
             {
-                name: 'wallet',
-                type: 'address',
-                indexed: true,
-                internalType: 'address',
+                "name": "wallet",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
             },
             {
-                name: 'token',
-                type: 'address',
-                indexed: true,
-                internalType: 'address',
+                "name": "token",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
             },
             {
-                name: 'amount',
-                type: 'uint256',
-                indexed: false,
-                internalType: 'uint256',
-            },
+                "name": "amount",
+                "type": "uint256",
+                "indexed": false,
+                "internalType": "uint256"
+            }
         ],
-        anonymous: false,
+        "anonymous": false
     },
     {
-        type: 'error',
-        name: 'ChallengeNotExpired',
-        inputs: [],
+        "type": "error",
+        "name": "ChallengeNotExpired",
+        "inputs": []
     },
     {
-        type: 'error',
-        name: 'ChannelNotFinal',
-        inputs: [],
+        "type": "error",
+        "name": "ChannelNotFinal",
+        "inputs": []
     },
     {
-        type: 'error',
-        name: 'ChannelNotFound',
-        inputs: [
+        "type": "error",
+        "name": "ChannelNotFound",
+        "inputs": [
             {
-                name: 'channelId',
-                type: 'bytes32',
-                internalType: 'bytes32',
-            },
-        ],
+                "name": "channelId",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
+        ]
     },
     {
-        type: 'error',
-        name: 'DepositAlreadyFulfilled',
-        inputs: [],
+        "type": "error",
+        "name": "DepositAlreadyFulfilled",
+        "inputs": []
     },
     {
-        type: 'error',
-        name: 'DepositsNotFulfilled',
-        inputs: [
+        "type": "error",
+        "name": "DepositsNotFulfilled",
+        "inputs": [
             {
-                name: 'expectedFulfilled',
-                type: 'uint256',
-                internalType: 'uint256',
-            },
-            {
-                name: 'actualFulfilled',
-                type: 'uint256',
-                internalType: 'uint256',
-            },
-        ],
-    },
-    {
-        type: 'error',
-        name: 'ECDSAInvalidSignature',
-        inputs: [],
-    },
-    {
-        type: 'error',
-        name: 'ECDSAInvalidSignatureLength',
-        inputs: [
-            {
-                name: 'length',
-                type: 'uint256',
-                internalType: 'uint256',
-            },
-        ],
-    },
-    {
-        type: 'error',
-        name: 'ECDSAInvalidSignatureS',
-        inputs: [
-            {
-                name: 's',
-                type: 'bytes32',
-                internalType: 'bytes32',
-            },
-        ],
-    },
-    {
-        type: 'error',
-        name: 'InsufficientBalance',
-        inputs: [
-            {
-                name: 'available',
-                type: 'uint256',
-                internalType: 'uint256',
+                "name": "expectedFulfilled",
+                "type": "uint256",
+                "internalType": "uint256"
             },
             {
-                name: 'required',
-                type: 'uint256',
-                internalType: 'uint256',
-            },
-        ],
+                "name": "actualFulfilled",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ]
     },
     {
-        type: 'error',
-        name: 'InvalidAdjudicator',
-        inputs: [],
+        "type": "error",
+        "name": "ECDSAInvalidSignature",
+        "inputs": []
     },
     {
-        type: 'error',
-        name: 'InvalidAllocations',
-        inputs: [],
-    },
-    {
-        type: 'error',
-        name: 'InvalidAmount',
-        inputs: [],
-    },
-    {
-        type: 'error',
-        name: 'InvalidChallengePeriod',
-        inputs: [],
-    },
-    {
-        type: 'error',
-        name: 'InvalidChallengerSignature',
-        inputs: [],
-    },
-    {
-        type: 'error',
-        name: 'InvalidParticipant',
-        inputs: [],
-    },
-    {
-        type: 'error',
-        name: 'InvalidState',
-        inputs: [],
-    },
-    {
-        type: 'error',
-        name: 'InvalidStateSignatures',
-        inputs: [],
-    },
-    {
-        type: 'error',
-        name: 'InvalidStatus',
-        inputs: [],
-    },
-    {
-        type: 'error',
-        name: 'InvalidValue',
-        inputs: [],
-    },
-    {
-        type: 'error',
-        name: 'SafeERC20FailedOperation',
-        inputs: [
+        "type": "error",
+        "name": "ECDSAInvalidSignatureLength",
+        "inputs": [
             {
-                name: 'token',
-                type: 'address',
-                internalType: 'address',
-            },
-        ],
+                "name": "length",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ]
     },
     {
-        type: 'error',
-        name: 'TransferFailed',
-        inputs: [
+        "type": "error",
+        "name": "ECDSAInvalidSignatureS",
+        "inputs": [
             {
-                name: 'token',
-                type: 'address',
-                internalType: 'address',
+                "name": "s",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
+        ]
+    },
+    {
+        "type": "error",
+        "name": "InsufficientBalance",
+        "inputs": [
+            {
+                "name": "available",
+                "type": "uint256",
+                "internalType": "uint256"
             },
             {
-                name: 'to',
-                type: 'address',
-                internalType: 'address',
+                "name": "required",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ]
+    },
+    {
+        "type": "error",
+        "name": "InvalidAdjudicator",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "InvalidAllocations",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "InvalidAmount",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "InvalidChallengePeriod",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "InvalidChallengerSignature",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "InvalidParticipant",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "InvalidShortString",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "InvalidState",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "InvalidStateSignatures",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "InvalidStatus",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "InvalidValue",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "SafeERC20FailedOperation",
+        "inputs": [
+            {
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
+            }
+        ]
+    },
+    {
+        "type": "error",
+        "name": "StringTooLong",
+        "inputs": [
+            {
+                "name": "str",
+                "type": "string",
+                "internalType": "string"
+            }
+        ]
+    },
+    {
+        "type": "error",
+        "name": "TransferFailed",
+        "inputs": [
+            {
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
             },
             {
-                name: 'amount',
-                type: 'uint256',
-                internalType: 'uint256',
+                "name": "to",
+                "type": "address",
+                "internalType": "address"
             },
-        ],
-    },
+            {
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ]
+    }
 ] as const;

--- a/sdk/src/abis/generated.ts
+++ b/sdk/src/abis/generated.ts
@@ -1,1514 +1,1514 @@
 // Auto-generated file. Do not edit manually.
 export const custodyAbi = [
-    {
-        "type": "constructor",
-        "inputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "challenge",
-        "inputs": [
-            {
-                "name": "channelId",
-                "type": "bytes32",
-                "internalType": "bytes32"
-            },
-            {
-                "name": "candidate",
-                "type": "tuple",
-                "internalType": "struct State",
-                "components": [
-                    {
-                        "name": "intent",
-                        "type": "uint8",
-                        "internalType": "enum StateIntent"
-                    },
-                    {
-                        "name": "version",
-                        "type": "uint256",
-                        "internalType": "uint256"
-                    },
-                    {
-                        "name": "data",
-                        "type": "bytes",
-                        "internalType": "bytes"
-                    },
-                    {
-                        "name": "allocations",
-                        "type": "tuple[]",
-                        "internalType": "struct Allocation[]",
-                        "components": [
-                            {
-                                "name": "destination",
-                                "type": "address",
-                                "internalType": "address"
-                            },
-                            {
-                                "name": "token",
-                                "type": "address",
-                                "internalType": "address"
-                            },
-                            {
-                                "name": "amount",
-                                "type": "uint256",
-                                "internalType": "uint256"
-                            }
-                        ]
-                    },
-                    {
-                        "name": "sigs",
-                        "type": "bytes[]",
-                        "internalType": "bytes[]"
-                    }
-                ]
-            },
-            {
-                "name": "proofs",
-                "type": "tuple[]",
-                "internalType": "struct State[]",
-                "components": [
-                    {
-                        "name": "intent",
-                        "type": "uint8",
-                        "internalType": "enum StateIntent"
-                    },
-                    {
-                        "name": "version",
-                        "type": "uint256",
-                        "internalType": "uint256"
-                    },
-                    {
-                        "name": "data",
-                        "type": "bytes",
-                        "internalType": "bytes"
-                    },
-                    {
-                        "name": "allocations",
-                        "type": "tuple[]",
-                        "internalType": "struct Allocation[]",
-                        "components": [
-                            {
-                                "name": "destination",
-                                "type": "address",
-                                "internalType": "address"
-                            },
-                            {
-                                "name": "token",
-                                "type": "address",
-                                "internalType": "address"
-                            },
-                            {
-                                "name": "amount",
-                                "type": "uint256",
-                                "internalType": "uint256"
-                            }
-                        ]
-                    },
-                    {
-                        "name": "sigs",
-                        "type": "bytes[]",
-                        "internalType": "bytes[]"
-                    }
-                ]
-            },
-            {
-                "name": "challengerSig",
-                "type": "bytes",
-                "internalType": "bytes"
-            }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "checkpoint",
-        "inputs": [
-            {
-                "name": "channelId",
-                "type": "bytes32",
-                "internalType": "bytes32"
-            },
-            {
-                "name": "candidate",
-                "type": "tuple",
-                "internalType": "struct State",
-                "components": [
-                    {
-                        "name": "intent",
-                        "type": "uint8",
-                        "internalType": "enum StateIntent"
-                    },
-                    {
-                        "name": "version",
-                        "type": "uint256",
-                        "internalType": "uint256"
-                    },
-                    {
-                        "name": "data",
-                        "type": "bytes",
-                        "internalType": "bytes"
-                    },
-                    {
-                        "name": "allocations",
-                        "type": "tuple[]",
-                        "internalType": "struct Allocation[]",
-                        "components": [
-                            {
-                                "name": "destination",
-                                "type": "address",
-                                "internalType": "address"
-                            },
-                            {
-                                "name": "token",
-                                "type": "address",
-                                "internalType": "address"
-                            },
-                            {
-                                "name": "amount",
-                                "type": "uint256",
-                                "internalType": "uint256"
-                            }
-                        ]
-                    },
-                    {
-                        "name": "sigs",
-                        "type": "bytes[]",
-                        "internalType": "bytes[]"
-                    }
-                ]
-            },
-            {
-                "name": "proofs",
-                "type": "tuple[]",
-                "internalType": "struct State[]",
-                "components": [
-                    {
-                        "name": "intent",
-                        "type": "uint8",
-                        "internalType": "enum StateIntent"
-                    },
-                    {
-                        "name": "version",
-                        "type": "uint256",
-                        "internalType": "uint256"
-                    },
-                    {
-                        "name": "data",
-                        "type": "bytes",
-                        "internalType": "bytes"
-                    },
-                    {
-                        "name": "allocations",
-                        "type": "tuple[]",
-                        "internalType": "struct Allocation[]",
-                        "components": [
-                            {
-                                "name": "destination",
-                                "type": "address",
-                                "internalType": "address"
-                            },
-                            {
-                                "name": "token",
-                                "type": "address",
-                                "internalType": "address"
-                            },
-                            {
-                                "name": "amount",
-                                "type": "uint256",
-                                "internalType": "uint256"
-                            }
-                        ]
-                    },
-                    {
-                        "name": "sigs",
-                        "type": "bytes[]",
-                        "internalType": "bytes[]"
-                    }
-                ]
-            }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "close",
-        "inputs": [
-            {
-                "name": "channelId",
-                "type": "bytes32",
-                "internalType": "bytes32"
-            },
-            {
-                "name": "candidate",
-                "type": "tuple",
-                "internalType": "struct State",
-                "components": [
-                    {
-                        "name": "intent",
-                        "type": "uint8",
-                        "internalType": "enum StateIntent"
-                    },
-                    {
-                        "name": "version",
-                        "type": "uint256",
-                        "internalType": "uint256"
-                    },
-                    {
-                        "name": "data",
-                        "type": "bytes",
-                        "internalType": "bytes"
-                    },
-                    {
-                        "name": "allocations",
-                        "type": "tuple[]",
-                        "internalType": "struct Allocation[]",
-                        "components": [
-                            {
-                                "name": "destination",
-                                "type": "address",
-                                "internalType": "address"
-                            },
-                            {
-                                "name": "token",
-                                "type": "address",
-                                "internalType": "address"
-                            },
-                            {
-                                "name": "amount",
-                                "type": "uint256",
-                                "internalType": "uint256"
-                            }
-                        ]
-                    },
-                    {
-                        "name": "sigs",
-                        "type": "bytes[]",
-                        "internalType": "bytes[]"
-                    }
-                ]
-            },
-            {
-                "name": "",
-                "type": "tuple[]",
-                "internalType": "struct State[]",
-                "components": [
-                    {
-                        "name": "intent",
-                        "type": "uint8",
-                        "internalType": "enum StateIntent"
-                    },
-                    {
-                        "name": "version",
-                        "type": "uint256",
-                        "internalType": "uint256"
-                    },
-                    {
-                        "name": "data",
-                        "type": "bytes",
-                        "internalType": "bytes"
-                    },
-                    {
-                        "name": "allocations",
-                        "type": "tuple[]",
-                        "internalType": "struct Allocation[]",
-                        "components": [
-                            {
-                                "name": "destination",
-                                "type": "address",
-                                "internalType": "address"
-                            },
-                            {
-                                "name": "token",
-                                "type": "address",
-                                "internalType": "address"
-                            },
-                            {
-                                "name": "amount",
-                                "type": "uint256",
-                                "internalType": "uint256"
-                            }
-                        ]
-                    },
-                    {
-                        "name": "sigs",
-                        "type": "bytes[]",
-                        "internalType": "bytes[]"
-                    }
-                ]
-            }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "create",
-        "inputs": [
-            {
-                "name": "ch",
-                "type": "tuple",
-                "internalType": "struct Channel",
-                "components": [
-                    {
-                        "name": "participants",
-                        "type": "address[]",
-                        "internalType": "address[]"
-                    },
-                    {
-                        "name": "adjudicator",
-                        "type": "address",
-                        "internalType": "address"
-                    },
-                    {
-                        "name": "challenge",
-                        "type": "uint64",
-                        "internalType": "uint64"
-                    },
-                    {
-                        "name": "nonce",
-                        "type": "uint64",
-                        "internalType": "uint64"
-                    }
-                ]
-            },
-            {
-                "name": "initial",
-                "type": "tuple",
-                "internalType": "struct State",
-                "components": [
-                    {
-                        "name": "intent",
-                        "type": "uint8",
-                        "internalType": "enum StateIntent"
-                    },
-                    {
-                        "name": "version",
-                        "type": "uint256",
-                        "internalType": "uint256"
-                    },
-                    {
-                        "name": "data",
-                        "type": "bytes",
-                        "internalType": "bytes"
-                    },
-                    {
-                        "name": "allocations",
-                        "type": "tuple[]",
-                        "internalType": "struct Allocation[]",
-                        "components": [
-                            {
-                                "name": "destination",
-                                "type": "address",
-                                "internalType": "address"
-                            },
-                            {
-                                "name": "token",
-                                "type": "address",
-                                "internalType": "address"
-                            },
-                            {
-                                "name": "amount",
-                                "type": "uint256",
-                                "internalType": "uint256"
-                            }
-                        ]
-                    },
-                    {
-                        "name": "sigs",
-                        "type": "bytes[]",
-                        "internalType": "bytes[]"
-                    }
-                ]
-            }
-        ],
-        "outputs": [
-            {
-                "name": "channelId",
-                "type": "bytes32",
-                "internalType": "bytes32"
-            }
-        ],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "deposit",
-        "inputs": [
-            {
-                "name": "account",
+  {
+    "type": "constructor",
+    "inputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "challenge",
+    "inputs": [
+      {
+        "name": "channelId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "candidate",
+        "type": "tuple",
+        "internalType": "struct State",
+        "components": [
+          {
+            "name": "intent",
+            "type": "uint8",
+            "internalType": "enum StateIntent"
+          },
+          {
+            "name": "version",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "data",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "allocations",
+            "type": "tuple[]",
+            "internalType": "struct Allocation[]",
+            "components": [
+              {
+                "name": "destination",
                 "type": "address",
                 "internalType": "address"
-            },
-            {
+              },
+              {
                 "name": "token",
                 "type": "address",
                 "internalType": "address"
-            },
-            {
+              },
+              {
                 "name": "amount",
                 "type": "uint256",
                 "internalType": "uint256"
-            }
-        ],
-        "outputs": [],
-        "stateMutability": "payable"
-    },
-    {
-        "type": "function",
-        "name": "depositAndCreate",
-        "inputs": [
-            {
+              }
+            ]
+          },
+          {
+            "name": "sigs",
+            "type": "bytes[]",
+            "internalType": "bytes[]"
+          }
+        ]
+      },
+      {
+        "name": "proofs",
+        "type": "tuple[]",
+        "internalType": "struct State[]",
+        "components": [
+          {
+            "name": "intent",
+            "type": "uint8",
+            "internalType": "enum StateIntent"
+          },
+          {
+            "name": "version",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "data",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "allocations",
+            "type": "tuple[]",
+            "internalType": "struct Allocation[]",
+            "components": [
+              {
+                "name": "destination",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
                 "name": "token",
                 "type": "address",
                 "internalType": "address"
-            },
-            {
+              },
+              {
                 "name": "amount",
                 "type": "uint256",
                 "internalType": "uint256"
-            },
-            {
-                "name": "ch",
-                "type": "tuple",
-                "internalType": "struct Channel",
-                "components": [
-                    {
-                        "name": "participants",
-                        "type": "address[]",
-                        "internalType": "address[]"
-                    },
-                    {
-                        "name": "adjudicator",
-                        "type": "address",
-                        "internalType": "address"
-                    },
-                    {
-                        "name": "challenge",
-                        "type": "uint64",
-                        "internalType": "uint64"
-                    },
-                    {
-                        "name": "nonce",
-                        "type": "uint64",
-                        "internalType": "uint64"
-                    }
-                ]
-            },
-            {
-                "name": "initial",
-                "type": "tuple",
-                "internalType": "struct State",
-                "components": [
-                    {
-                        "name": "intent",
-                        "type": "uint8",
-                        "internalType": "enum StateIntent"
-                    },
-                    {
-                        "name": "version",
-                        "type": "uint256",
-                        "internalType": "uint256"
-                    },
-                    {
-                        "name": "data",
-                        "type": "bytes",
-                        "internalType": "bytes"
-                    },
-                    {
-                        "name": "allocations",
-                        "type": "tuple[]",
-                        "internalType": "struct Allocation[]",
-                        "components": [
-                            {
-                                "name": "destination",
-                                "type": "address",
-                                "internalType": "address"
-                            },
-                            {
-                                "name": "token",
-                                "type": "address",
-                                "internalType": "address"
-                            },
-                            {
-                                "name": "amount",
-                                "type": "uint256",
-                                "internalType": "uint256"
-                            }
-                        ]
-                    },
-                    {
-                        "name": "sigs",
-                        "type": "bytes[]",
-                        "internalType": "bytes[]"
-                    }
-                ]
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "bytes32",
-                "internalType": "bytes32"
-            }
-        ],
-        "stateMutability": "payable"
-    },
-    {
-        "type": "function",
-        "name": "eip712Domain",
-        "inputs": [],
-        "outputs": [
-            {
-                "name": "fields",
-                "type": "bytes1",
-                "internalType": "bytes1"
-            },
-            {
-                "name": "name",
-                "type": "string",
-                "internalType": "string"
-            },
-            {
-                "name": "version",
-                "type": "string",
-                "internalType": "string"
-            },
-            {
-                "name": "chainId",
-                "type": "uint256",
-                "internalType": "uint256"
-            },
-            {
-                "name": "verifyingContract",
+              }
+            ]
+          },
+          {
+            "name": "sigs",
+            "type": "bytes[]",
+            "internalType": "bytes[]"
+          }
+        ]
+      },
+      {
+        "name": "challengerSig",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "checkpoint",
+    "inputs": [
+      {
+        "name": "channelId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "candidate",
+        "type": "tuple",
+        "internalType": "struct State",
+        "components": [
+          {
+            "name": "intent",
+            "type": "uint8",
+            "internalType": "enum StateIntent"
+          },
+          {
+            "name": "version",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "data",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "allocations",
+            "type": "tuple[]",
+            "internalType": "struct Allocation[]",
+            "components": [
+              {
+                "name": "destination",
                 "type": "address",
                 "internalType": "address"
-            },
-            {
-                "name": "salt",
-                "type": "bytes32",
-                "internalType": "bytes32"
-            },
-            {
-                "name": "extensions",
-                "type": "uint256[]",
-                "internalType": "uint256[]"
-            }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "getAccountsBalances",
-        "inputs": [
-            {
-                "name": "accounts",
-                "type": "address[]",
-                "internalType": "address[]"
-            },
-            {
-                "name": "tokens",
-                "type": "address[]",
-                "internalType": "address[]"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "uint256[][]",
-                "internalType": "uint256[][]"
-            }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "getChannelBalances",
-        "inputs": [
-            {
-                "name": "channelId",
-                "type": "bytes32",
-                "internalType": "bytes32"
-            },
-            {
-                "name": "tokens",
-                "type": "address[]",
-                "internalType": "address[]"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "balances",
-                "type": "uint256[]",
-                "internalType": "uint256[]"
-            }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "getChannelData",
-        "inputs": [
-            {
-                "name": "channelId",
-                "type": "bytes32",
-                "internalType": "bytes32"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "channel",
-                "type": "tuple",
-                "internalType": "struct Channel",
-                "components": [
-                    {
-                        "name": "participants",
-                        "type": "address[]",
-                        "internalType": "address[]"
-                    },
-                    {
-                        "name": "adjudicator",
-                        "type": "address",
-                        "internalType": "address"
-                    },
-                    {
-                        "name": "challenge",
-                        "type": "uint64",
-                        "internalType": "uint64"
-                    },
-                    {
-                        "name": "nonce",
-                        "type": "uint64",
-                        "internalType": "uint64"
-                    }
-                ]
-            },
-            {
-                "name": "status",
-                "type": "uint8",
-                "internalType": "enum ChannelStatus"
-            },
-            {
-                "name": "wallets",
-                "type": "address[]",
-                "internalType": "address[]"
-            },
-            {
-                "name": "challengeExpiry",
-                "type": "uint256",
-                "internalType": "uint256"
-            },
-            {
-                "name": "lastValidState",
-                "type": "tuple",
-                "internalType": "struct State",
-                "components": [
-                    {
-                        "name": "intent",
-                        "type": "uint8",
-                        "internalType": "enum StateIntent"
-                    },
-                    {
-                        "name": "version",
-                        "type": "uint256",
-                        "internalType": "uint256"
-                    },
-                    {
-                        "name": "data",
-                        "type": "bytes",
-                        "internalType": "bytes"
-                    },
-                    {
-                        "name": "allocations",
-                        "type": "tuple[]",
-                        "internalType": "struct Allocation[]",
-                        "components": [
-                            {
-                                "name": "destination",
-                                "type": "address",
-                                "internalType": "address"
-                            },
-                            {
-                                "name": "token",
-                                "type": "address",
-                                "internalType": "address"
-                            },
-                            {
-                                "name": "amount",
-                                "type": "uint256",
-                                "internalType": "uint256"
-                            }
-                        ]
-                    },
-                    {
-                        "name": "sigs",
-                        "type": "bytes[]",
-                        "internalType": "bytes[]"
-                    }
-                ]
-            }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "getOpenChannels",
-        "inputs": [
-            {
-                "name": "accounts",
-                "type": "address[]",
-                "internalType": "address[]"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "bytes32[][]",
-                "internalType": "bytes32[][]"
-            }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "join",
-        "inputs": [
-            {
-                "name": "channelId",
-                "type": "bytes32",
-                "internalType": "bytes32"
-            },
-            {
-                "name": "index",
-                "type": "uint256",
-                "internalType": "uint256"
-            },
-            {
-                "name": "sig",
-                "type": "bytes",
-                "internalType": "bytes"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "bytes32",
-                "internalType": "bytes32"
-            }
-        ],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "resize",
-        "inputs": [
-            {
-                "name": "channelId",
-                "type": "bytes32",
-                "internalType": "bytes32"
-            },
-            {
-                "name": "candidate",
-                "type": "tuple",
-                "internalType": "struct State",
-                "components": [
-                    {
-                        "name": "intent",
-                        "type": "uint8",
-                        "internalType": "enum StateIntent"
-                    },
-                    {
-                        "name": "version",
-                        "type": "uint256",
-                        "internalType": "uint256"
-                    },
-                    {
-                        "name": "data",
-                        "type": "bytes",
-                        "internalType": "bytes"
-                    },
-                    {
-                        "name": "allocations",
-                        "type": "tuple[]",
-                        "internalType": "struct Allocation[]",
-                        "components": [
-                            {
-                                "name": "destination",
-                                "type": "address",
-                                "internalType": "address"
-                            },
-                            {
-                                "name": "token",
-                                "type": "address",
-                                "internalType": "address"
-                            },
-                            {
-                                "name": "amount",
-                                "type": "uint256",
-                                "internalType": "uint256"
-                            }
-                        ]
-                    },
-                    {
-                        "name": "sigs",
-                        "type": "bytes[]",
-                        "internalType": "bytes[]"
-                    }
-                ]
-            },
-            {
-                "name": "proofs",
-                "type": "tuple[]",
-                "internalType": "struct State[]",
-                "components": [
-                    {
-                        "name": "intent",
-                        "type": "uint8",
-                        "internalType": "enum StateIntent"
-                    },
-                    {
-                        "name": "version",
-                        "type": "uint256",
-                        "internalType": "uint256"
-                    },
-                    {
-                        "name": "data",
-                        "type": "bytes",
-                        "internalType": "bytes"
-                    },
-                    {
-                        "name": "allocations",
-                        "type": "tuple[]",
-                        "internalType": "struct Allocation[]",
-                        "components": [
-                            {
-                                "name": "destination",
-                                "type": "address",
-                                "internalType": "address"
-                            },
-                            {
-                                "name": "token",
-                                "type": "address",
-                                "internalType": "address"
-                            },
-                            {
-                                "name": "amount",
-                                "type": "uint256",
-                                "internalType": "uint256"
-                            }
-                        ]
-                    },
-                    {
-                        "name": "sigs",
-                        "type": "bytes[]",
-                        "internalType": "bytes[]"
-                    }
-                ]
-            }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "withdraw",
-        "inputs": [
-            {
+              },
+              {
                 "name": "token",
                 "type": "address",
                 "internalType": "address"
-            },
-            {
+              },
+              {
                 "name": "amount",
                 "type": "uint256",
                 "internalType": "uint256"
-            }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "event",
-        "name": "Challenged",
-        "inputs": [
-            {
-                "name": "channelId",
-                "type": "bytes32",
-                "indexed": true,
-                "internalType": "bytes32"
-            },
-            {
-                "name": "state",
-                "type": "tuple",
-                "indexed": false,
-                "internalType": "struct State",
-                "components": [
-                    {
-                        "name": "intent",
-                        "type": "uint8",
-                        "internalType": "enum StateIntent"
-                    },
-                    {
-                        "name": "version",
-                        "type": "uint256",
-                        "internalType": "uint256"
-                    },
-                    {
-                        "name": "data",
-                        "type": "bytes",
-                        "internalType": "bytes"
-                    },
-                    {
-                        "name": "allocations",
-                        "type": "tuple[]",
-                        "internalType": "struct Allocation[]",
-                        "components": [
-                            {
-                                "name": "destination",
-                                "type": "address",
-                                "internalType": "address"
-                            },
-                            {
-                                "name": "token",
-                                "type": "address",
-                                "internalType": "address"
-                            },
-                            {
-                                "name": "amount",
-                                "type": "uint256",
-                                "internalType": "uint256"
-                            }
-                        ]
-                    },
-                    {
-                        "name": "sigs",
-                        "type": "bytes[]",
-                        "internalType": "bytes[]"
-                    }
-                ]
-            },
-            {
-                "name": "expiration",
-                "type": "uint256",
-                "indexed": false,
-                "internalType": "uint256"
-            }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Checkpointed",
-        "inputs": [
-            {
-                "name": "channelId",
-                "type": "bytes32",
-                "indexed": true,
-                "internalType": "bytes32"
-            },
-            {
-                "name": "state",
-                "type": "tuple",
-                "indexed": false,
-                "internalType": "struct State",
-                "components": [
-                    {
-                        "name": "intent",
-                        "type": "uint8",
-                        "internalType": "enum StateIntent"
-                    },
-                    {
-                        "name": "version",
-                        "type": "uint256",
-                        "internalType": "uint256"
-                    },
-                    {
-                        "name": "data",
-                        "type": "bytes",
-                        "internalType": "bytes"
-                    },
-                    {
-                        "name": "allocations",
-                        "type": "tuple[]",
-                        "internalType": "struct Allocation[]",
-                        "components": [
-                            {
-                                "name": "destination",
-                                "type": "address",
-                                "internalType": "address"
-                            },
-                            {
-                                "name": "token",
-                                "type": "address",
-                                "internalType": "address"
-                            },
-                            {
-                                "name": "amount",
-                                "type": "uint256",
-                                "internalType": "uint256"
-                            }
-                        ]
-                    },
-                    {
-                        "name": "sigs",
-                        "type": "bytes[]",
-                        "internalType": "bytes[]"
-                    }
-                ]
-            }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Closed",
-        "inputs": [
-            {
-                "name": "channelId",
-                "type": "bytes32",
-                "indexed": true,
-                "internalType": "bytes32"
-            },
-            {
-                "name": "finalState",
-                "type": "tuple",
-                "indexed": false,
-                "internalType": "struct State",
-                "components": [
-                    {
-                        "name": "intent",
-                        "type": "uint8",
-                        "internalType": "enum StateIntent"
-                    },
-                    {
-                        "name": "version",
-                        "type": "uint256",
-                        "internalType": "uint256"
-                    },
-                    {
-                        "name": "data",
-                        "type": "bytes",
-                        "internalType": "bytes"
-                    },
-                    {
-                        "name": "allocations",
-                        "type": "tuple[]",
-                        "internalType": "struct Allocation[]",
-                        "components": [
-                            {
-                                "name": "destination",
-                                "type": "address",
-                                "internalType": "address"
-                            },
-                            {
-                                "name": "token",
-                                "type": "address",
-                                "internalType": "address"
-                            },
-                            {
-                                "name": "amount",
-                                "type": "uint256",
-                                "internalType": "uint256"
-                            }
-                        ]
-                    },
-                    {
-                        "name": "sigs",
-                        "type": "bytes[]",
-                        "internalType": "bytes[]"
-                    }
-                ]
-            }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Created",
-        "inputs": [
-            {
-                "name": "channelId",
-                "type": "bytes32",
-                "indexed": true,
-                "internalType": "bytes32"
-            },
-            {
-                "name": "wallet",
-                "type": "address",
-                "indexed": true,
-                "internalType": "address"
-            },
-            {
-                "name": "channel",
-                "type": "tuple",
-                "indexed": false,
-                "internalType": "struct Channel",
-                "components": [
-                    {
-                        "name": "participants",
-                        "type": "address[]",
-                        "internalType": "address[]"
-                    },
-                    {
-                        "name": "adjudicator",
-                        "type": "address",
-                        "internalType": "address"
-                    },
-                    {
-                        "name": "challenge",
-                        "type": "uint64",
-                        "internalType": "uint64"
-                    },
-                    {
-                        "name": "nonce",
-                        "type": "uint64",
-                        "internalType": "uint64"
-                    }
-                ]
-            },
-            {
-                "name": "initial",
-                "type": "tuple",
-                "indexed": false,
-                "internalType": "struct State",
-                "components": [
-                    {
-                        "name": "intent",
-                        "type": "uint8",
-                        "internalType": "enum StateIntent"
-                    },
-                    {
-                        "name": "version",
-                        "type": "uint256",
-                        "internalType": "uint256"
-                    },
-                    {
-                        "name": "data",
-                        "type": "bytes",
-                        "internalType": "bytes"
-                    },
-                    {
-                        "name": "allocations",
-                        "type": "tuple[]",
-                        "internalType": "struct Allocation[]",
-                        "components": [
-                            {
-                                "name": "destination",
-                                "type": "address",
-                                "internalType": "address"
-                            },
-                            {
-                                "name": "token",
-                                "type": "address",
-                                "internalType": "address"
-                            },
-                            {
-                                "name": "amount",
-                                "type": "uint256",
-                                "internalType": "uint256"
-                            }
-                        ]
-                    },
-                    {
-                        "name": "sigs",
-                        "type": "bytes[]",
-                        "internalType": "bytes[]"
-                    }
-                ]
-            }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Deposited",
-        "inputs": [
-            {
-                "name": "wallet",
-                "type": "address",
-                "indexed": true,
-                "internalType": "address"
-            },
-            {
-                "name": "token",
-                "type": "address",
-                "indexed": true,
-                "internalType": "address"
-            },
-            {
-                "name": "amount",
-                "type": "uint256",
-                "indexed": false,
-                "internalType": "uint256"
-            }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "EIP712DomainChanged",
-        "inputs": [],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Joined",
-        "inputs": [
-            {
-                "name": "channelId",
-                "type": "bytes32",
-                "indexed": true,
-                "internalType": "bytes32"
-            },
-            {
-                "name": "index",
-                "type": "uint256",
-                "indexed": false,
-                "internalType": "uint256"
-            }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Opened",
-        "inputs": [
-            {
-                "name": "channelId",
-                "type": "bytes32",
-                "indexed": true,
-                "internalType": "bytes32"
-            }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Resized",
-        "inputs": [
-            {
-                "name": "channelId",
-                "type": "bytes32",
-                "indexed": true,
-                "internalType": "bytes32"
-            },
-            {
-                "name": "deltaAllocations",
-                "type": "int256[]",
-                "indexed": false,
-                "internalType": "int256[]"
-            }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Withdrawn",
-        "inputs": [
-            {
-                "name": "wallet",
-                "type": "address",
-                "indexed": true,
-                "internalType": "address"
-            },
-            {
-                "name": "token",
-                "type": "address",
-                "indexed": true,
-                "internalType": "address"
-            },
-            {
-                "name": "amount",
-                "type": "uint256",
-                "indexed": false,
-                "internalType": "uint256"
-            }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "error",
-        "name": "ChallengeNotExpired",
-        "inputs": []
-    },
-    {
-        "type": "error",
-        "name": "ChannelNotFinal",
-        "inputs": []
-    },
-    {
-        "type": "error",
-        "name": "ChannelNotFound",
-        "inputs": [
-            {
-                "name": "channelId",
-                "type": "bytes32",
-                "internalType": "bytes32"
-            }
+              }
+            ]
+          },
+          {
+            "name": "sigs",
+            "type": "bytes[]",
+            "internalType": "bytes[]"
+          }
         ]
-    },
-    {
-        "type": "error",
-        "name": "DepositAlreadyFulfilled",
-        "inputs": []
-    },
-    {
-        "type": "error",
-        "name": "DepositsNotFulfilled",
-        "inputs": [
-            {
-                "name": "expectedFulfilled",
-                "type": "uint256",
-                "internalType": "uint256"
-            },
-            {
-                "name": "actualFulfilled",
-                "type": "uint256",
-                "internalType": "uint256"
-            }
-        ]
-    },
-    {
-        "type": "error",
-        "name": "ECDSAInvalidSignature",
-        "inputs": []
-    },
-    {
-        "type": "error",
-        "name": "ECDSAInvalidSignatureLength",
-        "inputs": [
-            {
-                "name": "length",
-                "type": "uint256",
-                "internalType": "uint256"
-            }
-        ]
-    },
-    {
-        "type": "error",
-        "name": "ECDSAInvalidSignatureS",
-        "inputs": [
-            {
-                "name": "s",
-                "type": "bytes32",
-                "internalType": "bytes32"
-            }
-        ]
-    },
-    {
-        "type": "error",
-        "name": "InsufficientBalance",
-        "inputs": [
-            {
-                "name": "available",
-                "type": "uint256",
-                "internalType": "uint256"
-            },
-            {
-                "name": "required",
-                "type": "uint256",
-                "internalType": "uint256"
-            }
-        ]
-    },
-    {
-        "type": "error",
-        "name": "InvalidAdjudicator",
-        "inputs": []
-    },
-    {
-        "type": "error",
-        "name": "InvalidAllocations",
-        "inputs": []
-    },
-    {
-        "type": "error",
-        "name": "InvalidAmount",
-        "inputs": []
-    },
-    {
-        "type": "error",
-        "name": "InvalidChallengePeriod",
-        "inputs": []
-    },
-    {
-        "type": "error",
-        "name": "InvalidChallengerSignature",
-        "inputs": []
-    },
-    {
-        "type": "error",
-        "name": "InvalidParticipant",
-        "inputs": []
-    },
-    {
-        "type": "error",
-        "name": "InvalidShortString",
-        "inputs": []
-    },
-    {
-        "type": "error",
-        "name": "InvalidState",
-        "inputs": []
-    },
-    {
-        "type": "error",
-        "name": "InvalidStateSignatures",
-        "inputs": []
-    },
-    {
-        "type": "error",
-        "name": "InvalidStatus",
-        "inputs": []
-    },
-    {
-        "type": "error",
-        "name": "InvalidValue",
-        "inputs": []
-    },
-    {
-        "type": "error",
-        "name": "SafeERC20FailedOperation",
-        "inputs": [
-            {
+      },
+      {
+        "name": "proofs",
+        "type": "tuple[]",
+        "internalType": "struct State[]",
+        "components": [
+          {
+            "name": "intent",
+            "type": "uint8",
+            "internalType": "enum StateIntent"
+          },
+          {
+            "name": "version",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "data",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "allocations",
+            "type": "tuple[]",
+            "internalType": "struct Allocation[]",
+            "components": [
+              {
+                "name": "destination",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
                 "name": "token",
                 "type": "address",
                 "internalType": "address"
-            }
-        ]
-    },
-    {
-        "type": "error",
-        "name": "StringTooLong",
-        "inputs": [
-            {
-                "name": "str",
-                "type": "string",
-                "internalType": "string"
-            }
-        ]
-    },
-    {
-        "type": "error",
-        "name": "TransferFailed",
-        "inputs": [
-            {
-                "name": "token",
-                "type": "address",
-                "internalType": "address"
-            },
-            {
-                "name": "to",
-                "type": "address",
-                "internalType": "address"
-            },
-            {
+              },
+              {
                 "name": "amount",
                 "type": "uint256",
                 "internalType": "uint256"
-            }
+              }
+            ]
+          },
+          {
+            "name": "sigs",
+            "type": "bytes[]",
+            "internalType": "bytes[]"
+          }
         ]
-    }
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "close",
+    "inputs": [
+      {
+        "name": "channelId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "candidate",
+        "type": "tuple",
+        "internalType": "struct State",
+        "components": [
+          {
+            "name": "intent",
+            "type": "uint8",
+            "internalType": "enum StateIntent"
+          },
+          {
+            "name": "version",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "data",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "allocations",
+            "type": "tuple[]",
+            "internalType": "struct Allocation[]",
+            "components": [
+              {
+                "name": "destination",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "sigs",
+            "type": "bytes[]",
+            "internalType": "bytes[]"
+          }
+        ]
+      },
+      {
+        "name": "",
+        "type": "tuple[]",
+        "internalType": "struct State[]",
+        "components": [
+          {
+            "name": "intent",
+            "type": "uint8",
+            "internalType": "enum StateIntent"
+          },
+          {
+            "name": "version",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "data",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "allocations",
+            "type": "tuple[]",
+            "internalType": "struct Allocation[]",
+            "components": [
+              {
+                "name": "destination",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "sigs",
+            "type": "bytes[]",
+            "internalType": "bytes[]"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "create",
+    "inputs": [
+      {
+        "name": "ch",
+        "type": "tuple",
+        "internalType": "struct Channel",
+        "components": [
+          {
+            "name": "participants",
+            "type": "address[]",
+            "internalType": "address[]"
+          },
+          {
+            "name": "adjudicator",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "challenge",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "nonce",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      },
+      {
+        "name": "initial",
+        "type": "tuple",
+        "internalType": "struct State",
+        "components": [
+          {
+            "name": "intent",
+            "type": "uint8",
+            "internalType": "enum StateIntent"
+          },
+          {
+            "name": "version",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "data",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "allocations",
+            "type": "tuple[]",
+            "internalType": "struct Allocation[]",
+            "components": [
+              {
+                "name": "destination",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "sigs",
+            "type": "bytes[]",
+            "internalType": "bytes[]"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "channelId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "deposit",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "depositAndCreate",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "ch",
+        "type": "tuple",
+        "internalType": "struct Channel",
+        "components": [
+          {
+            "name": "participants",
+            "type": "address[]",
+            "internalType": "address[]"
+          },
+          {
+            "name": "adjudicator",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "challenge",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "nonce",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      },
+      {
+        "name": "initial",
+        "type": "tuple",
+        "internalType": "struct State",
+        "components": [
+          {
+            "name": "intent",
+            "type": "uint8",
+            "internalType": "enum StateIntent"
+          },
+          {
+            "name": "version",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "data",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "allocations",
+            "type": "tuple[]",
+            "internalType": "struct Allocation[]",
+            "components": [
+              {
+                "name": "destination",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "sigs",
+            "type": "bytes[]",
+            "internalType": "bytes[]"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "eip712Domain",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "fields",
+        "type": "bytes1",
+        "internalType": "bytes1"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "version",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "chainId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "verifyingContract",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "salt",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "extensions",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getAccountsBalances",
+    "inputs": [
+      {
+        "name": "accounts",
+        "type": "address[]",
+        "internalType": "address[]"
+      },
+      {
+        "name": "tokens",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256[][]",
+        "internalType": "uint256[][]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getChannelBalances",
+    "inputs": [
+      {
+        "name": "channelId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "tokens",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "balances",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getChannelData",
+    "inputs": [
+      {
+        "name": "channelId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "channel",
+        "type": "tuple",
+        "internalType": "struct Channel",
+        "components": [
+          {
+            "name": "participants",
+            "type": "address[]",
+            "internalType": "address[]"
+          },
+          {
+            "name": "adjudicator",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "challenge",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "nonce",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      },
+      {
+        "name": "status",
+        "type": "uint8",
+        "internalType": "enum ChannelStatus"
+      },
+      {
+        "name": "wallets",
+        "type": "address[]",
+        "internalType": "address[]"
+      },
+      {
+        "name": "challengeExpiry",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "lastValidState",
+        "type": "tuple",
+        "internalType": "struct State",
+        "components": [
+          {
+            "name": "intent",
+            "type": "uint8",
+            "internalType": "enum StateIntent"
+          },
+          {
+            "name": "version",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "data",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "allocations",
+            "type": "tuple[]",
+            "internalType": "struct Allocation[]",
+            "components": [
+              {
+                "name": "destination",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "sigs",
+            "type": "bytes[]",
+            "internalType": "bytes[]"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getOpenChannels",
+    "inputs": [
+      {
+        "name": "accounts",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32[][]",
+        "internalType": "bytes32[][]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "join",
+    "inputs": [
+      {
+        "name": "channelId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "index",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "sig",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "resize",
+    "inputs": [
+      {
+        "name": "channelId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "candidate",
+        "type": "tuple",
+        "internalType": "struct State",
+        "components": [
+          {
+            "name": "intent",
+            "type": "uint8",
+            "internalType": "enum StateIntent"
+          },
+          {
+            "name": "version",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "data",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "allocations",
+            "type": "tuple[]",
+            "internalType": "struct Allocation[]",
+            "components": [
+              {
+                "name": "destination",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "sigs",
+            "type": "bytes[]",
+            "internalType": "bytes[]"
+          }
+        ]
+      },
+      {
+        "name": "proofs",
+        "type": "tuple[]",
+        "internalType": "struct State[]",
+        "components": [
+          {
+            "name": "intent",
+            "type": "uint8",
+            "internalType": "enum StateIntent"
+          },
+          {
+            "name": "version",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "data",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "allocations",
+            "type": "tuple[]",
+            "internalType": "struct Allocation[]",
+            "components": [
+              {
+                "name": "destination",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "sigs",
+            "type": "bytes[]",
+            "internalType": "bytes[]"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "withdraw",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "Challenged",
+    "inputs": [
+      {
+        "name": "channelId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "state",
+        "type": "tuple",
+        "indexed": false,
+        "internalType": "struct State",
+        "components": [
+          {
+            "name": "intent",
+            "type": "uint8",
+            "internalType": "enum StateIntent"
+          },
+          {
+            "name": "version",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "data",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "allocations",
+            "type": "tuple[]",
+            "internalType": "struct Allocation[]",
+            "components": [
+              {
+                "name": "destination",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "sigs",
+            "type": "bytes[]",
+            "internalType": "bytes[]"
+          }
+        ]
+      },
+      {
+        "name": "expiration",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Checkpointed",
+    "inputs": [
+      {
+        "name": "channelId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "state",
+        "type": "tuple",
+        "indexed": false,
+        "internalType": "struct State",
+        "components": [
+          {
+            "name": "intent",
+            "type": "uint8",
+            "internalType": "enum StateIntent"
+          },
+          {
+            "name": "version",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "data",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "allocations",
+            "type": "tuple[]",
+            "internalType": "struct Allocation[]",
+            "components": [
+              {
+                "name": "destination",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "sigs",
+            "type": "bytes[]",
+            "internalType": "bytes[]"
+          }
+        ]
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Closed",
+    "inputs": [
+      {
+        "name": "channelId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "finalState",
+        "type": "tuple",
+        "indexed": false,
+        "internalType": "struct State",
+        "components": [
+          {
+            "name": "intent",
+            "type": "uint8",
+            "internalType": "enum StateIntent"
+          },
+          {
+            "name": "version",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "data",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "allocations",
+            "type": "tuple[]",
+            "internalType": "struct Allocation[]",
+            "components": [
+              {
+                "name": "destination",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "sigs",
+            "type": "bytes[]",
+            "internalType": "bytes[]"
+          }
+        ]
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Created",
+    "inputs": [
+      {
+        "name": "channelId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "wallet",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "channel",
+        "type": "tuple",
+        "indexed": false,
+        "internalType": "struct Channel",
+        "components": [
+          {
+            "name": "participants",
+            "type": "address[]",
+            "internalType": "address[]"
+          },
+          {
+            "name": "adjudicator",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "challenge",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "nonce",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      },
+      {
+        "name": "initial",
+        "type": "tuple",
+        "indexed": false,
+        "internalType": "struct State",
+        "components": [
+          {
+            "name": "intent",
+            "type": "uint8",
+            "internalType": "enum StateIntent"
+          },
+          {
+            "name": "version",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "data",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "allocations",
+            "type": "tuple[]",
+            "internalType": "struct Allocation[]",
+            "components": [
+              {
+                "name": "destination",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "sigs",
+            "type": "bytes[]",
+            "internalType": "bytes[]"
+          }
+        ]
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Deposited",
+    "inputs": [
+      {
+        "name": "wallet",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "token",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "EIP712DomainChanged",
+    "inputs": [],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Joined",
+    "inputs": [
+      {
+        "name": "channelId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "index",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Opened",
+    "inputs": [
+      {
+        "name": "channelId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Resized",
+    "inputs": [
+      {
+        "name": "channelId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "deltaAllocations",
+        "type": "int256[]",
+        "indexed": false,
+        "internalType": "int256[]"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Withdrawn",
+    "inputs": [
+      {
+        "name": "wallet",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "token",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "ChallengeNotExpired",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ChannelNotFinal",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ChannelNotFound",
+    "inputs": [
+      {
+        "name": "channelId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "DepositAlreadyFulfilled",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "DepositsNotFulfilled",
+    "inputs": [
+      {
+        "name": "expectedFulfilled",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "actualFulfilled",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ECDSAInvalidSignature",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ECDSAInvalidSignatureLength",
+    "inputs": [
+      {
+        "name": "length",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ECDSAInvalidSignatureS",
+    "inputs": [
+      {
+        "name": "s",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InsufficientBalance",
+    "inputs": [
+      {
+        "name": "available",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "required",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidAdjudicator",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidAllocations",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidAmount",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidChallengePeriod",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidChallengerSignature",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidParticipant",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidShortString",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidState",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidStateSignatures",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidStatus",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidValue",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "SafeERC20FailedOperation",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "StringTooLong",
+    "inputs": [
+      {
+        "name": "str",
+        "type": "string",
+        "internalType": "string"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "TransferFailed",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  }
 ] as const;

--- a/sdk/src/client/services/NitroliteService.ts
+++ b/sdk/src/client/services/NitroliteService.ts
@@ -156,11 +156,7 @@ export class NitroliteService {
                 token: alloc.token,
                 amount: alloc.amount,
             })),
-            sigs: contractState.sigs.map((sig: any) => ({
-                v: sig.v,
-                r: sig.r,
-                s: sig.s,
-            })),
+            sigs: contractState.sigs,
         };
     }
 

--- a/sdk/src/client/services/NitroliteService.ts
+++ b/sdk/src/client/services/NitroliteService.ts
@@ -1,4 +1,4 @@
-import { Account, Address, PublicClient, WalletClient, Hash, zeroAddress } from 'viem';
+import { Account, Address, PublicClient, WalletClient, Hash, zeroAddress, Hex } from 'viem';
 import { custodyAbi } from '../../abis/generated';
 import { ContractAddresses } from '../../abis';
 import { Errors } from '../../errors';
@@ -127,27 +127,7 @@ export class NitroliteService {
                 token: Address;
                 amount: bigint;
             }[],
-            sigs: (state.sigs || []).map((sig) => ({
-                v: sig.v,
-                r: sig.r,
-                s: sig.s,
-            })) as readonly {
-                v: number;
-                r: `0x${string}`;
-                s: `0x${string}`;
-            }[],
-        } as const;
-    }
-
-    /**
-     * Converts Signature type to format expected by generated ABI
-     * REQUIRED: Ensures proper readonly typing for viem compatibility
-     */
-    private convertSignatureForABI(signature: Signature) {
-        return {
-            v: signature.v,
-            r: signature.r,
-            s: signature.s,
+            sigs: state.sigs || [] as readonly Hex[],
         } as const;
     }
 
@@ -371,13 +351,11 @@ export class NitroliteService {
         const operationName = 'prepareJoinChannel';
 
         try {
-            const abiSignature = this.convertSignatureForABI(sig);
-
             const { request } = await this.publicClient.simulateContract({
                 address: this.custodyAddress,
                 abi: custodyAbi,
                 functionName: 'join',
-                args: [channelId, index, abiSignature],
+                args: [channelId, index, sig],
                 account: account,
             });
 
@@ -492,13 +470,12 @@ export class NitroliteService {
         try {
             const abiCandidate = this.convertStateForABI(candidate);
             const abiProofs = proofs.map((proof) => this.convertStateForABI(proof));
-            const challengerSigABI = this.convertSignatureForABI(challengerSig);
 
             const { request } = await this.publicClient.simulateContract({
                 address: this.custodyAddress,
                 abi: custodyAbi,
                 functionName: 'challenge',
-                args: [channelId, abiCandidate, abiProofs, challengerSigABI],
+                args: [channelId, abiCandidate, abiProofs, challengerSig],
                 account: account,
             });
 

--- a/sdk/src/client/state.ts
+++ b/sdk/src/client/state.ts
@@ -1,6 +1,6 @@
 import { Address, encodeAbiParameters, Hex, keccak256 } from 'viem';
 import * as Errors from '../errors';
-import { generateChannelNonce, getChannelId, getStateHash, removeQuotesFromRS, signState } from '../utils';
+import { generateChannelNonce, getChannelId, getStateHash, signState } from '../utils';
 import { PreparerDependencies } from './prepare';
 import {
     ChallengeChannelParams,
@@ -138,7 +138,6 @@ export async function _prepareAndSignResizeState(
     }
 
     const channelId = resizeState.channelId;
-    const serverSignature = removeQuotesFromRS(resizeState.serverSignature);
 
     const stateToSign: State = {
         data: resizeState.data,
@@ -155,7 +154,7 @@ export async function _prepareAndSignResizeState(
     // Create a new state with signatures in the requested style
     const resizeStateWithSigs: State = {
         ...stateToSign,
-        sigs: [accountSignature, serverSignature],
+        sigs: [accountSignature, resizeState.serverSignature],
     };
 
     let proofs: State[] = [...proofStates];
@@ -181,7 +180,6 @@ export async function _prepareAndSignFinalState(
     }
 
     const channelId = finalState.channelId;
-    const serverSignature = removeQuotesFromRS(finalState.serverSignature);
 
     const stateToSign: State = {
         data: stateData,
@@ -198,7 +196,7 @@ export async function _prepareAndSignFinalState(
     // Create a new state with signatures in the requested style
     const finalStateWithSigs: State = {
         ...stateToSign,
-        sigs: [accountSignature, serverSignature],
+        sigs: [accountSignature, finalState.serverSignature],
     };
 
     return { finalStateWithSigs, channelId };

--- a/sdk/src/client/types.ts
+++ b/sdk/src/client/types.ts
@@ -12,13 +12,10 @@ export type ChannelId = Hex;
 export type StateHash = Hex;
 
 /**
- * Signature structure used for state channel operations
+ * Signature type used when signing states
+ * @dev Hex is used to support EIP-1271 and EIP-6492 signatures.
  */
-export interface Signature {
-    v: number;
-    r: Hex;
-    s: Hex;
-}
+export type Signature = Hex;
 
 /**
  * Allocation structure representing fund distribution

--- a/sdk/src/rpc/parse/channel.ts
+++ b/sdk/src/rpc/parse/channel.ts
@@ -17,15 +17,7 @@ const RPCAllocationSchema = z.object({
     amount: z.union([z.string(), z.number()]).transform((a) => BigInt(a)),
 });
 
-const ServerSignatureSchema = z.object({
-    v: z.union([z.string(), z.number()]).transform((a) => Number(a)),
-    // TODO: it should use hexScheme as provided, but for some reason R and S value
-    // are hex strings inside escaped double quotes: '"0x1234"' instead of '0x1234'
-    // r: hexSchema,
-    // s: hexSchema,
-    r: z.string(),
-    s: z.string(),
-});
+const ServerSignatureSchema = hexSchema;
 
 const ResizeChannelParamsSchema = z
     .array(
@@ -52,11 +44,7 @@ const ResizeChannelParamsSchema = z
                             amount: a.amount,
                         })),
                         stateHash: raw.state_hash as Hex,
-                        serverSignature: {
-                            v: +raw.server_signature.v,
-                            r: raw.server_signature.r as Hex,
-                            s: raw.server_signature.s as Hex,
-                        },
+                        serverSignature: raw.server_signature,
                     }) as ResizeChannelResponseParams,
             ),
     )
@@ -88,11 +76,7 @@ const CloseChannelParamsSchema = z
                             amount: a.amount,
                         })),
                         stateHash: raw.state_hash as Hex,
-                        serverSignature: {
-                            v: +raw.server_signature.v,
-                            r: raw.server_signature.r as Hex,
-                            s: raw.server_signature.s as Hex,
-                        },
+                        serverSignature: raw.server_signature,
                     }) as CloseChannelResponseParams,
             ),
     )

--- a/sdk/src/rpc/parse/channel.ts
+++ b/sdk/src/rpc/parse/channel.ts
@@ -17,8 +17,6 @@ const RPCAllocationSchema = z.object({
     amount: z.union([z.string(), z.number()]).transform((a) => BigInt(a)),
 });
 
-const ServerSignatureSchema = hexSchema;
-
 const ResizeChannelParamsSchema = z
     .array(
         z
@@ -29,7 +27,7 @@ const ResizeChannelParamsSchema = z
                 version: z.number(),
                 allocations: z.array(RPCAllocationSchema),
                 state_hash: hexSchema,
-                server_signature: ServerSignatureSchema,
+                server_signature: hexSchema,
             })
             .transform(
                 (raw) =>
@@ -61,7 +59,7 @@ const CloseChannelParamsSchema = z
                 version: z.number(),
                 allocations: z.array(RPCAllocationSchema),
                 state_hash: hexSchema,
-                server_signature: ServerSignatureSchema,
+                server_signature: hexSchema,
             })
             .transform(
                 (raw) =>

--- a/sdk/src/rpc/types/response.ts
+++ b/sdk/src/rpc/types/response.ts
@@ -217,12 +217,7 @@ export interface GetAppSessionsResponseParams {
 }
 export type GetAppSessionsRPCResponseParams = GetAppSessionsResponseParams; // for backward compatibility
 
-export interface ServerSignature {
-    /** The recovery value of the signature. */
-    v: number;
-    r: Hex;
-    s: Hex;
-}
+export type ServerSignature = Hex;
 
 export interface RPCAllocation {
     /** The destination address for the allocation. */

--- a/sdk/test/unit/client/index.test.ts
+++ b/sdk/test/unit/client/index.test.ts
@@ -11,12 +11,9 @@ describe('NitroliteClient', () => {
         waitForTransactionReceipt: jest.fn(() => Promise.resolve({ status: 'success' })),
     } as any;
     const mockAccount = { address: '0x1234567890123456789012345678901234567890' as Address };
+    const mockSignature = '0x' + '1234567890abcdef'.repeat(8) + '1b'; // 128 hex chars, v = 27
     const mockSignMessage = jest.fn(() =>
-        Promise.resolve(
-            '0x' +
-                '1234567890abcdef'.repeat(8) + // 128 hex chars
-                '1b', // v = 27
-        ),
+        Promise.resolve(mockSignature),
     );
     const mockWalletClient = {
         account: mockAccount,
@@ -260,7 +257,7 @@ describe('NitroliteClient', () => {
                 params.channelId,
                 params.candidateState,
                 params.proofStates,
-                expect.any(Object), // the signature
+                mockSignature, // the signature
             );
             expect(tx).toBe('0xCHL');
         });

--- a/sdk/test/unit/client/state.test.ts
+++ b/sdk/test/unit/client/state.test.ts
@@ -105,7 +105,7 @@ describe('_prepareAndSignInitialState', () => {
 
 describe('_prepareAndSignFinalState', () => {
     let deps: any;
-    const serverSigRaw = '"srvSig"';
+    const serverSig = 'srvSig';
     const channelIdArg = 'cid' as Hex;
     const allocations = [{ destination: '0xA' as Hex, token: '0xT' as Hex, amount: 5n }];
     const version = 7n;
@@ -134,7 +134,7 @@ describe('_prepareAndSignFinalState', () => {
                 channelId: channelIdArg,
                 allocations,
                 version,
-                serverSignature: serverSigRaw,
+                serverSignature: serverSig,
             },
         };
         const { finalStateWithSigs, channelId } = await _prepareAndSignFinalState(deps, params as any);
@@ -156,7 +156,6 @@ describe('_prepareAndSignFinalState', () => {
             sigs: [],
         });
         expect(utils.signState).toHaveBeenCalledWith('hsh', deps.stateWalletClient.signMessage);
-        expect(utils.removeQuotesFromRS).toHaveBeenCalledWith(serverSigRaw);
     });
 
     test('throws if no stateData', async () => {
@@ -166,7 +165,7 @@ describe('_prepareAndSignFinalState', () => {
                 channelId: channelIdArg,
                 allocations,
                 version,
-                serverSignature: serverSigRaw,
+                serverSignature: serverSig,
             },
         };
         await expect(_prepareAndSignFinalState(deps, params as any)).rejects.toThrow(Errors.MissingParameterError);


### PR DESCRIPTION
This is mainly to marshal signature as Hex, not as base64

Before merge:
- [ ] rebase on base after #284 is merged