### PR TITLE
test(integration): generate private key, add response predicates

### DIFF
--- a/integration/common/ws.ts
+++ b/integration/common/ws.ts
@@ -239,6 +239,12 @@ export const getGetUserTagPredicate = () => {
     };
 };
 
+export const getRevokeSessionKeyPredicate = () => {
+    return (data: string, reqId?: number): boolean => {
+        return genericPredicate(data, (r) => r.method === RPCMethod.RevokeSessionKey, reqId);
+    };
+};
+
 export const getTransferPredicate = () => {
     return (data: string, reqId?: number): boolean => {
         return genericPredicate(data, (r) => r.method === RPCMethod.Transfer, reqId);

--- a/integration/tests/session_key.test.ts
+++ b/integration/tests/session_key.test.ts
@@ -25,7 +25,6 @@ import {
 import { submitAppStateUpdate_v04 } from '@/testAppSessionHelpers';
 import { setupTestIdentitiesAndConnections } from '@/testSetup';
 import { generatePrivateKey } from 'viem/accounts';
-import { get } from 'http';
 
 describe('Session Keys', () => {
     const ASSET_SYMBOL = CONFIG.TOKEN_SYMBOL;
@@ -644,15 +643,11 @@ describe('Session Keys', () => {
 
             const revokeResponse = await aliceAppWS.sendAndWaitForResponse(
                 revokeMsg,
-                (data: string) => {
-                    const parsed = parseAnyRPCResponse(data);
-                    return parsed.method === RPCMethod.RevokeSessionKey;
-                },
+                getRevokeSessionKeyPredicate(),
                 5000
             );
 
             const parsedRevoke = parseAnyRPCResponse(revokeResponse);
-            expect(parsedRevoke.method).toBe(RPCMethod.RevokeSessionKey);
             expect((parsedRevoke.params as any).sessionKey).toBe(aliceAppIdentity.sessionKeyAddress);
 
             // Verify session key can no longer be used
@@ -684,7 +679,6 @@ describe('Session Keys', () => {
             );
 
             const parsedRevoke = parseAnyRPCResponse(revokeResponse);
-            expect(parsedRevoke.method).toBe(RPCMethod.RevokeSessionKey);
             expect((parsedRevoke.params as any).sessionKey).toBe(aliceAppIdentity.sessionKeyAddress);
         });
 
@@ -702,7 +696,6 @@ describe('Session Keys', () => {
             );
 
             const parsedRevoke = parseAnyRPCResponse(revokeResponse);
-            expect(parsedRevoke.method).toBe(RPCMethod.RevokeSessionKey);
             expect((parsedRevoke.params as any).sessionKey).toBe(aliceAppIdentity.sessionKeyAddress);
         });
 
@@ -814,7 +807,7 @@ describe('Session Keys', () => {
                     getTransferPredicate(),
                     5000
                 )
-            ).rejects.toThrow();
+            ).rejects.toThrow(/invalid signature/i);
         });
 
         it('should reject app session creation after session key is revoked', async () => {
@@ -831,7 +824,6 @@ describe('Session Keys', () => {
             );
 
             const parsedRevoke = parseAnyRPCResponse(revokeResponse);
-            expect(parsedRevoke.method).toBe(RPCMethod.RevokeSessionKey);
             expect((parsedRevoke.params as any).sessionKey).toBe(aliceAppIdentity.sessionKeyAddress);
 
             // Try to create app session with revoked session key - should fail
@@ -845,7 +837,7 @@ describe('Session Keys', () => {
                     initialDepositAmount.toString(),
                     SESSION_DATA
                 )
-            ).rejects.toThrow();
+            ).rejects.toThrow(/missing signature for participant/i);
         });
 
         it('should reject app state submission after session key is revoked', async () => {
@@ -875,7 +867,6 @@ describe('Session Keys', () => {
             );
 
             const parsedRevoke = parseAnyRPCResponse(revokeResponse);
-            expect(parsedRevoke.method).toBe(RPCMethod.RevokeSessionKey);
             expect((parsedRevoke.params as any).sessionKey).toBe(aliceAppIdentity.sessionKeyAddress);
 
             // Try to submit app state update with revoked session key - should fail
@@ -903,7 +894,7 @@ describe('Session Keys', () => {
                     allocations,
                     SESSION_DATA
                 )
-            ).rejects.toThrow();
+            ).rejects.toThrow(/signature from unknown participant wallet/i);
         });
     });
 });

--- a/integration/tests/session_key.test.ts
+++ b/integration/tests/session_key.test.ts
@@ -2,7 +2,7 @@ import { BlockchainUtils } from '@/blockchainUtils';
 import { DatabaseUtils } from '@/databaseUtils';
 import { Identity } from '@/identity';
 import { TestNitroliteClient } from '@/nitroliteClient';
-import { TestWebSocket } from '@/ws';
+import { getRevokeSessionKeyPredicate, getTransferPredicate, TestWebSocket } from '@/ws';
 import { CONFIG } from '@/setup';
 import {
     RPCAppStateIntent,
@@ -24,13 +24,8 @@ import {
 } from '@/testHelpers';
 import { submitAppStateUpdate_v04 } from '@/testAppSessionHelpers';
 import { setupTestIdentitiesAndConnections } from '@/testSetup';
-
-// Helper to generate random private key for testing
-function generateRandomPrivateKey(): Hex {
-    const randomBytes = new Uint8Array(32);
-    crypto.getRandomValues(randomBytes);
-    return `0x${Array.from(randomBytes).map(b => b.toString(16).padStart(2, '0')).join('')}` as Hex;
-}
+import { generatePrivateKey } from 'viem/accounts';
+import { get } from 'http';
 
 describe('Session Keys', () => {
     const ASSET_SYMBOL = CONFIG.TOKEN_SYMBOL;
@@ -627,7 +622,7 @@ describe('Session Keys', () => {
             await authenticateAppWithAllowances(aliceAppWS, aliceAppIdentity, ASSET_SYMBOL, spendingCapAmount.toString());
 
             // Create a clearnode session key for testing privileged revocation
-            const clearnodeSessionPK = generateRandomPrivateKey();
+            const clearnodeSessionPK = generatePrivateKey();
             aliceClearnodeIdentity = new Identity(CONFIG.IDENTITIES[0].WALLET_PK, clearnodeSessionPK);
             aliceClearnodeWS = new TestWebSocket(CONFIG.CLEARNODE_URL, CONFIG.DEBUG_MODE);
             await aliceClearnodeWS.connect();
@@ -669,22 +664,10 @@ describe('Session Keys', () => {
             await expect(
                 aliceAppWS.sendAndWaitForResponse(
                     transferMsg,
-                    (data: string) => {
-                        const parsed = parseAnyRPCResponse(data);
-                        const requestId = JSON.parse(transferMsg).req[0];
-
-                        if (parsed.requestId === requestId) {
-                            if (parsed.method === RPCMethod.Error) {
-                                const errorMsg = (parsed.params as any)?.error || 'Unknown error';
-                                throw new Error(`RPC Error: ${errorMsg}`);
-                            }
-                            return parsed.method === RPCMethod.Transfer;
-                        }
-                        return false;
-                    },
+                    getTransferPredicate(),
                     5000
                 )
-            ).rejects.toThrow();
+            ).rejects.toThrow(/invalid signature/i);
         });
 
         it('should allow wallet to revoke its session key', async () => {
@@ -696,10 +679,7 @@ describe('Session Keys', () => {
 
             const revokeResponse = await aliceAppWS.sendAndWaitForResponse(
                 revokeMsg,
-                (data: string) => {
-                    const parsed = parseAnyRPCResponse(data);
-                    return parsed.method === RPCMethod.RevokeSessionKey;
-                },
+                getRevokeSessionKeyPredicate(),
                 5000
             );
 
@@ -717,10 +697,7 @@ describe('Session Keys', () => {
 
             const revokeResponse = await aliceClearnodeWS.sendAndWaitForResponse(
                 revokeMsg,
-                (data: string) => {
-                    const parsed = parseAnyRPCResponse(data);
-                    return parsed.method === RPCMethod.RevokeSessionKey;
-                },
+                getRevokeSessionKeyPredicate(),
                 5000
             );
 
@@ -731,7 +708,7 @@ describe('Session Keys', () => {
 
         it('should reject non-clearnode session key revoking another session key', async () => {
             // Create a second non-clearnode session key
-            const app2SessionPK = generateRandomPrivateKey();
+            const app2SessionPK = generatePrivateKey();
             const aliceApp2Identity = new Identity(CONFIG.IDENTITIES[0].WALLET_PK, app2SessionPK);
             const aliceApp2WS = new TestWebSocket(CONFIG.CLEARNODE_URL, CONFIG.DEBUG_MODE);
             await aliceApp2WS.connect();
@@ -746,19 +723,7 @@ describe('Session Keys', () => {
             await expect(
                 aliceApp2WS.sendAndWaitForResponse(
                     revokeMsg,
-                    (data: string) => {
-                        const parsed = parseAnyRPCResponse(data);
-                        const requestId = JSON.parse(revokeMsg).req[0];
-
-                        if (parsed.requestId === requestId) {
-                            if (parsed.method === RPCMethod.Error) {
-                                const errorMsg = (parsed.params as any)?.error || 'Unknown error';
-                                throw new Error(`RPC Error: ${errorMsg}`);
-                            }
-                            return parsed.method === RPCMethod.RevokeSessionKey;
-                        }
-                        return false;
-                    },
+                    getRevokeSessionKeyPredicate(),
                     5000
                 )
             ).rejects.toThrow(/insufficient permissions for the active session key/i);
@@ -768,7 +733,7 @@ describe('Session Keys', () => {
 
         it('should reject revoking another user\'s session key', async () => {
             // Bob tries to revoke Alice's session key
-            const bobAppSessionPK = generateRandomPrivateKey();
+            const bobAppSessionPK = generatePrivateKey();
             const bobAppIdentityLocal = new Identity(CONFIG.IDENTITIES[1].WALLET_PK, bobAppSessionPK);
             const bobAppWS = new TestWebSocket(CONFIG.CLEARNODE_URL, CONFIG.DEBUG_MODE);
             await bobAppWS.connect();
@@ -782,19 +747,7 @@ describe('Session Keys', () => {
             await expect(
                 bobAppWS.sendAndWaitForResponse(
                     revokeMsg,
-                    (data: string) => {
-                        const parsed = parseAnyRPCResponse(data);
-                        const requestId = JSON.parse(revokeMsg).req[0];
-
-                        if (parsed.requestId === requestId) {
-                            if (parsed.method === RPCMethod.Error) {
-                                const errorMsg = (parsed.params as any)?.error || 'Unknown error';
-                                throw new Error(`RPC Error: ${errorMsg}`);
-                            }
-                            return parsed.method === RPCMethod.RevokeSessionKey;
-                        }
-                        return false;
-                    },
+                    getRevokeSessionKeyPredicate(),
                     5000
                 )
             ).rejects.toThrow(/not an active session key of this user/i);
@@ -804,8 +757,8 @@ describe('Session Keys', () => {
 
         it('should reject revoking non-existent session key', async () => {
             // Generate a random address that's not a session key
-            const randomSessionPK = generateRandomPrivateKey();
-            const randomWalletPK = generateRandomPrivateKey();
+            const randomSessionPK = generatePrivateKey();
+            const randomWalletPK = generatePrivateKey();
             const randomIdentity = new Identity(randomWalletPK, randomSessionPK);
             const randomAddress = randomIdentity.sessionKeyAddress;
 
@@ -817,19 +770,7 @@ describe('Session Keys', () => {
             await expect(
                 aliceAppWS.sendAndWaitForResponse(
                     revokeMsg,
-                    (data: string) => {
-                        const parsed = parseAnyRPCResponse(data);
-                        const requestId = JSON.parse(revokeMsg).req[0];
-
-                        if (parsed.requestId === requestId) {
-                            if (parsed.method === RPCMethod.Error) {
-                                const errorMsg = (parsed.params as any)?.error || 'Unknown error';
-                                throw new Error(`RPC Error: ${errorMsg}`);
-                            }
-                            return parsed.method === RPCMethod.RevokeSessionKey;
-                        }
-                        return false;
-                    },
+                    getRevokeSessionKeyPredicate(),
                     5000
                 )
             ).rejects.toThrow(/not an active session key of this user/i);
@@ -842,15 +783,11 @@ describe('Session Keys', () => {
                 allocations: [{ asset: ASSET_SYMBOL, amount: '100' }],
             });
 
-            const transferResponse = await aliceAppWS.sendAndWaitForResponse(
+            await aliceAppWS.sendAndWaitForResponse(
                 transferMsg,
-                (data: string) => {
-                    const parsed = parseAnyRPCResponse(data);
-                    return parsed.method === RPCMethod.Transfer;
-                },
+                getTransferPredicate(),
                 5000
             );
-            expect(parseAnyRPCResponse(transferResponse).method).toBe(RPCMethod.Transfer);
 
             // Revoke the session key using wallet signature
             const revokeMsg = await createRevokeSessionKeyMessage(
@@ -860,16 +797,10 @@ describe('Session Keys', () => {
 
             const revokeResponse = await aliceAppWS.sendAndWaitForResponse(
                 revokeMsg,
-                (data: string) => {
-                    const parsed = parseAnyRPCResponse(data);
-                    return parsed.method === RPCMethod.RevokeSessionKey;
-                },
+                getRevokeSessionKeyPredicate(),
                 5000
             );
-
-            const parsedRevoke = parseAnyRPCResponse(revokeResponse);
-            expect(parsedRevoke.method).toBe(RPCMethod.RevokeSessionKey);
-            expect((parsedRevoke.params as any).sessionKey).toBe(aliceAppIdentity.sessionKeyAddress);
+            expect((parseAnyRPCResponse(revokeResponse).params as any).sessionKey).toBe(aliceAppIdentity.sessionKeyAddress);
 
             // Try transfer with revoked session key - should fail
             const transferMsg2 = await createTransferMessage(aliceAppIdentity.messageSKSigner, {
@@ -880,19 +811,7 @@ describe('Session Keys', () => {
             await expect(
                 aliceAppWS.sendAndWaitForResponse(
                     transferMsg2,
-                    (data: string) => {
-                        const parsed = parseAnyRPCResponse(data);
-                        const requestId = JSON.parse(transferMsg2).req[0];
-
-                        if (parsed.requestId === requestId) {
-                            if (parsed.method === RPCMethod.Error) {
-                                const errorMsg = (parsed.params as any)?.error || 'Unknown error';
-                                throw new Error(`RPC Error: ${errorMsg}`);
-                            }
-                            return parsed.method === RPCMethod.Transfer;
-                        }
-                        return false;
-                    },
+                    getTransferPredicate(),
                     5000
                 )
             ).rejects.toThrow();
@@ -907,10 +826,7 @@ describe('Session Keys', () => {
 
             const revokeResponse = await aliceAppWS.sendAndWaitForResponse(
                 revokeMsg,
-                (data: string) => {
-                    const parsed = parseAnyRPCResponse(data);
-                    return parsed.method === RPCMethod.RevokeSessionKey;
-                },
+                getRevokeSessionKeyPredicate(),
                 5000
             );
 
@@ -954,10 +870,7 @@ describe('Session Keys', () => {
 
             const revokeResponse = await aliceAppWS.sendAndWaitForResponse(
                 revokeMsg,
-                (data: string) => {
-                    const parsed = parseAnyRPCResponse(data);
-                    return parsed.method === RPCMethod.RevokeSessionKey;
-                },
+                getRevokeSessionKeyPredicate(),
                 5000
             );
 


### PR DESCRIPTION
This is a continuation of #419 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved session key validation and revocation tests using centralized predicate-based RPC checks and updated key generation, leading to more reliable coverage of transfer and revoke scenarios.

* **Chores**
  * Streamlined test utilities and imports to simplify session key handling and assertions in integration tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->