### PR TITLE
M-L02: return correct node address for escrow getters

### DIFF
--- a/pkg/blockchain/evm/blockchain_client.go
+++ b/pkg/blockchain/evm/blockchain_client.go
@@ -237,7 +237,7 @@ func (c *BlockchainClient) GetEscrowDepositData(escrowChannelID string) (core.Es
 
 	return core.EscrowDepositDataResponse{
 		EscrowChannelID: escrowChannelID,
-		Node:            c.channelHubContractAddress.Hex(),
+		Node:            c.nodeAddress.Hex(),
 		LastState:       *lastState,
 		UnlockExpiry:    data.UnlockAt,
 		ChallengeExpiry: data.ChallengeExpiry,
@@ -262,7 +262,7 @@ func (c *BlockchainClient) GetEscrowWithdrawalData(escrowChannelID string) (core
 
 	return core.EscrowWithdrawalDataResponse{
 		EscrowChannelID: escrowChannelID,
-		Node:            c.channelHubContractAddress.Hex(),
+		Node:            c.nodeAddress.Hex(),
 		LastState:       *lastState,
 	}, nil
 }


### PR DESCRIPTION
## Description

The Go blockchain client functions `GetEscrowDepositData` and `GetEscrowWithdrawalData` return the wrong value in the `Node` field. Instead of returning the escrow’s actual node address, both functions populate `Node` with the ChannelHub contract address.

```go
Node:            c.channelHubContractAddress.Hex()
```

As a result, external integrators using these escrow getters may rely on the wrong node identity and be misled.