### PR TITLE
M-M09: reject asset decimals exceeding its token's decimals

### DIFF
--- a/clearnode/store/memory/asset_config.go
+++ b/clearnode/store/memory/asset_config.go
@@ -129,6 +129,11 @@ func verifyAssetsConfig(cfg *AssetsConfig) error {
 			} else if !contractAddressRegex.MatchString(token.Address) {
 				return fmt.Errorf("invalid %s token address '%s' for blockchain with id %d", token.Name, token.Address, token.BlockchainID)
 			}
+
+			if asset.Decimals > token.Decimals {
+				return fmt.Errorf("asset %s decimals (%d) must not exceed token %s decimals (%d) on blockchain %d",
+					asset.Symbol, asset.Decimals, token.Symbol, token.Decimals, token.BlockchainID)
+			}
 		}
 	}
 

--- a/clearnode/store/memory/asset_config_test.go
+++ b/clearnode/store/memory/asset_config_test.go
@@ -71,6 +71,57 @@ func TestAssetsConfig_verifyVariables(t *testing.T) {
 		assert.Equal(t, "invalid USD Coin token address '0xinvalid' for blockchain with id 1", err.Error())
 	})
 
+	// Test asset decimals exceeding token decimals
+	t.Run("asset decimals exceed token decimals", func(t *testing.T) {
+		cfg := AssetsConfig{
+			Assets: []AssetConfig{
+				{
+					Name:                  "USD Coin",
+					Symbol:                "USDC",
+					Decimals:              8,
+					SuggestedBlockchainID: 1,
+					Tokens: []TokenConfig{
+						{
+							Name:         "USD Coin",
+							Symbol:       "USDC",
+							BlockchainID: 1,
+							Address:      "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+							Decimals:     6,
+						},
+					},
+				},
+			},
+		}
+		err := verifyAssetsConfig(&cfg)
+		require.Error(t, err)
+		assert.Equal(t, "asset USDC decimals (8) must not exceed token USDC decimals (6) on blockchain 1", err.Error())
+	})
+
+	// Test asset decimals equal to token decimals (should pass)
+	t.Run("asset decimals equal to token decimals", func(t *testing.T) {
+		cfg := AssetsConfig{
+			Assets: []AssetConfig{
+				{
+					Name:                  "USD Coin",
+					Symbol:                "USDC",
+					Decimals:              6,
+					SuggestedBlockchainID: 1,
+					Tokens: []TokenConfig{
+						{
+							Name:         "USD Coin",
+							Symbol:       "USDC",
+							BlockchainID: 1,
+							Address:      "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+							Decimals:     6,
+						},
+					},
+				},
+			},
+		}
+		err := verifyAssetsConfig(&cfg)
+		require.NoError(t, err)
+	})
+
 	// Test custom symbol for token (inherits from asset when empty)
 	t.Run("custom symbol for token", func(t *testing.T) {
 		cfg := AssetsConfig{

--- a/sdk/go/asset_cache.go
+++ b/sdk/go/asset_cache.go
@@ -29,6 +29,12 @@ func (s *clientAssetStore) populateCache() error {
 		return fmt.Errorf("failed to fetch assets: %w", err)
 	}
 	for _, a := range assets {
+		for _, token := range a.Tokens {
+			if a.Decimals > token.Decimals {
+				return fmt.Errorf("asset %s decimals (%d) must not exceed token %s decimals (%d) on blockchain %d",
+					a.Symbol, a.Decimals, token.Symbol, token.Decimals, token.BlockchainID)
+			}
+		}
 		s.cache[strings.ToLower(a.Symbol)] = a
 	}
 	return nil

--- a/sdk/go/asset_cache_test.go
+++ b/sdk/go/asset_cache_test.go
@@ -135,6 +135,43 @@ func TestClientAssetStore_Caching(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestClientAssetStore_DecimalsValidation(t *testing.T) {
+	t.Parallel()
+	mockDialer := NewMockDialer()
+	mockDialer.Dial(context.Background(), "", nil)
+
+	mockResp := rpc.NodeV1GetAssetsResponse{
+		Assets: []rpc.AssetV1{
+			{
+				Name:                  "USDC",
+				Symbol:                "USDC",
+				Decimals:              18,
+				SuggestedBlockchainID: "137",
+				Tokens: []rpc.TokenV1{
+					{
+						BlockchainID: "137",
+						Address:      "0xToken137",
+						Name:         "USDC (Polygon)",
+						Symbol:       "USDC",
+						Decimals:     6,
+					},
+				},
+			},
+		},
+	}
+	mockDialer.RegisterResponse(rpc.NodeV1GetAssetsMethod.String(), mockResp)
+
+	rpcClient := rpc.NewClient(mockDialer)
+	client := &Client{
+		rpcClient: rpcClient,
+	}
+	store := newClientAssetStore(client)
+
+	_, err := store.GetAssetDecimals("USDC")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "asset USDC decimals (18) must not exceed token USDC decimals (6)")
+}
+
 func TestDefaultWebsocketDialerConfig(t *testing.T) {
 	t.Parallel()
 	assert.Equal(t, 5*time.Second, rpc.DefaultWebsocketDialerConfig.HandshakeTimeout)


### PR DESCRIPTION
## Description

`GetAssetDecimals` and `GetTokenDecimals` read from two independent maps in the memory store, populated from separate config fields with no requirement that they are the same. The asset-level field is a single value per asset symbol, while `GetTokenDecimals` is keyed on `blockchainID` and `tokenAddress`, meaning the same asset can have different precision on different chains.
This is also problematic in escrow flows, where the same transition amount may need to be represented on both the home and escrow ledgers. If those two token representations use different decimals, the request can pass transition validation under the asset-level precision and fail later when one of the ledgers is converted using the lower token precision.
Consequently, valid operations can be rejected or accepted only to fail later in the signing flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to ensure asset decimal values do not exceed their associated token decimal values. Invalid configurations are now rejected with detailed error messages during asset verification and caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->