### PR TITLE
YNU-158: ignore clearnode tags on auto tag

### DIFF
--- a/.github/workflows/main-push.yml
+++ b/.github/workflows/main-push.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Get the new tag without 'v' prefix
         id: tagger
         run: |
-          NEW_TAG=$(git describe --tags --abbrev=0)
+          NEW_TAG=$(git describe --tags --match "v[0-9]*.[0-9]*.[0-9]*-rc.[0-9]*" --abbrev=0)
           NEW_TAG_WITHOUT_V=${NEW_TAG#v}
           echo "new_tag=$NEW_TAG_WITHOUT_V" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release tagging to consider only RC-versioned tags (vX.Y.Z-rc.N) when computing new version identifiers.
  * Affects pre-release build selection and labeling; stable releases and app functionality remain unchanged.
  * Users of RC builds may notice more consistent RC version identifiers across artifacts and announcements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->