### PR TITLE
H-L06: fix(contracts/ChannelHub): remove payable from methods, clarify in create

### DIFF
--- a/contracts/src/ChannelHub.sol
+++ b/contracts/src/ChannelHub.sol
@@ -476,6 +476,9 @@ contract ChannelHub is IVault, ReentrancyGuard {
                 || initState.intent == StateIntent.OPERATE,
             IncorrectStateIntent()
         );
+        if (initState.intent != StateIntent.DEPOSIT) {
+            require(msg.value == 0, IncorrectValue());
+        }
 
         bytes32 channelId = Utils.getChannelId(def, VERSION);
 
@@ -517,7 +520,7 @@ contract ChannelHub is IVault, ReentrancyGuard {
         emit ChannelDeposited(channelId, candidate);
     }
 
-    function withdrawFromChannel(bytes32 channelId, State calldata candidate) public payable {
+    function withdrawFromChannel(bytes32 channelId, State calldata candidate) public {
         require(candidate.intent == StateIntent.WITHDRAW, IncorrectStateIntent());
 
         ChannelMeta storage meta = _channels[channelId];
@@ -533,7 +536,7 @@ contract ChannelHub is IVault, ReentrancyGuard {
         emit ChannelWithdrawn(channelId, candidate);
     }
 
-    function checkpointChannel(bytes32 channelId, State calldata candidate) external payable {
+    function checkpointChannel(bytes32 channelId, State calldata candidate) external {
         require(candidate.intent == StateIntent.OPERATE, IncorrectStateIntent()); // Can only checkpoint operate states
 
         ChannelMeta storage meta = _channels[channelId];
@@ -599,7 +602,7 @@ contract ChannelHub is IVault, ReentrancyGuard {
         emit ChannelChallenged(channelId, candidate, challengeExpiry);
     }
 
-    function closeChannel(bytes32 channelId, State calldata candidate) external payable {
+    function closeChannel(bytes32 channelId, State calldata candidate) external {
         ChannelMeta storage meta = _channels[channelId];
         ChannelDefinition memory def = meta.definition;
         ChannelStatus status = meta.status;

--- a/contracts/test/ChannelHub_units/ChannelHub_checkpointChannel.t.sol
+++ b/contracts/test/ChannelHub_units/ChannelHub_checkpointChannel.t.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.30;
+
+import {ChannelHubTest_Base} from "../ChannelHub_Base.t.sol";
+
+import {State} from "../../src/interfaces/Types.sol";
+
+contract ChannelHubTest_checkpointChannel is ChannelHubTest_Base {
+    // ========== Payable ==========
+
+    // The EVM rejects ETH at the dispatcher level before any Solidity code runs,
+    // producing an empty revert (no error selector).
+
+    function test_revert_ifETHSent() public {
+        State memory state;
+
+        vm.deal(address(this), 1);
+        (bool success, bytes memory returnData) =
+            address(cHub).call{value: 1}(abi.encodeCall(cHub.checkpointChannel, (bytes32(0), state)));
+
+        assertFalse(success, "checkpointChannel must not accept ETH");
+        assertEq(returnData.length, 0, "Non-payable rejection produces no error data");
+    }
+}

--- a/contracts/test/ChannelHub_units/ChannelHub_closeChannel.t.sol
+++ b/contracts/test/ChannelHub_units/ChannelHub_closeChannel.t.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.30;
+
+import {ChannelHubTest_Base} from "../ChannelHub_Base.t.sol";
+
+import {State} from "../../src/interfaces/Types.sol";
+
+contract ChannelHubTest_closeChannel is ChannelHubTest_Base {
+    // ========== Payable ==========
+
+    // The EVM rejects ETH at the dispatcher level before any Solidity code runs,
+    // producing an empty revert (no error selector).
+
+    function test_revert_ifETHSent() public {
+        State memory state;
+
+        vm.deal(address(this), 1);
+        (bool success, bytes memory returnData) =
+            address(cHub).call{value: 1}(abi.encodeCall(cHub.closeChannel, (bytes32(0), state)));
+
+        assertFalse(success, "closeChannel must not accept ETH");
+        assertEq(returnData.length, 0, "Non-payable rejection produces no error data");
+    }
+}

--- a/contracts/test/ChannelHub_units/ChannelHub_createChannel.t.sol
+++ b/contracts/test/ChannelHub_units/ChannelHub_createChannel.t.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.30;
+
+import {ChannelHubTest_Base} from "../ChannelHub_Base.t.sol";
+
+import {ChannelHub} from "../../src/ChannelHub.sol";
+import {ChannelDefinition, State, StateIntent} from "../../src/interfaces/Types.sol";
+import {TestUtils} from "../TestUtils.sol";
+
+contract ChannelHubTest_createChannel is ChannelHubTest_Base {
+    ChannelDefinition internal def;
+
+    function setUp() public override {
+        super.setUp();
+        def = ChannelDefinition({
+            challengeDuration: CHALLENGE_DURATION,
+            user: alice,
+            node: node,
+            nonce: NONCE,
+            approvedSignatureValidators: 0,
+            metadata: bytes32(0)
+        });
+    }
+
+    // ========== Payable ==========
+
+    // createChannel is payable to support native ETH deposits (DEPOSIT intent).
+    // For WITHDRAW and OPERATE intents, no funds are pulled from the user,
+    // so any ETH sent with these intents is explicitly rejected.
+
+    function test_revert_ifETHSent_withdrawIntent() public {
+        State memory state;
+        state.intent = StateIntent.WITHDRAW;
+
+        vm.deal(address(this), 1);
+        vm.expectRevert(ChannelHub.IncorrectValue.selector);
+        cHub.createChannel{value: 1}(def, state);
+    }
+
+    function test_revert_ifETHSent_operateIntent() public {
+        State memory state;
+        state.intent = StateIntent.OPERATE;
+
+        vm.deal(address(this), 1);
+        vm.expectRevert(ChannelHub.IncorrectValue.selector);
+        cHub.createChannel{value: 1}(def, state);
+    }
+}

--- a/contracts/test/ChannelHub_units/ChannelHub_withdrawFromChannel.t.sol
+++ b/contracts/test/ChannelHub_units/ChannelHub_withdrawFromChannel.t.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.30;
+
+import {ChannelHubTest_Base} from "../ChannelHub_Base.t.sol";
+
+import {State} from "../../src/interfaces/Types.sol";
+
+contract ChannelHubTest_withdrawFromChannel is ChannelHubTest_Base {
+    // ========== Payable ==========
+
+    // The EVM rejects ETH at the dispatcher level before any Solidity code runs,
+    // producing an empty revert (no error selector).
+
+    function test_revert_ifETHSent() public {
+        State memory state;
+
+        vm.deal(address(this), 1);
+        (bool success, bytes memory returnData) =
+            address(cHub).call{value: 1}(abi.encodeCall(cHub.withdrawFromChannel, (bytes32(0), state)));
+
+        assertFalse(success, "withdrawFromChannel must not accept ETH");
+        assertEq(returnData.length, 0, "Non-payable rejection produces no error data");
+    }
+}


### PR DESCRIPTION
## Description

The functions `withdrawFromChannel(...)`, `checkpointChannel(...)`, and `createChannel(...)` are marked payable but fail to validate `msg.value` for operations that should never accept ETH.

Specifically: 

1. `withdrawFromChannel(...)` only accepts `WITHDRAW` intent, which always has userFundsDelta < 0 (funds flowing OUT to user), yet is marked payable;
2. `checkpointChannel(...)` only accepts `OPERATE` intent, which always has `userFundsDelta = 0` (no user fund movement), yet is marked payable; 
3. `createChannel(...)` accepts multiple intents (`DEPOSIT`, `WITHDRAW`, `OPERATE`) but only validates `msg.value` inside `_pullFunds(...)`, which is only called when `userFundsDelta > 0`. For `WITHDRAW` (`userFundsDelta < 0`) and `OPERATE` (`userFundsDelta = 0`) intents, `msg.value` is never validated.

Any ETH sent with these non-deposit operations is added to the contract balance, but not tracked in any accounting variable (`_nodeBalances`, `lockedFunds`, or `_reclaims`), making it permanently stuck with no recovery mechanism.

## Impact

This is a fail-unsafe design where the protocol silently accepts invalid input instead of rejecting it. The payable modifier on `withdrawFromChannel(..)` and `checkpointChannel(..)` creates a misleading interface that suggests these functions can accept ETH when they logically never should. Users who send ETH with these operations (whether through direct calls, contract integration bugs, SDK errors, or UI mistakes) will permanently lose those funds. While this requires user error to trigger and provides no direct benefit to attackers, it represents a protocol design flaw where the declared interface (payable) doesn't match the actual behavior (never processes ETH).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened ETH handling for channel operations to prevent unintended native asset transfers. Channel withdrawals, checkpoints, and closures now reject ETH. Channel creation stricter validates ETH acceptance based on operation intent.

* **Tests**
  * Added comprehensive test coverage for ETH rejection behavior across channel operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->