### PR TITLE
M-I02: normalize input hex addresses

### DIFF
--- a/clearnode/api/app_session_v1/submit_session_key_state.go
+++ b/clearnode/api/app_session_v1/submit_session_key_state.go
@@ -4,10 +4,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 
 	"github.com/layer-3/nitrolite/pkg/app"
+	"github.com/layer-3/nitrolite/pkg/core"
 	"github.com/layer-3/nitrolite/pkg/log"
 	"github.com/layer-3/nitrolite/pkg/rpc"
 	"github.com/layer-3/nitrolite/pkg/sign"
@@ -46,14 +46,18 @@ func (h *Handler) SubmitSessionKeyState(c *rpc.Context) {
 	}
 
 	// Validate required fields
-	if !common.IsHexAddress(coreState.UserAddress) {
-		c.Fail(rpc.Errorf("invalid_session_key_state: invalid user_address"), "")
+	coreState.UserAddress, err = core.NormalizeHexAddress(coreState.UserAddress)
+	if err != nil {
+		c.Fail(rpc.Errorf("invalid_session_key_state: invalid user_address: %v", err), "")
 		return
 	}
-	if !common.IsHexAddress(coreState.SessionKey) {
-		c.Fail(rpc.Errorf("invalid_session_key_state: invalid session_key"), "")
+
+	coreState.SessionKey, err = core.NormalizeHexAddress(coreState.SessionKey)
+	if err != nil {
+		c.Fail(rpc.Errorf("invalid_session_key_state: invalid session_key: %v", err), "")
 		return
 	}
+
 	if coreState.Version == 0 {
 		c.Fail(rpc.Errorf("invalid_session_key_state: version must be greater than 0"), "")
 		return

--- a/clearnode/api/channel_v1/handler.go
+++ b/clearnode/api/channel_v1/handler.go
@@ -66,7 +66,11 @@ func (h *Handler) issueTransferReceiverState(ctx context.Context, tx Store, send
 	if incomingTransition.Type != core.TransitionTypeTransferSend {
 		return nil, rpc.Errorf("incoming state doesn't have 'transfer_send' transition")
 	}
-	receiverWallet := incomingTransition.AccountID
+	receiverWallet, err := core.NormalizeHexAddress(incomingTransition.AccountID)
+	if err != nil {
+		return nil, rpc.Errorf("invalid receiver wallet address: %v", err)
+	}
+
 	if senderState.UserWallet == receiverWallet {
 		return nil, rpc.Errorf("sender and receiver wallets are the same")
 	}
@@ -85,7 +89,7 @@ func (h *Handler) issueTransferReceiverState(ctx context.Context, tx Store, send
 
 	currentState, err := tx.GetLastUserState(receiverWallet, senderState.Asset, false)
 	if err != nil {
-		return nil, rpc.Errorf("failed to get last %s user state for transfer receiver with address %s", senderState.Asset, incomingTransition.AccountID)
+		return nil, rpc.Errorf("failed to get last %s user state for transfer receiver with address %s", senderState.Asset, receiverWallet)
 	}
 	if currentState == nil {
 		currentState = core.NewVoidState(senderState.Asset, receiverWallet)
@@ -102,7 +106,7 @@ func (h *Handler) issueTransferReceiverState(ctx context.Context, tx Store, send
 
 	lastSignedState, err := tx.GetLastUserState(receiverWallet, senderState.Asset, true)
 	if err != nil {
-		return nil, rpc.Errorf("failed to get last %s user state for transfer receiver with address %s", senderState.Asset, incomingTransition.AccountID)
+		return nil, rpc.Errorf("failed to get last %s user state for transfer receiver with address %s", senderState.Asset, receiverWallet)
 	}
 
 	// TODO: move to DB query

--- a/clearnode/api/channel_v1/request_creation.go
+++ b/clearnode/api/channel_v1/request_creation.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/layer-3/nitrolite/pkg/core"
 	"github.com/layer-3/nitrolite/pkg/log"
@@ -24,8 +23,10 @@ func (h *Handler) RequestCreation(c *rpc.Context) {
 		return
 	}
 
-	if !common.IsHexAddress(reqPayload.State.UserWallet) {
-		c.Fail(rpc.Errorf("invalid user_wallet address"), "")
+	var err error
+	reqPayload.State.UserWallet, err = core.NormalizeHexAddress(reqPayload.State.UserWallet)
+	if err != nil {
+		c.Fail(rpc.Errorf("invalid user_wallet: %v", err), "")
 		return
 	}
 

--- a/clearnode/api/channel_v1/submit_session_key_state.go
+++ b/clearnode/api/channel_v1/submit_session_key_state.go
@@ -3,8 +3,6 @@ package channel_v1
 import (
 	"time"
 
-	"github.com/ethereum/go-ethereum/common"
-
 	"github.com/layer-3/nitrolite/pkg/core"
 	"github.com/layer-3/nitrolite/pkg/log"
 	"github.com/layer-3/nitrolite/pkg/rpc"
@@ -34,14 +32,18 @@ func (h *Handler) SubmitSessionKeyState(c *rpc.Context) {
 	}
 
 	// Validate required fields
-	if !common.IsHexAddress(coreState.UserAddress) {
-		c.Fail(rpc.Errorf("invalid_session_key_state: invalid user_address"), "")
+	coreState.UserAddress, err = core.NormalizeHexAddress(coreState.UserAddress)
+	if err != nil {
+		c.Fail(rpc.Errorf("invalid_session_key_state: invalid user_address: %v", err), "")
 		return
 	}
-	if !common.IsHexAddress(coreState.SessionKey) {
-		c.Fail(rpc.Errorf("invalid_session_key_state: invalid session_key"), "")
+
+	coreState.SessionKey, err = core.NormalizeHexAddress(coreState.SessionKey)
+	if err != nil {
+		c.Fail(rpc.Errorf("invalid_session_key_state: invalid session_key: %v", err), "")
 		return
 	}
+
 	if coreState.Version == 0 {
 		c.Fail(rpc.Errorf("invalid_session_key_state: version must be greater than 0"), "")
 		return

--- a/pkg/app/app_v1.go
+++ b/pkg/app/app_v1.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/layer-3/nitrolite/pkg/core"
 )
 
 var AppIDV1Regex = regexp.MustCompile(`^[a-z0-9][-a-z0-9]{0,65}$`)
@@ -30,8 +31,10 @@ type AppInfoV1 struct {
 
 // PackAppV1 packs the AppV1 for signing using ABI encoding.
 func PackAppV1(app AppV1) ([]byte, error) {
-	if !common.IsHexAddress(app.OwnerWallet) {
-		return nil, fmt.Errorf("invalid owner wallet address: %s", app.OwnerWallet)
+	var err error
+	app.OwnerWallet, err = core.NormalizeHexAddress(app.OwnerWallet)
+	if err != nil {
+		return nil, fmt.Errorf("invalid owner wallet address: %v", err)
 	}
 
 	args := abi.Arguments{

--- a/pkg/core/utils.go
+++ b/pkg/core/utils.go
@@ -25,6 +25,23 @@ var (
 	uint256Type, _ = abi.NewType("uint256", "", nil)
 )
 
+func NormalizeHexAddress(s string) (string, error) {
+	s = strings.ToLower(s)
+
+	if !strings.HasPrefix(s, "0x") || len(s) != 42 {
+		return "", fmt.Errorf("invalid hex address: incorrect length, expected 42 characters including 0x prefix")
+	}
+
+	for i := 2; i < len(s); i++ {
+		c := s[i]
+		if !(('0' <= c && c <= '9') || ('a' <= c && c <= 'f')) {
+			return "", fmt.Errorf("invalid hex address: character '%c' at position %d is not a valid hexadecimal character", c, i)
+		}
+	}
+
+	return s, nil
+}
+
 func TransitionToIntent(transition Transition) uint8 {
 	switch transition.Type {
 	case TransitionTypeTransferSend,

--- a/pkg/core/utils_test.go
+++ b/pkg/core/utils_test.go
@@ -10,6 +10,80 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestNormalizeHexAddress(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "valid_lowercase",
+			input: "0x1234567890abcdef1234567890abcdef12345678",
+			want:  "0x1234567890abcdef1234567890abcdef12345678",
+		},
+		{
+			name:  "valid_uppercase_normalized",
+			input: "0xABCDEF1234567890ABCDEF1234567890ABCDEF12",
+			want:  "0xabcdef1234567890abcdef1234567890abcdef12",
+		},
+		{
+			name:  "valid_mixed_case",
+			input: "0xAbCdEf1234567890aBcDeF1234567890AbCdEf12",
+			want:  "0xabcdef1234567890abcdef1234567890abcdef12",
+		},
+		{
+			name:  "valid_checksum_address",
+			input: "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed",
+			want:  "0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed",
+		},
+		{
+			name:    "missing_0x_prefix",
+			input:   "1234567890abcdef1234567890abcdef12345678",
+			wantErr: true,
+		},
+		{
+			name:    "too_short",
+			input:   "0x1234",
+			wantErr: true,
+		},
+		{
+			name:    "too_long",
+			input:   "0x1234567890abcdef1234567890abcdef1234567890",
+			wantErr: true,
+		},
+		{
+			name:    "empty_string",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "invalid_hex_char",
+			input:   "0x1234567890abcdef1234567890abcdef1234567g",
+			wantErr: true,
+		},
+		{
+			name:  "all_zeros",
+			input: "0x0000000000000000000000000000000000000000",
+			want:  "0x0000000000000000000000000000000000000000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := NormalizeHexAddress(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestValidateDecimalPrecision(t *testing.T) {
 	t.Parallel()
 	tests := []struct {


### PR DESCRIPTION
## Description

The clearnode API accepts wallet addresses without the `0x` prefix. `common.IsHexAddress` validates format but accepts both `"0xabc123..."` (42 chars) and `"abc123..."` (40 chars) as valid. Both representations decode to the same 20-byte address via `common.HexToAddress`, producing identical channel IDs, signatures, and on-chain behavior — but they are treated as different strings in the database.

The signature verification in `ChannelSigValidator.Verify` (`pkg/core/channel_signer.go:213`) compares the recovered address (always `"0x..."`-prefixed via `EthereumAddress.String()`) against the wallet using `strings.EqualFold`. A no-prefix wallet will always fail this comparison, causing the entire database transaction to roll back.

However, this is an **accidental** guard — the rejection happens at signature validation (line 150), not at input sanitization (line 27). The code between those lines (channel ID computation, existing channel lookup, state advancement validation) all execute with a wallet string that doesn't match the database's expected format before the transaction is rolled back.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Improved Ethereum address validation with clearer, more detailed error messages across API endpoints for session and channel operations.
- Standardized address formatting for consistent handling across the platform.

**Tests**
- Added comprehensive test coverage for address validation and normalization functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->