### PR TITLE
YNU-158: add badges to README for project visibility

### DIFF
--- a/clearnode/README.md
+++ b/clearnode/README.md
@@ -1,3 +1,7 @@
+[![codecov](https://codecov.io/github/erc7824/nitrolite/graph/badge.svg?token=XASM4CIEFO)](https://codecov.io/github/erc7824/nitrolite)
+[![Go Reference](https://pkg.go.dev/badge/github.com/erc7824/nitrolite/clearnode.svg)](https://pkg.go.dev/github.com/erc7824/nitrolite/clearnode)
+[![Go Report Card](https://goreportcard.com/badge/github.com/erc7824/nitrolite/clearnode)](https://goreportcard.com/report/github.com/erc7824/nitrolite/clearnode)
+
 # Clearnode
 
 Clearnode is an implementation of a message broker node providing ledger services for the Clearnet protocol, which enables efficient off-chain payment channels with on-chain settlement capabilities for fast payment channel applications. This system allows participants to conduct transactions without requiring on-chain operations for every exchange, significantly reducing transaction costs and improving efficiency.

--- a/clearnode/README.md
+++ b/clearnode/README.md
@@ -1,4 +1,4 @@
-[![codecov](https://codecov.io/github/erc7824/nitrolite/graph/badge.svg?token=XASM4CIEFO)](https://codecov.io/github/erc7824/nitrolite)
+[![codecov](https://codecov.io/github/erc7824/nitrolite/graph/badge.svg)](https://codecov.io/github/erc7824/nitrolite)
 [![Go Reference](https://pkg.go.dev/badge/github.com/erc7824/nitrolite/clearnode.svg)](https://pkg.go.dev/github.com/erc7824/nitrolite/clearnode)
 [![Go Report Card](https://goreportcard.com/badge/github.com/erc7824/nitrolite/clearnode)](https://goreportcard.com/report/github.com/erc7824/nitrolite/clearnode)
 


### PR DESCRIPTION
Added badges for code coverage, Go reference, and Go report card to README.

Follow-up #363

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added three status badges to the README for quick at-a-glance project information (e.g., build/status, version, license).
  * Badges are placed at the top of the README for improved visibility of project health and metadata.
  * No functional or behavioral changes; purely informational update to the repository homepage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->