### PR TITLE
M-L01: return correct errors during state advancement validation

### DIFF
--- a/pkg/core/state_advancer.go
+++ b/pkg/core/state_advancer.go
@@ -161,7 +161,7 @@ func (v *StateAdvancerV1) ValidateAdvancement(currentState, proposedState State)
 		return fmt.Errorf("new transition does not match expected: %w", err)
 	}
 
-	if err := proposedState.HomeLedger.Equal(expectedState.HomeLedger); err != nil {
+	if err := expectedState.HomeLedger.Equal(proposedState.HomeLedger); err != nil {
 		return fmt.Errorf("home ledger mismatch: %w", err)
 	}
 	if err := proposedState.HomeLedger.Validate(); err != nil {
@@ -183,7 +183,7 @@ func (v *StateAdvancerV1) ValidateAdvancement(currentState, proposedState State)
 	}
 
 	if expectedState.EscrowLedger != nil && proposedState.EscrowLedger != nil {
-		if err := proposedState.EscrowLedger.Equal(*expectedState.EscrowLedger); err != nil {
+		if err := expectedState.EscrowLedger.Equal(*proposedState.EscrowLedger); err != nil {
 			return fmt.Errorf("escrow ledger mismatch: %w", err)
 		}
 		if err := proposedState.EscrowLedger.Validate(); err != nil {


### PR DESCRIPTION
## Description

The `Ledger.Equal()` method in `pkg/core/types.go` formats error messages with `l1` labeled as "expected" and l2 labeled as "proposed":

```go
func (l1 Ledger) Equal(l2 Ledger) error {
    if l1.TokenAddress != l2.TokenAddress {
        return fmt.Errorf("token address mismatch: expected=%s, proposed=%s", l1.TokenAddress, l2.TokenAddress)
    }
    // ... same pattern for other fields
}
```

However, both call sites in `pkg/core/state_advancer.go` pass the proposed state as the receiver and the expected state as the argument:

```go
proposedState.HomeLedger.Equal(expectedState.HomeLedger)   
```

```go
proposedState.EscrowLedger.Equal(*expectedState.EscrowLedger)

```

This causes error messages to show the expected and proposed values swapped, making debugging harder.