### PR TITLE
M-H07: fix(contracts/ChannelHub): emit stored, not arbitrary candidate state

### DIFF
--- a/contracts/src/ChannelHub.sol
+++ b/contracts/src/ChannelHub.sol
@@ -718,7 +718,7 @@ contract ChannelHub is IVault, ReentrancyGuard {
             // Eagerly advance the queue head so FINALIZED entries don't accumulate
             _purgeEscrowDeposits();
 
-            emit EscrowDepositFinalized(escrowId, channelId, candidate);
+            emit EscrowDepositFinalized(escrowId, channelId, meta.initState);
             return;
         }
 
@@ -824,7 +824,7 @@ contract ChannelHub is IVault, ReentrancyGuard {
             // Eagerly advance the queue head so FINALIZED entries don't accumulate
             _purgeEscrowDeposits();
 
-            emit EscrowWithdrawalFinalized(escrowId, channelId, candidate);
+            emit EscrowWithdrawalFinalized(escrowId, channelId, meta.initState);
             return;
         }
 

--- a/contracts/test/ChannelHub_challenge/ChannelHub_challengeNonHomeChain.t.sol
+++ b/contracts/test/ChannelHub_challenge/ChannelHub_challengeNonHomeChain.t.sol
@@ -36,6 +36,7 @@ contract ChannelHubTest_Challenge_NonHomeChain_EscrowDeposit is ChannelHubTest_C
     - challenged escrow deposit can be resolved until `challengeExpireAt` time has passed with a newer finalization state, which removes challenge and unlock funds
     - challenged escrow deposit can NOT be resolved if `challengeExpireAt` has passed, but
         can be withdrawn after `challengeExpireAt` time passes
+    - challenged escrow deposit unilateral finalization emits event with INITIATE state as candidate, ignoring arbitrary candidate input
     - reverts on challenging already challenged escrow deposit
     */
 
@@ -182,6 +183,21 @@ contract ChannelHubTest_Challenge_NonHomeChain_EscrowDeposit is ChannelHubTest_C
         assertEq(token.balanceOf(alice), aliceBalanceBefore + ESCROW_AMOUNT, "User should receive locked amount");
     }
 
+    function test_challengedEscrowDeposit_unilateralFinalize_emitsInitState_ignoringArbitraryCandidate() public {
+        _challengeEscrowDeposit();
+
+        vm.warp(block.timestamp + EscrowDepositEngine.CHALLENGE_DURATION + 1);
+
+        State memory poisonedCandidate = initiateEscrowDepositState;
+        poisonedCandidate.version = 999999;
+
+        vm.expectEmit(true, true, false, true);
+        emit ChannelHub.EscrowDepositFinalized(escrowId, channelId, initiateEscrowDepositState);
+
+        vm.prank(node);
+        cHub.finalizeEscrowDeposit(channelId, escrowId, poisonedCandidate);
+    }
+
     function test_revert_challengeEscrowDeposit_alreadyChallenged() public {
         _challengeEscrowDeposit();
 
@@ -201,6 +217,7 @@ contract ChannelHubTest_Challenge_NonHomeChain_EscrowWithdrawal is ChannelHubTes
     - challenged escrow withdrawal can be resolved until `challengeExpireAt` time has passed with a newer finalization state, which removes challenge and unlock funds
     - challenged escrow withdrawal can NOT be resolved if `challengeExpireAt` has passed, but
         can be withdrawn after `challengeExpireAt` time passes
+    - challenged escrow withdrawal unilateral finalization emits event with INITIATE state as candidate, ignoring arbitrary candidate input
     - reverts on challenging already challenged escrow withdrawal
     */
 
@@ -343,6 +360,21 @@ contract ChannelHubTest_Challenge_NonHomeChain_EscrowWithdrawal is ChannelHubTes
             "Node vault should reclaim locked amount (cooperative resolution bypassed)"
         );
         assertEq(token.balanceOf(alice), aliceBalanceBefore, "User wallet unchanged: withdrawal was not completed");
+    }
+
+    function test_challengedEscrowWithdrawal_unilateralFinalize_emitsInitState_ignoringArbitraryCandidate() public {
+        _challengeEscrowWithdrawal();
+
+        vm.warp(block.timestamp + EscrowWithdrawalEngine.CHALLENGE_DURATION + 1);
+
+        State memory poisonedCandidate = initiateEscrowWithdrawalState;
+        poisonedCandidate.version = 999999;
+
+        vm.expectEmit(true, true, false, true);
+        emit ChannelHub.EscrowWithdrawalFinalized(escrowId, channelId, initiateEscrowWithdrawalState);
+
+        vm.prank(node);
+        cHub.finalizeEscrowWithdrawal(channelId, escrowId, poisonedCandidate);
     }
 
     function test_revert_challengeEscrowWithdrawal_alreadyChallenged() public {


### PR DESCRIPTION
## **Description**

When an escrow deposit is challenged and the challenge times out, `finalizeEscrowDeposit` enters a permissionless unilateral finalization path. In this path, the `candidate` parameter is never validated — the contract releases funds correctly using `meta.initState`, but emits `candidate` directly in the `EscrowDepositFinalized` event.

The clearnode event listener trusts the event data: it extracts `event.State.Version` and writes it to the escrow channel's `state_version` column. A griefer can call `finalizeEscrowDeposit` with an arbitrary `candidate.version` (e.g. 999999), corrupting the escrow channel version in the clearnode database.

This permanently breaks `EnsureNoOngoingStateTransitions` for the victim's home channel, because the MutualLock check requires `stateVersion == escrowChannelVersion` — a condition that can never be satisfied. The victim cannot submit any new off-chain state (transfers, withdrawals, deposits), which temporarily locks their funds. They are forced to close their channel through a challenge and wait for the whole duration of the challenge period before accessing their funds again.

## Attack path

1. Victim creates a channel, deposits, submits MutualLock, and initiates escrow deposit on both chains (normal flow).
2. Victim challenges the escrow deposit on the escrow chain (1-day challenge period).
3. Challenge times out.
4. Griefer monitors for `EscrowDepositChallenged` events. After timeout, griefer calls `finalizeEscrowDeposit(channelId, escrowId, poisonedCandidate)` where `poisonedCandidate.version = 999999`.
5. On-chain: funds released correctly to victim from `meta.initState`. The poisoned candidate is ignored for fund logic.
6. Off-chain: the `EscrowDepositFinalized` event carries `version = 999999`. The clearnode sets `escrowChannel.state_version = 999999`.
7. Victim's home channel is permanently stuck — any state submission fails with "mutual lock is still ongoing" because `stateVersion != escrowChannelVersion`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected escrow deposit and withdrawal finalization event emissions to use the contract's expected state instead of potentially arbitrary caller-provided state when finalizing challenged escrows on non-home chains.

* **Tests**
  * Added integration tests verifying correct state emission during unilateral finalization of challenged escrow deposits and withdrawals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->