### PR TITLE
M-L03: limit number of related ids per session key state

### DIFF
--- a/clearnode/api/app_session_v1/submit_session_key_state.go
+++ b/clearnode/api/app_session_v1/submit_session_key_state.go
@@ -24,15 +24,6 @@ func (h *Handler) SubmitSessionKeyState(c *rpc.Context) {
 		return
 	}
 
-	if len(reqPayload.State.ApplicationIDs) > h.maxSessionKeyIDs {
-		c.Fail(rpc.Errorf("application_ids array exceeds maximum length of %d", h.maxSessionKeyIDs), "")
-		return
-	}
-	if len(reqPayload.State.AppSessionIDs) > h.maxSessionKeyIDs {
-		c.Fail(rpc.Errorf("app_session_ids array exceeds maximum length of %d", h.maxSessionKeyIDs), "")
-		return
-	}
-
 	logger.Debug("processing session key state submission",
 		"userAddress", reqPayload.State.UserAddress,
 		"sessionKey", reqPayload.State.SessionKey,
@@ -60,6 +51,14 @@ func (h *Handler) SubmitSessionKeyState(c *rpc.Context) {
 	}
 	if coreState.ExpiresAt.Before(time.Now()) {
 		c.Fail(rpc.Errorf("invalid_session_key_state: expires_at must be in the future"), "")
+		return
+	}
+	if len(coreState.AppSessionIDs) > h.maxSessionKeyIDs {
+		c.Fail(rpc.Errorf("invalid_session_key_state: app_session_ids array exceeds maximum length of %d", h.maxSessionKeyIDs), "")
+		return
+	}
+	if len(coreState.ApplicationIDs) > h.maxSessionKeyIDs {
+		c.Fail(rpc.Errorf("invalid_session_key_state: application_ids array exceeds maximum length of %d", h.maxSessionKeyIDs), "")
 		return
 	}
 	if coreState.UserSig == "" {

--- a/clearnode/api/app_session_v1/submit_session_key_state_test.go
+++ b/clearnode/api/app_session_v1/submit_session_key_state_test.go
@@ -1,0 +1,436 @@
+package app_session_v1
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/layer-3/nitrolite/clearnode/metrics"
+	"github.com/layer-3/nitrolite/pkg/app"
+	"github.com/layer-3/nitrolite/pkg/rpc"
+	"github.com/layer-3/nitrolite/pkg/sign"
+)
+
+// buildSignedSessionKeyStateReq creates a properly signed SubmitSessionKeyState request.
+func buildSignedSessionKeyStateReq(t *testing.T, userAddress, sessionKey string, version uint64, applicationIDs, appSessionIDs []string, expiresAt time.Time, signer sign.Signer) rpc.AppSessionsV1SubmitSessionKeyStateRequest {
+	t.Helper()
+
+	if applicationIDs == nil {
+		applicationIDs = []string{}
+	}
+	if appSessionIDs == nil {
+		appSessionIDs = []string{}
+	}
+
+	coreState := app.AppSessionKeyStateV1{
+		UserAddress:    strings.ToLower(userAddress),
+		SessionKey:     strings.ToLower(sessionKey),
+		Version:        version,
+		ApplicationIDs: applicationIDs,
+		AppSessionIDs:  appSessionIDs,
+		ExpiresAt:      expiresAt,
+	}
+
+	packed, err := app.PackAppSessionKeyStateV1(coreState)
+	require.NoError(t, err)
+
+	sig, err := signer.Sign(packed)
+	require.NoError(t, err)
+
+	return rpc.AppSessionsV1SubmitSessionKeyStateRequest{
+		State: rpc.AppSessionKeyStateV1{
+			UserAddress:    userAddress,
+			SessionKey:     sessionKey,
+			Version:        strconv.FormatUint(version, 10),
+			ApplicationIDs: applicationIDs,
+			AppSessionIDs:  appSessionIDs,
+			ExpiresAt:      strconv.FormatInt(expiresAt.Unix(), 10),
+			UserSig:        hexutil.Encode(sig),
+		},
+	}
+}
+
+func TestSubmitSessionKeyState_Success(t *testing.T) {
+	mockStore := new(MockStore)
+	userSigner := NewMockSigner()
+	userAddress := strings.ToLower(userSigner.PublicKey().Address().String())
+	sessionKeySigner := NewMockSigner()
+	sessionKeyAddress := strings.ToLower(sessionKeySigner.PublicKey().Address().String())
+
+	handler := &Handler{
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockStore)
+		},
+		metrics:          metrics.NewNoopRuntimeMetricExporter(),
+		maxSessionKeyIDs: 10,
+		maxParticipants:  32,
+		maxSessionData:   1024,
+		maxSignedUpdates: 16,
+	}
+
+	expiresAt := time.Now().Add(24 * time.Hour).Truncate(time.Second)
+	appIDs := []string{"0x1111111111111111111111111111111111111111111111111111111111111111"}
+	sessionIDs := []string{"0x2222222222222222222222222222222222222222222222222222222222222222"}
+
+	reqPayload := buildSignedSessionKeyStateReq(t, userAddress, sessionKeyAddress, 1, appIDs, sessionIDs, expiresAt, userSigner)
+
+	mockStore.On("GetLastAppSessionKeyVersion", userAddress, sessionKeyAddress).Return(uint64(0), nil)
+	mockStore.On("StoreAppSessionKeyState", mock.AnythingOfType("app.AppSessionKeyStateV1")).Return(nil)
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, rpc.AppSessionsV1SubmitSessionKeyStateMethod.String(), payload),
+	}
+
+	handler.SubmitSessionKeyState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	assert.Nil(t, ctx.Response.Error())
+	assert.Equal(t, rpc.MsgTypeResp, ctx.Response.Type)
+	mockStore.AssertExpectations(t)
+}
+
+func TestSubmitSessionKeyState_ApplicationIDsExceedsMax(t *testing.T) {
+	mockStore := new(MockStore)
+	handler := &Handler{
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockStore)
+		},
+		metrics:          metrics.NewNoopRuntimeMetricExporter(),
+		maxSessionKeyIDs: 2,
+	}
+
+	userSigner := NewMockSigner()
+	userAddress := strings.ToLower(userSigner.PublicKey().Address().String())
+	sessionKeyAddress := "0x3333333333333333333333333333333333333333"
+
+	// 3 application_ids exceeds max of 2
+	appIDs := []string{
+		"0x1111111111111111111111111111111111111111111111111111111111111111",
+		"0x2222222222222222222222222222222222222222222222222222222222222222",
+		"0x3333333333333333333333333333333333333333333333333333333333333333",
+	}
+
+	reqPayload := rpc.AppSessionsV1SubmitSessionKeyStateRequest{
+		State: rpc.AppSessionKeyStateV1{
+			UserAddress:    userAddress,
+			SessionKey:     sessionKeyAddress,
+			Version:        "1",
+			ApplicationIDs: appIDs,
+			AppSessionIDs:  []string{},
+			ExpiresAt:      strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10),
+			UserSig:        "0xdeadbeef",
+		},
+	}
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, rpc.AppSessionsV1SubmitSessionKeyStateMethod.String(), payload),
+	}
+
+	handler.SubmitSessionKeyState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.NotNil(t, respErr)
+	assert.Contains(t, respErr.Error(), "application_ids array exceeds maximum length of 2")
+}
+
+func TestSubmitSessionKeyState_AppSessionIDsExceedsMax(t *testing.T) {
+	mockStore := new(MockStore)
+	handler := &Handler{
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockStore)
+		},
+		metrics:          metrics.NewNoopRuntimeMetricExporter(),
+		maxSessionKeyIDs: 2,
+	}
+
+	userSigner := NewMockSigner()
+	userAddress := strings.ToLower(userSigner.PublicKey().Address().String())
+	sessionKeyAddress := "0x3333333333333333333333333333333333333333"
+
+	// 3 app_session_ids exceeds max of 2
+	sessionIDs := []string{
+		"0x1111111111111111111111111111111111111111111111111111111111111111",
+		"0x2222222222222222222222222222222222222222222222222222222222222222",
+		"0x3333333333333333333333333333333333333333333333333333333333333333",
+	}
+
+	reqPayload := rpc.AppSessionsV1SubmitSessionKeyStateRequest{
+		State: rpc.AppSessionKeyStateV1{
+			UserAddress:    userAddress,
+			SessionKey:     sessionKeyAddress,
+			Version:        "1",
+			ApplicationIDs: []string{},
+			AppSessionIDs:  sessionIDs,
+			ExpiresAt:      strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10),
+			UserSig:        "0xdeadbeef",
+		},
+	}
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, rpc.AppSessionsV1SubmitSessionKeyStateMethod.String(), payload),
+	}
+
+	handler.SubmitSessionKeyState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.NotNil(t, respErr)
+	assert.Contains(t, respErr.Error(), "app_session_ids array exceeds maximum length of 2")
+}
+
+func TestSubmitSessionKeyState_AtMaxLimit(t *testing.T) {
+	mockStore := new(MockStore)
+	userSigner := NewMockSigner()
+	userAddress := strings.ToLower(userSigner.PublicKey().Address().String())
+	sessionKeySigner := NewMockSigner()
+	sessionKeyAddress := strings.ToLower(sessionKeySigner.PublicKey().Address().String())
+
+	handler := &Handler{
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockStore)
+		},
+		metrics:          metrics.NewNoopRuntimeMetricExporter(),
+		maxSessionKeyIDs: 2,
+	}
+
+	expiresAt := time.Now().Add(24 * time.Hour).Truncate(time.Second)
+	// Exactly at max (2) should pass validation
+	appIDs := []string{
+		"0x1111111111111111111111111111111111111111111111111111111111111111",
+		"0x2222222222222222222222222222222222222222222222222222222222222222",
+	}
+	sessionIDs := []string{
+		"0x3333333333333333333333333333333333333333333333333333333333333333",
+		"0x4444444444444444444444444444444444444444444444444444444444444444",
+	}
+
+	reqPayload := buildSignedSessionKeyStateReq(t, userAddress, sessionKeyAddress, 1, appIDs, sessionIDs, expiresAt, userSigner)
+
+	mockStore.On("GetLastAppSessionKeyVersion", userAddress, sessionKeyAddress).Return(uint64(0), nil)
+	mockStore.On("StoreAppSessionKeyState", mock.AnythingOfType("app.AppSessionKeyStateV1")).Return(nil)
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, rpc.AppSessionsV1SubmitSessionKeyStateMethod.String(), payload),
+	}
+
+	handler.SubmitSessionKeyState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	assert.Nil(t, ctx.Response.Error())
+	mockStore.AssertExpectations(t)
+}
+
+func TestSubmitSessionKeyState_InvalidUserAddress(t *testing.T) {
+	mockStore := new(MockStore)
+	handler := &Handler{
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockStore)
+		},
+		metrics:          metrics.NewNoopRuntimeMetricExporter(),
+		maxSessionKeyIDs: 10,
+	}
+
+	reqPayload := rpc.AppSessionsV1SubmitSessionKeyStateRequest{
+		State: rpc.AppSessionKeyStateV1{
+			UserAddress:    "not-an-address",
+			SessionKey:     "0x3333333333333333333333333333333333333333",
+			Version:        "1",
+			ApplicationIDs: []string{},
+			AppSessionIDs:  []string{},
+			ExpiresAt:      strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10),
+			UserSig:        "0xdeadbeef",
+		},
+	}
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, rpc.AppSessionsV1SubmitSessionKeyStateMethod.String(), payload),
+	}
+
+	handler.SubmitSessionKeyState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.NotNil(t, respErr)
+	assert.Contains(t, respErr.Error(), "invalid user_address")
+}
+
+func TestSubmitSessionKeyState_ExpiredExpiresAt(t *testing.T) {
+	mockStore := new(MockStore)
+	handler := &Handler{
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockStore)
+		},
+		metrics:          metrics.NewNoopRuntimeMetricExporter(),
+		maxSessionKeyIDs: 10,
+	}
+
+	reqPayload := rpc.AppSessionsV1SubmitSessionKeyStateRequest{
+		State: rpc.AppSessionKeyStateV1{
+			UserAddress:    "0x1111111111111111111111111111111111111111",
+			SessionKey:     "0x3333333333333333333333333333333333333333",
+			Version:        "1",
+			ApplicationIDs: []string{},
+			AppSessionIDs:  []string{},
+			ExpiresAt:      strconv.FormatInt(time.Now().Add(-time.Hour).Unix(), 10),
+			UserSig:        "0xdeadbeef",
+		},
+	}
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, rpc.AppSessionsV1SubmitSessionKeyStateMethod.String(), payload),
+	}
+
+	handler.SubmitSessionKeyState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.NotNil(t, respErr)
+	assert.Contains(t, respErr.Error(), "expires_at must be in the future")
+}
+
+func TestSubmitSessionKeyState_MissingUserSig(t *testing.T) {
+	mockStore := new(MockStore)
+	handler := &Handler{
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockStore)
+		},
+		metrics:          metrics.NewNoopRuntimeMetricExporter(),
+		maxSessionKeyIDs: 10,
+	}
+
+	reqPayload := rpc.AppSessionsV1SubmitSessionKeyStateRequest{
+		State: rpc.AppSessionKeyStateV1{
+			UserAddress:    "0x1111111111111111111111111111111111111111",
+			SessionKey:     "0x3333333333333333333333333333333333333333",
+			Version:        "1",
+			ApplicationIDs: []string{},
+			AppSessionIDs:  []string{},
+			ExpiresAt:      strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10),
+			UserSig:        "",
+		},
+	}
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, rpc.AppSessionsV1SubmitSessionKeyStateMethod.String(), payload),
+	}
+
+	handler.SubmitSessionKeyState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.NotNil(t, respErr)
+	assert.Contains(t, respErr.Error(), "user_sig is required")
+}
+
+func TestSubmitSessionKeyState_VersionMismatch(t *testing.T) {
+	mockStore := new(MockStore)
+	userSigner := NewMockSigner()
+	userAddress := strings.ToLower(userSigner.PublicKey().Address().String())
+	sessionKeySigner := NewMockSigner()
+	sessionKeyAddress := strings.ToLower(sessionKeySigner.PublicKey().Address().String())
+
+	handler := &Handler{
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockStore)
+		},
+		metrics:          metrics.NewNoopRuntimeMetricExporter(),
+		maxSessionKeyIDs: 10,
+	}
+
+	expiresAt := time.Now().Add(24 * time.Hour).Truncate(time.Second)
+
+	// Submit version 3 when latest is 0 (expects 1)
+	reqPayload := buildSignedSessionKeyStateReq(t, userAddress, sessionKeyAddress, 3, []string{}, []string{}, expiresAt, userSigner)
+
+	mockStore.On("GetLastAppSessionKeyVersion", userAddress, sessionKeyAddress).Return(uint64(0), nil)
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, rpc.AppSessionsV1SubmitSessionKeyStateMethod.String(), payload),
+	}
+
+	handler.SubmitSessionKeyState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.NotNil(t, respErr)
+	assert.Contains(t, respErr.Error(), fmt.Sprintf("expected version %d, got %d", 1, 3))
+	mockStore.AssertExpectations(t)
+}
+
+func TestSubmitSessionKeyState_SignatureMismatch(t *testing.T) {
+	mockStore := new(MockStore)
+	userSigner := NewMockSigner()
+	differentSigner := NewMockSigner() // sign with a different key
+	userAddress := strings.ToLower(userSigner.PublicKey().Address().String())
+	sessionKeySigner := NewMockSigner()
+	sessionKeyAddress := strings.ToLower(sessionKeySigner.PublicKey().Address().String())
+
+	handler := &Handler{
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockStore)
+		},
+		metrics:          metrics.NewNoopRuntimeMetricExporter(),
+		maxSessionKeyIDs: 10,
+	}
+
+	expiresAt := time.Now().Add(24 * time.Hour).Truncate(time.Second)
+
+	// Sign with differentSigner but claim userAddress
+	reqPayload := buildSignedSessionKeyStateReq(t, userAddress, sessionKeyAddress, 1, []string{}, []string{}, expiresAt, differentSigner)
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, rpc.AppSessionsV1SubmitSessionKeyStateMethod.String(), payload),
+	}
+
+	handler.SubmitSessionKeyState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.NotNil(t, respErr)
+	assert.Contains(t, respErr.Error(), "signature does not match user_address")
+}

--- a/clearnode/api/channel_v1/submit_session_key_state.go
+++ b/clearnode/api/channel_v1/submit_session_key_state.go
@@ -50,6 +50,10 @@ func (h *Handler) SubmitSessionKeyState(c *rpc.Context) {
 		c.Fail(rpc.Errorf("invalid_session_key_state: expires_at must be in the future"), "")
 		return
 	}
+	if len(coreState.Assets) > h.maxSessionKeyIDs {
+		c.Fail(rpc.Errorf("invalid_session_key_state: assets array exceeds maximum length of %d", h.maxSessionKeyIDs), "")
+		return
+	}
 	if coreState.UserSig == "" {
 		c.Fail(rpc.Errorf("invalid_session_key_state: user_sig is required"), "")
 		return

--- a/clearnode/api/channel_v1/submit_session_key_state_test.go
+++ b/clearnode/api/channel_v1/submit_session_key_state_test.go
@@ -1,0 +1,352 @@
+package channel_v1
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/layer-3/nitrolite/clearnode/metrics"
+	"github.com/layer-3/nitrolite/pkg/core"
+	"github.com/layer-3/nitrolite/pkg/rpc"
+	"github.com/layer-3/nitrolite/pkg/sign"
+)
+
+// buildSignedChannelSessionKeyStateReq creates a properly signed ChannelsV1SubmitSessionKeyState request.
+func buildSignedChannelSessionKeyStateReq(t *testing.T, userAddress, sessionKey string, version uint64, assets []string, expiresAt time.Time, signer sign.Signer) rpc.ChannelsV1SubmitSessionKeyStateRequest {
+	t.Helper()
+
+	if assets == nil {
+		assets = []string{}
+	}
+
+	metadataHash, err := core.GetChannelSessionKeyAuthMetadataHashV1(version, assets, expiresAt.Unix())
+	require.NoError(t, err)
+
+	packed, err := core.PackChannelKeyStateV1(strings.ToLower(sessionKey), metadataHash)
+	require.NoError(t, err)
+
+	sig, err := signer.Sign(packed)
+	require.NoError(t, err)
+
+	return rpc.ChannelsV1SubmitSessionKeyStateRequest{
+		State: rpc.ChannelSessionKeyStateV1{
+			UserAddress: userAddress,
+			SessionKey:  sessionKey,
+			Version:     strconv.FormatUint(version, 10),
+			Assets:      assets,
+			ExpiresAt:   strconv.FormatInt(expiresAt.Unix(), 10),
+			UserSig:     hexutil.Encode(sig),
+		},
+	}
+}
+
+func TestChannelSubmitSessionKeyState_Success(t *testing.T) {
+	mockStore := new(MockStore)
+	userSigner := NewMockSigner()
+	userAddress := strings.ToLower(userSigner.PublicKey().Address().String())
+	sessionKeySigner := NewMockSigner()
+	sessionKeyAddress := strings.ToLower(sessionKeySigner.PublicKey().Address().String())
+
+	handler := &Handler{
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockStore)
+		},
+		metrics:          metrics.NewNoopRuntimeMetricExporter(),
+		maxSessionKeyIDs: 10,
+	}
+
+	expiresAt := time.Now().Add(24 * time.Hour).Truncate(time.Second)
+	assets := []string{"USDC"}
+
+	reqPayload := buildSignedChannelSessionKeyStateReq(t, userAddress, sessionKeyAddress, 1, assets, expiresAt, userSigner)
+
+	mockStore.On("GetLastChannelSessionKeyVersion", userAddress, sessionKeyAddress).Return(uint64(0), nil)
+	mockStore.On("StoreChannelSessionKeyState", mock.AnythingOfType("core.ChannelSessionKeyStateV1")).Return(nil)
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, rpc.ChannelsV1SubmitSessionKeyStateMethod.String(), payload),
+	}
+
+	handler.SubmitSessionKeyState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	assert.Nil(t, ctx.Response.Error())
+	assert.Equal(t, rpc.MsgTypeResp, ctx.Response.Type)
+	mockStore.AssertExpectations(t)
+}
+
+func TestChannelSubmitSessionKeyState_AssetsExceedsMax(t *testing.T) {
+	mockStore := new(MockStore)
+	handler := &Handler{
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockStore)
+		},
+		metrics:          metrics.NewNoopRuntimeMetricExporter(),
+		maxSessionKeyIDs: 2,
+	}
+
+	// 3 assets exceeds max of 2
+	reqPayload := rpc.ChannelsV1SubmitSessionKeyStateRequest{
+		State: rpc.ChannelSessionKeyStateV1{
+			UserAddress: "0x1111111111111111111111111111111111111111",
+			SessionKey:  "0x3333333333333333333333333333333333333333",
+			Version:     "1",
+			Assets:      []string{"USDC", "ETH", "BTC"},
+			ExpiresAt:   strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10),
+			UserSig:     "0xdeadbeef",
+		},
+	}
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, rpc.ChannelsV1SubmitSessionKeyStateMethod.String(), payload),
+	}
+
+	handler.SubmitSessionKeyState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.NotNil(t, respErr)
+	assert.Contains(t, respErr.Error(), "assets array exceeds maximum length of 2")
+}
+
+func TestChannelSubmitSessionKeyState_AtMaxLimit(t *testing.T) {
+	mockStore := new(MockStore)
+	userSigner := NewMockSigner()
+	userAddress := strings.ToLower(userSigner.PublicKey().Address().String())
+	sessionKeySigner := NewMockSigner()
+	sessionKeyAddress := strings.ToLower(sessionKeySigner.PublicKey().Address().String())
+
+	handler := &Handler{
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockStore)
+		},
+		metrics:          metrics.NewNoopRuntimeMetricExporter(),
+		maxSessionKeyIDs: 2,
+	}
+
+	expiresAt := time.Now().Add(24 * time.Hour).Truncate(time.Second)
+	// Exactly at max (2) should pass validation
+	assets := []string{"USDC", "ETH"}
+
+	reqPayload := buildSignedChannelSessionKeyStateReq(t, userAddress, sessionKeyAddress, 1, assets, expiresAt, userSigner)
+
+	mockStore.On("GetLastChannelSessionKeyVersion", userAddress, sessionKeyAddress).Return(uint64(0), nil)
+	mockStore.On("StoreChannelSessionKeyState", mock.AnythingOfType("core.ChannelSessionKeyStateV1")).Return(nil)
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, rpc.ChannelsV1SubmitSessionKeyStateMethod.String(), payload),
+	}
+
+	handler.SubmitSessionKeyState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	assert.Nil(t, ctx.Response.Error())
+	mockStore.AssertExpectations(t)
+}
+
+func TestChannelSubmitSessionKeyState_InvalidUserAddress(t *testing.T) {
+	mockStore := new(MockStore)
+	handler := &Handler{
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockStore)
+		},
+		metrics:          metrics.NewNoopRuntimeMetricExporter(),
+		maxSessionKeyIDs: 10,
+	}
+
+	reqPayload := rpc.ChannelsV1SubmitSessionKeyStateRequest{
+		State: rpc.ChannelSessionKeyStateV1{
+			UserAddress: "not-an-address",
+			SessionKey:  "0x3333333333333333333333333333333333333333",
+			Version:     "1",
+			Assets:      []string{},
+			ExpiresAt:   strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10),
+			UserSig:     "0xdeadbeef",
+		},
+	}
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, rpc.ChannelsV1SubmitSessionKeyStateMethod.String(), payload),
+	}
+
+	handler.SubmitSessionKeyState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.NotNil(t, respErr)
+	assert.Contains(t, respErr.Error(), "invalid user_address")
+}
+
+func TestChannelSubmitSessionKeyState_ExpiredExpiresAt(t *testing.T) {
+	mockStore := new(MockStore)
+	handler := &Handler{
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockStore)
+		},
+		metrics:          metrics.NewNoopRuntimeMetricExporter(),
+		maxSessionKeyIDs: 10,
+	}
+
+	reqPayload := rpc.ChannelsV1SubmitSessionKeyStateRequest{
+		State: rpc.ChannelSessionKeyStateV1{
+			UserAddress: "0x1111111111111111111111111111111111111111",
+			SessionKey:  "0x3333333333333333333333333333333333333333",
+			Version:     "1",
+			Assets:      []string{},
+			ExpiresAt:   strconv.FormatInt(time.Now().Add(-time.Hour).Unix(), 10),
+			UserSig:     "0xdeadbeef",
+		},
+	}
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, rpc.ChannelsV1SubmitSessionKeyStateMethod.String(), payload),
+	}
+
+	handler.SubmitSessionKeyState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.NotNil(t, respErr)
+	assert.Contains(t, respErr.Error(), "expires_at must be in the future")
+}
+
+func TestChannelSubmitSessionKeyState_MissingUserSig(t *testing.T) {
+	mockStore := new(MockStore)
+	handler := &Handler{
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockStore)
+		},
+		metrics:          metrics.NewNoopRuntimeMetricExporter(),
+		maxSessionKeyIDs: 10,
+	}
+
+	reqPayload := rpc.ChannelsV1SubmitSessionKeyStateRequest{
+		State: rpc.ChannelSessionKeyStateV1{
+			UserAddress: "0x1111111111111111111111111111111111111111",
+			SessionKey:  "0x3333333333333333333333333333333333333333",
+			Version:     "1",
+			Assets:      []string{},
+			ExpiresAt:   strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10),
+			UserSig:     "",
+		},
+	}
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, rpc.ChannelsV1SubmitSessionKeyStateMethod.String(), payload),
+	}
+
+	handler.SubmitSessionKeyState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.NotNil(t, respErr)
+	assert.Contains(t, respErr.Error(), "user_sig is required")
+}
+
+func TestChannelSubmitSessionKeyState_VersionMismatch(t *testing.T) {
+	mockStore := new(MockStore)
+	userSigner := NewMockSigner()
+	userAddress := strings.ToLower(userSigner.PublicKey().Address().String())
+	sessionKeySigner := NewMockSigner()
+	sessionKeyAddress := strings.ToLower(sessionKeySigner.PublicKey().Address().String())
+
+	handler := &Handler{
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockStore)
+		},
+		metrics:          metrics.NewNoopRuntimeMetricExporter(),
+		maxSessionKeyIDs: 10,
+	}
+
+	expiresAt := time.Now().Add(24 * time.Hour).Truncate(time.Second)
+
+	// Submit version 3 when latest is 0 (expects 1)
+	reqPayload := buildSignedChannelSessionKeyStateReq(t, userAddress, sessionKeyAddress, 3, []string{}, expiresAt, userSigner)
+
+	mockStore.On("GetLastChannelSessionKeyVersion", userAddress, sessionKeyAddress).Return(uint64(0), nil)
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, rpc.ChannelsV1SubmitSessionKeyStateMethod.String(), payload),
+	}
+
+	handler.SubmitSessionKeyState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.NotNil(t, respErr)
+	assert.Contains(t, respErr.Error(), fmt.Sprintf("expected version %d, got %d", 1, 3))
+	mockStore.AssertExpectations(t)
+}
+
+func TestChannelSubmitSessionKeyState_SignatureMismatch(t *testing.T) {
+	mockStore := new(MockStore)
+	userSigner := NewMockSigner()
+	differentSigner := NewMockSigner() // sign with a different key
+	userAddress := strings.ToLower(userSigner.PublicKey().Address().String())
+	sessionKeySigner := NewMockSigner()
+	sessionKeyAddress := strings.ToLower(sessionKeySigner.PublicKey().Address().String())
+
+	handler := &Handler{
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockStore)
+		},
+		metrics:          metrics.NewNoopRuntimeMetricExporter(),
+		maxSessionKeyIDs: 10,
+	}
+
+	expiresAt := time.Now().Add(24 * time.Hour).Truncate(time.Second)
+
+	// Sign with differentSigner but claim userAddress
+	reqPayload := buildSignedChannelSessionKeyStateReq(t, userAddress, sessionKeyAddress, 1, []string{}, expiresAt, differentSigner)
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, rpc.ChannelsV1SubmitSessionKeyStateMethod.String(), payload),
+	}
+
+	handler.SubmitSessionKeyState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.NotNil(t, respErr)
+	assert.Contains(t, respErr.Error(), "does not match wallet")
+}

--- a/clearnode/runtime.go
+++ b/clearnode/runtime.go
@@ -81,7 +81,7 @@ type ValidationLimits struct {
 	MaxParticipants   int `yaml:"max_participants" env:"CLEARNODE_MAX_PARTICIPANTS" env-default:"32"`
 	MaxSessionDataLen int `yaml:"max_session_data_len" env:"CLEARNODE_MAX_SESSION_DATA_LEN" env-default:"1024"`
 	MaxAppMetadataLen int `yaml:"max_app_metadata_len" env:"CLEARNODE_MAX_APP_METADATA_LEN" env-default:"1024"`
-	MaxSessionKeyIDs  int `yaml:"max_session_key_ids" env:"CLEARNODE_MAX_SESSION_KEY_IDS" env-default:"256"`
+	MaxSessionKeyIDs  int `yaml:"max_session_key_ids" env:"CLEARNODE_MAX_SESSION_KEY_IDS" env-default:"10"`
 	MaxSignedUpdates  int `yaml:"max_signed_updates" env:"CLEARNODE_MAX_SIGNED_UPDATES" env-default:"0"`
 }
 


### PR DESCRIPTION
## Description

In `channel_v1`, `SubmitSessionKeyState` accepts a `ChannelSessionKeyStateV1` payload containing an unbounded assets array but never validates its length against the configured `maxSessionKeyIDs` limit. In contrast, the equivalent `app_session_v1.SubmitSessionKeyState` handler correctly enforces this limit. As a result, a user request can supply an arbitrarily large asset list, which is then packed into the session key metadata hash and persisted as one database row per asset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * Default maximum session key IDs reduced from 256 to 10 (configurable via environment variable).

* **Bug Fixes**
  * Improved validation for session key state submissions with more specific error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->