### PR TITLE
M-I01: feat(contracts/ChannelHub): remove updateLastState flag

### DIFF
--- a/contracts/src/ChannelEngine.sol
+++ b/contracts/src/ChannelEngine.sol
@@ -65,7 +65,6 @@ library ChannelEngine {
         // State updates
         ChannelStatus newStatus;
         uint64 newChallengeExpiry;
-        bool updateLastState;
         bool closeChannel;
     }
 
@@ -173,7 +172,6 @@ library ChannelEngine {
             revert IncorrectStateIntent();
         }
 
-        effects.updateLastState = true;
         return effects;
     }
 

--- a/contracts/src/ChannelHub.sol
+++ b/contracts/src/ChannelHub.sol
@@ -1116,9 +1116,7 @@ contract ChannelHub is IVault, ReentrancyGuard {
     ) internal {
         ChannelMeta storage meta = _channels[channelId];
 
-        if (effects.updateLastState) {
-            meta.lastState = candidate;
-        }
+        meta.lastState = candidate;
 
         address token = candidate.homeLedger.token;
 


### PR DESCRIPTION
## **Description**

`_calculateEffectsByIntent()` always sets `effects.updateLastState = true`, and no code path ever sets it to `false`. As a result, `_applyTransitionEffects()` in `ChannelHub` always updates `meta.lastState` via the `if (effects.updateLastState)` guard, making the flag and conditional redundant. This adds dead code and extra complexity without changing behavior