### PR TITLE
YNU-158: add Go Reference badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![codecov](https://codecov.io/github/erc7824/nitrolite/graph/badge.svg?token=XASM4CIEFO)](https://codecov.io/github/erc7824/nitrolite)
+[![Go Reference](https://pkg.go.dev/badge/github.com/erc7824/nitrolite/clearnode.svg)](https://pkg.go.dev/github.com/erc7824/nitrolite/clearnode)
 
 # Nitrolite: State Channel Framework
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added a Go Reference badge to the README alongside the existing codecov badge, improving visibility and quick access to Go API documentation from the project homepage.
  - Enhances documentation discoverability and reinforces project credibility with standard badges.
  - No functional or runtime changes; this is a README/UI-only update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->