### PR TITLE
M-H09: use channel signer for all channel state node sigs

### DIFF
--- a/clearnode/api/app_session_v1/create_app_session_test.go
+++ b/clearnode/api/app_session_v1/create_app_session_test.go
@@ -22,7 +22,7 @@ func TestCreateAppSession_Success(t *testing.T) {
 		return fn(mockStore)
 	}
 
-	mockSigner := NewMockSigner()
+	mockSigner := NewMockChannelSigner()
 	mockAssetStore := new(MockAssetStore)
 	mockStatePacker := new(MockStatePacker)
 
@@ -126,7 +126,7 @@ func TestCreateAppSession_QuorumWithMultipleSignatures(t *testing.T) {
 		return fn(mockStore)
 	}
 
-	mockSigner := NewMockSigner()
+	mockSigner := NewMockChannelSigner()
 	mockAssetStore := new(MockAssetStore)
 	mockStatePacker := new(MockStatePacker)
 
@@ -228,7 +228,7 @@ func TestCreateAppSession_ZeroNonce(t *testing.T) {
 		return fn(mockStore)
 	}
 
-	mockSigner := NewMockSigner()
+	mockSigner := NewMockChannelSigner()
 	mockAssetStore := new(MockAssetStore)
 	mockStatePacker := new(MockStatePacker)
 
@@ -292,7 +292,7 @@ func TestCreateAppSession_QuorumExceedsTotalWeights(t *testing.T) {
 		return fn(mockStore)
 	}
 
-	mockSigner := NewMockSigner()
+	mockSigner := NewMockChannelSigner()
 	mockAssetStore := new(MockAssetStore)
 	mockStatePacker := new(MockStatePacker)
 
@@ -362,7 +362,7 @@ func TestCreateAppSession_NoSignatures(t *testing.T) {
 		return fn(mockStore)
 	}
 
-	mockSigner := NewMockSigner()
+	mockSigner := NewMockChannelSigner()
 	mockAssetStore := new(MockAssetStore)
 	mockStatePacker := new(MockStatePacker)
 
@@ -426,7 +426,7 @@ func TestCreateAppSession_SignatureFromNonParticipant(t *testing.T) {
 		return fn(mockStore)
 	}
 
-	mockSigner := NewMockSigner()
+	mockSigner := NewMockChannelSigner()
 	mockAssetStore := new(MockAssetStore)
 	mockStatePacker := new(MockStatePacker)
 
@@ -508,7 +508,7 @@ func TestCreateAppSession_QuorumNotMet(t *testing.T) {
 		return fn(mockStore)
 	}
 
-	mockSigner := NewMockSigner()
+	mockSigner := NewMockChannelSigner()
 	mockAssetStore := new(MockAssetStore)
 	mockStatePacker := new(MockStatePacker)
 
@@ -604,7 +604,7 @@ func TestCreateAppSession_DuplicateSignatures(t *testing.T) {
 		return fn(mockStore)
 	}
 
-	mockSigner := NewMockSigner()
+	mockSigner := NewMockChannelSigner()
 	mockAssetStore := new(MockAssetStore)
 	mockStatePacker := new(MockStatePacker)
 
@@ -697,7 +697,7 @@ func TestCreateAppSession_InvalidSignatureHex(t *testing.T) {
 		return fn(mockStore)
 	}
 
-	mockSigner := NewMockSigner()
+	mockSigner := NewMockChannelSigner()
 	mockAssetStore := new(MockAssetStore)
 	mockStatePacker := new(MockStatePacker)
 
@@ -766,7 +766,7 @@ func TestCreateAppSession_SignatureRecoveryFailure(t *testing.T) {
 		return fn(mockStore)
 	}
 
-	mockSigner := NewMockSigner()
+	mockSigner := NewMockChannelSigner()
 	mockAssetStore := new(MockAssetStore)
 	mockStatePacker := new(MockStatePacker)
 
@@ -835,7 +835,7 @@ func TestCreateAppSession_AppNotRegistered(t *testing.T) {
 		return fn(mockStore)
 	}
 
-	mockSigner := NewMockSigner()
+	mockSigner := NewMockChannelSigner()
 	mockAssetStore := new(MockAssetStore)
 	mockStatePacker := new(MockStatePacker)
 
@@ -904,7 +904,7 @@ func TestCreateAppSession_OwnerSigRequired(t *testing.T) {
 		return fn(mockStore)
 	}
 
-	mockSigner := NewMockSigner()
+	mockSigner := NewMockChannelSigner()
 	mockAssetStore := new(MockAssetStore)
 	mockStatePacker := new(MockStatePacker)
 
@@ -980,7 +980,7 @@ func TestCreateAppSession_OwnerSigSuccess(t *testing.T) {
 		return fn(mockStore)
 	}
 
-	mockSigner := NewMockSigner()
+	mockSigner := NewMockChannelSigner()
 	mockAssetStore := new(MockAssetStore)
 	mockStatePacker := new(MockStatePacker)
 

--- a/clearnode/api/app_session_v1/get_app_definition_test.go
+++ b/clearnode/api/app_session_v1/get_app_definition_test.go
@@ -17,7 +17,7 @@ import (
 func TestGetAppDefinition_Success(t *testing.T) {
 	// Setup
 	mockStore := new(MockStore)
-	mockSigner := NewMockSigner()
+	mockSigner := NewMockChannelSigner()
 
 	mockAssetStore := new(MockAssetStore)
 	mockStatePacker := new(MockStatePacker)
@@ -101,7 +101,7 @@ func TestGetAppDefinition_Success(t *testing.T) {
 func TestGetAppDefinition_NotFound(t *testing.T) {
 	// Setup
 	mockStore := new(MockStore)
-	mockSigner := NewMockSigner()
+	mockSigner := NewMockChannelSigner()
 
 	mockAssetStore := new(MockAssetStore)
 	mockStatePacker := new(MockStatePacker)

--- a/clearnode/api/app_session_v1/get_app_sessions_test.go
+++ b/clearnode/api/app_session_v1/get_app_sessions_test.go
@@ -19,7 +19,7 @@ import (
 func TestGetAppSessions_SuccessWithParticipant(t *testing.T) {
 	// Setup
 	mockStore := new(MockStore)
-	mockSigner := NewMockSigner()
+	mockSigner := NewMockChannelSigner()
 
 	mockAssetStore := new(MockAssetStore)
 	mockStatePacker := new(MockStatePacker)
@@ -143,7 +143,7 @@ func TestGetAppSessions_SuccessWithParticipant(t *testing.T) {
 func TestGetAppSessions_SuccessWithAppSessionID(t *testing.T) {
 	// Setup
 	mockStore := new(MockStore)
-	mockSigner := NewMockSigner()
+	mockSigner := NewMockChannelSigner()
 
 	mockAssetStore := new(MockAssetStore)
 	mockStatePacker := new(MockStatePacker)
@@ -229,7 +229,7 @@ func TestGetAppSessions_SuccessWithAppSessionID(t *testing.T) {
 func TestGetAppSessions_MissingRequiredParams(t *testing.T) {
 	// Setup
 	mockStore := new(MockStore)
-	mockSigner := NewMockSigner()
+	mockSigner := NewMockChannelSigner()
 
 	mockAssetStore := new(MockAssetStore)
 	mockStatePacker := new(MockStatePacker)
@@ -274,7 +274,7 @@ func TestGetAppSessions_MissingRequiredParams(t *testing.T) {
 func TestGetAppSessions_WithStatusFilter(t *testing.T) {
 	// Setup
 	mockStore := new(MockStore)
-	mockSigner := NewMockSigner()
+	mockSigner := NewMockChannelSigner()
 
 	mockAssetStore := new(MockAssetStore)
 	mockStatePacker := new(MockStatePacker)
@@ -361,7 +361,7 @@ func TestGetAppSessions_WithStatusFilter(t *testing.T) {
 func TestGetAppSessions_StoreError(t *testing.T) {
 	// Setup
 	mockStore := new(MockStore)
-	mockSigner := NewMockSigner()
+	mockSigner := NewMockChannelSigner()
 
 	mockAssetStore := new(MockAssetStore)
 	mockStatePacker := new(MockStatePacker)

--- a/clearnode/api/app_session_v1/handler.go
+++ b/clearnode/api/app_session_v1/handler.go
@@ -12,7 +12,6 @@ import (
 	"github.com/layer-3/nitrolite/pkg/core"
 	"github.com/layer-3/nitrolite/pkg/log"
 	"github.com/layer-3/nitrolite/pkg/rpc"
-	"github.com/layer-3/nitrolite/pkg/sign"
 )
 
 // Handler manages app session operations and provides RPC endpoints for app session management.
@@ -20,7 +19,7 @@ type Handler struct {
 	useStoreInTx     StoreTxProvider
 	assetStore       AssetStore
 	actionGateway    ActionGateway
-	signer           sign.Signer
+	signer           *core.ChannelDefaultSigner
 	stateAdvancer    core.StateAdvancer
 	statePacker      core.StatePacker
 	nodeAddress      string // Node's wallet address
@@ -36,7 +35,7 @@ func NewHandler(
 	useStoreInTx StoreTxProvider,
 	assetStore AssetStore,
 	actionGateway ActionGateway,
-	signer sign.Signer,
+	signer *core.ChannelDefaultSigner,
 	stateAdvancer core.StateAdvancer,
 	statePacker core.StatePacker,
 	nodeAddress string,

--- a/clearnode/api/app_session_v1/submit_app_state_test.go
+++ b/clearnode/api/app_session_v1/submit_app_state_test.go
@@ -22,7 +22,7 @@ func TestSubmitAppState_OperateIntent_NoRedistribution_Success(t *testing.T) {
 		return fn(mockStore)
 	}
 
-	mockSigner := NewMockSigner()
+	mockSigner := NewMockChannelSigner()
 	mockAssetStore := new(MockAssetStore)
 	mockStatePacker := new(MockStatePacker)
 
@@ -137,7 +137,7 @@ func TestSubmitAppState_OperateIntent_WithRedistribution_Success(t *testing.T) {
 		return fn(mockStore)
 	}
 
-	mockSigner := NewMockSigner()
+	mockSigner := NewMockChannelSigner()
 	mockAssetStore := new(MockAssetStore)
 	mockStatePacker := new(MockStatePacker)
 
@@ -253,7 +253,7 @@ func TestSubmitAppState_OperateIntent_WithRedistribution_Success(t *testing.T) {
 func TestSubmitAppState_WithdrawIntent_Success(t *testing.T) {
 	// Setup
 	mockStore := new(MockStore)
-	mockSigner := NewMockSigner()
+	mockSigner := NewMockChannelSigner()
 
 	storeTxProvider := func(fn StoreTxHandler) error {
 		return fn(mockStore)
@@ -367,7 +367,7 @@ func TestSubmitAppState_WithdrawIntent_Success(t *testing.T) {
 func TestSubmitAppState_CloseIntent_Success(t *testing.T) {
 	// Setup
 	mockStore := new(MockStore)
-	mockSigner := NewMockSigner()
+	mockSigner := NewMockChannelSigner()
 
 	storeTxProvider := func(fn StoreTxHandler) error {
 		return fn(mockStore)
@@ -500,7 +500,7 @@ func TestSubmitAppState_CloseIntent_AllocationMismatch_Rejected(t *testing.T) {
 		return fn(mockStore)
 	}
 
-	mockSigner := NewMockSigner()
+	mockSigner := NewMockChannelSigner()
 	mockAssetStore := new(MockAssetStore)
 	mockStatePacker := new(MockStatePacker)
 
@@ -599,7 +599,7 @@ func TestSubmitAppState_OperateIntent_MissingAllocation_Rejected(t *testing.T) {
 		return fn(mockStore)
 	}
 
-	mockSigner := NewMockSigner()
+	mockSigner := NewMockChannelSigner()
 	mockAssetStore := new(MockAssetStore)
 	mockStatePacker := new(MockStatePacker)
 
@@ -707,7 +707,7 @@ func TestSubmitAppState_OperateIntent_MissingAllocation_Rejected(t *testing.T) {
 func TestSubmitAppState_WithdrawIntent_MissingAllocation_Rejected(t *testing.T) {
 	// Setup
 	mockStore := new(MockStore)
-	mockSigner := NewMockSigner()
+	mockSigner := NewMockChannelSigner()
 
 	storeTxProvider := func(fn StoreTxHandler) error {
 		return fn(mockStore)
@@ -823,7 +823,7 @@ func TestSubmitAppState_DepositIntent_Rejected(t *testing.T) {
 		return fn(mockStore)
 	}
 
-	mockSigner := NewMockSigner()
+	mockSigner := NewMockChannelSigner()
 	mockAssetStore := new(MockAssetStore)
 	mockStatePacker := new(MockStatePacker)
 
@@ -878,7 +878,7 @@ func TestSubmitAppState_ClosedSession_Rejected(t *testing.T) {
 		return fn(mockStore)
 	}
 
-	mockSigner := NewMockSigner()
+	mockSigner := NewMockChannelSigner()
 	mockAssetStore := new(MockAssetStore)
 	mockStatePacker := new(MockStatePacker)
 
@@ -948,7 +948,7 @@ func TestSubmitAppState_InvalidVersion_Rejected(t *testing.T) {
 		return fn(mockStore)
 	}
 
-	mockSigner := NewMockSigner()
+	mockSigner := NewMockChannelSigner()
 	mockAssetStore := new(MockAssetStore)
 	mockStatePacker := new(MockStatePacker)
 
@@ -1023,7 +1023,7 @@ func TestSubmitAppState_SessionNotFound_Rejected(t *testing.T) {
 		return fn(mockStore)
 	}
 
-	mockSigner := NewMockSigner()
+	mockSigner := NewMockChannelSigner()
 	mockAssetStore := new(MockAssetStore)
 	mockStatePacker := new(MockStatePacker)
 
@@ -1083,7 +1083,7 @@ func TestSubmitAppState_OperateIntent_InvalidDecimalPrecision_Rejected(t *testin
 		return fn(mockStore)
 	}
 
-	mockSigner := NewMockSigner()
+	mockSigner := NewMockChannelSigner()
 	mockAssetStore := new(MockAssetStore)
 	mockStatePacker := new(MockStatePacker)
 
@@ -1186,7 +1186,7 @@ func TestSubmitAppState_OperateIntent_InvalidDecimalPrecision_Rejected(t *testin
 func TestSubmitAppState_WithdrawIntent_InvalidDecimalPrecision_Rejected(t *testing.T) {
 	// Setup
 	mockStore := new(MockStore)
-	mockSigner := NewMockSigner()
+	mockSigner := NewMockChannelSigner()
 
 	storeTxProvider := func(fn StoreTxHandler) error {
 		return fn(mockStore)
@@ -1295,7 +1295,7 @@ func TestSubmitAppState_OperateIntent_RedistributeToNewParticipant_Success(t *te
 		return fn(mockStore)
 	}
 
-	mockSigner := NewMockSigner()
+	mockSigner := NewMockChannelSigner()
 	mockAssetStore := new(MockAssetStore)
 	mockStatePacker := new(MockStatePacker)
 

--- a/clearnode/api/app_session_v1/submit_app_state_test.go
+++ b/clearnode/api/app_session_v1/submit_app_state_test.go
@@ -3,6 +3,7 @@ package app_session_v1
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/layer-3/nitrolite/clearnode/metrics"
@@ -254,6 +255,7 @@ func TestSubmitAppState_WithdrawIntent_Success(t *testing.T) {
 	// Setup
 	mockStore := new(MockStore)
 	mockSigner := NewMockChannelSigner()
+	nodeAddress := strings.ToLower(mockSigner.PublicKey().Address().String())
 
 	storeTxProvider := func(fn StoreTxHandler) error {
 		return fn(mockStore)
@@ -269,7 +271,7 @@ func TestSubmitAppState_WithdrawIntent_Success(t *testing.T) {
 		mockSigner,
 		core.NewStateAdvancerV1(mockAssetStore),
 		mockStatePacker,
-		"0xNode",
+		nodeAddress,
 		metrics.NewNoopRuntimeMetricExporter(),
 		32, 1024, 256, 16,
 	)
@@ -331,12 +333,29 @@ func TestSubmitAppState_WithdrawIntent_Success(t *testing.T) {
 	mockStore.On("RecordLedgerEntry", participant1, appSessionID, "USDC", decimal.NewFromInt(-40)).Return(nil)
 
 	// Mock expectations for channel state issuance (issueReleaseReceiverState)
+	homeChannelID := "0xHomeChannel"
+	existingUserState := core.State{
+		Asset:         "USDC",
+		UserWallet:    participant1,
+		Epoch:         1,
+		Version:       1,
+		HomeChannelID: &homeChannelID,
+		HomeLedger: core.Ledger{
+			UserBalance: decimal.NewFromInt(200),
+			UserNetFlow: decimal.NewFromInt(200),
+		},
+	}
 	mockStore.On("LockUserState", participant1, "USDC").Return(decimal.Zero, nil)
-	mockStore.On("GetLastUserState", participant1, "USDC", false).Return(nil, nil)
+	mockStore.On("GetLastUserState", participant1, "USDC", false).Return(existingUserState, nil)
 	mockStore.On("GetLastUserState", participant1, "USDC", true).Return(nil, nil)
 	mockStatePacker.On("PackState", mock.Anything).Return([]byte("packed"), nil)
 	mockStore.On("RecordTransaction", mock.Anything).Return(nil)
-	mockStore.On("StoreUserState", mock.Anything).Return(nil)
+
+	var capturedState core.State
+	mockStore.On("StoreUserState", mock.MatchedBy(func(state core.State) bool {
+		capturedState = state
+		return true
+	})).Return(nil)
 
 	mockStore.On("UpdateAppSession", mock.MatchedBy(func(session app.AppSessionV1) bool {
 		return session.Version == 2 && session.Status == app.AppSessionStatusOpen
@@ -361,6 +380,10 @@ func TestSubmitAppState_WithdrawIntent_Success(t *testing.T) {
 	}
 	assert.Equal(t, rpc.MsgTypeResp, ctx.Response.Type)
 
+	// Verify node signature on stored channel state
+	require.NotNil(t, capturedState.NodeSig, "Node signature should be present on stored state")
+	VerifyNodeSignature(t, nodeAddress, []byte("packed"), *capturedState.NodeSig)
+
 	mockStore.AssertExpectations(t)
 }
 
@@ -368,6 +391,7 @@ func TestSubmitAppState_CloseIntent_Success(t *testing.T) {
 	// Setup
 	mockStore := new(MockStore)
 	mockSigner := NewMockChannelSigner()
+	nodeAddress := strings.ToLower(mockSigner.PublicKey().Address().String())
 
 	storeTxProvider := func(fn StoreTxHandler) error {
 		return fn(mockStore)
@@ -383,7 +407,7 @@ func TestSubmitAppState_CloseIntent_Success(t *testing.T) {
 		mockSigner,
 		core.NewStateAdvancerV1(mockAssetStore),
 		mockStatePacker,
-		"0xNode",
+		nodeAddress,
 		metrics.NewNoopRuntimeMetricExporter(),
 		32, 1024, 256, 16,
 	)
@@ -450,22 +474,51 @@ func TestSubmitAppState_CloseIntent_Success(t *testing.T) {
 	mockStore.On("GetParticipantAllocations", appSessionID).Return(currentAllocations, nil)
 	mockAssetStore.On("GetAssetDecimals", "USDC").Return(uint8(6), nil)
 
+	homeChannelID := "0xHomeChannel"
+	existingUserState1 := core.State{
+		Asset:         "USDC",
+		UserWallet:    participant1,
+		Epoch:         1,
+		Version:       1,
+		HomeChannelID: &homeChannelID,
+		HomeLedger: core.Ledger{
+			UserBalance: decimal.NewFromInt(200),
+			UserNetFlow: decimal.NewFromInt(200),
+		},
+	}
+	existingUserState2 := core.State{
+		Asset:         "USDC",
+		UserWallet:    participant2,
+		Epoch:         1,
+		Version:       1,
+		HomeChannelID: &homeChannelID,
+		HomeLedger: core.Ledger{
+			UserBalance: decimal.NewFromInt(100),
+			UserNetFlow: decimal.NewFromInt(100),
+		},
+	}
+
 	// Mock expectations for fund release and channel state issuance on close
 	// Participant 1: 100 USDC
 	mockStore.On("RecordLedgerEntry", participant1, appSessionID, "USDC", decimal.NewFromInt(-100)).Return(nil)
 	mockStore.On("LockUserState", participant1, "USDC").Return(decimal.Zero, nil)
-	mockStore.On("GetLastUserState", participant1, "USDC", false).Return(nil, nil)
+	mockStore.On("GetLastUserState", participant1, "USDC", false).Return(existingUserState1, nil)
 	mockStore.On("GetLastUserState", participant1, "USDC", true).Return(nil, nil)
 	mockStatePacker.On("PackState", mock.Anything).Return([]byte("packed"), nil)
 	mockStore.On("RecordTransaction", mock.Anything).Return(nil)
-	mockStore.On("StoreUserState", mock.Anything).Return(nil).Once()
 
 	// Participant 2: 50 USDC
 	mockStore.On("RecordLedgerEntry", participant2, appSessionID, "USDC", decimal.NewFromInt(-50)).Return(nil)
 	mockStore.On("LockUserState", participant2, "USDC").Return(decimal.Zero, nil)
-	mockStore.On("GetLastUserState", participant2, "USDC", false).Return(nil, nil)
+	mockStore.On("GetLastUserState", participant2, "USDC", false).Return(existingUserState2, nil)
 	mockStore.On("GetLastUserState", participant2, "USDC", true).Return(nil, nil)
-	mockStore.On("StoreUserState", mock.Anything).Return(nil).Once()
+
+	// Capture stored states to verify node signatures
+	var capturedStates []core.State
+	mockStore.On("StoreUserState", mock.MatchedBy(func(state core.State) bool {
+		capturedStates = append(capturedStates, state)
+		return true
+	})).Return(nil)
 
 	mockStore.On("UpdateAppSession", mock.MatchedBy(func(session app.AppSessionV1) bool {
 		return session.Version == 2 && session.Status == app.AppSessionStatusClosed
@@ -489,6 +542,13 @@ func TestSubmitAppState_CloseIntent_Success(t *testing.T) {
 		t.Fatalf("Unexpected error response: %v", respErr)
 	}
 	assert.Equal(t, rpc.MsgTypeResp, ctx.Response.Type)
+
+	// Verify node signatures on all stored channel states
+	require.Len(t, capturedStates, 2, "Expected 2 stored states for 2 participants")
+	for _, state := range capturedStates {
+		require.NotNil(t, state.NodeSig, "Node signature should be present on stored state for %s", state.UserWallet)
+		VerifyNodeSignature(t, nodeAddress, []byte("packed"), *state.NodeSig)
+	}
 
 	mockStore.AssertExpectations(t)
 }

--- a/clearnode/api/app_session_v1/submit_deposit_state_test.go
+++ b/clearnode/api/app_session_v1/submit_deposit_state_test.go
@@ -22,7 +22,7 @@ import (
 func TestSubmitDepositState_Success(t *testing.T) {
 	// Setup
 	mockStore := new(MockStore)
-	mockSigner := NewMockSigner()
+	mockSigner := NewMockChannelSigner()
 	nodeAddress := mockSigner.PublicKey().Address().String()
 	mockAssetStore := new(MockAssetStore)
 	mockStatePacker := new(MockStatePacker)
@@ -231,7 +231,7 @@ func TestSubmitDepositState_Success(t *testing.T) {
 func TestSubmitDepositState_InvalidTransitionType(t *testing.T) {
 	// Setup
 	mockStore := new(MockStore)
-	mockSigner := NewMockSigner()
+	mockSigner := NewMockChannelSigner()
 	nodeAddress := mockSigner.PublicKey().Address().String()
 	mockAssetStore := new(MockAssetStore)
 	mockStatePacker := new(MockStatePacker)
@@ -375,7 +375,7 @@ func TestSubmitDepositState_InvalidTransitionType(t *testing.T) {
 func TestSubmitDepositState_QuorumNotMet(t *testing.T) {
 	// Setup
 	mockStore := new(MockStore)
-	mockSigner := NewMockSigner()
+	mockSigner := NewMockChannelSigner()
 	nodeAddress := mockSigner.PublicKey().Address().String()
 	mockAssetStore := new(MockAssetStore)
 	mockStatePacker := new(MockStatePacker)

--- a/clearnode/api/app_session_v1/submit_deposit_state_test.go
+++ b/clearnode/api/app_session_v1/submit_deposit_state_test.go
@@ -224,6 +224,9 @@ func TestSubmitDepositState_Success(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, response.StateNodeSig, "Node signature should be present")
 
+	// Verify the node signature is valid and recoverable to the node address
+	VerifyNodeSignature(t, nodeAddress, []byte("packed"), response.StateNodeSig)
+
 	// Verify all mock expectations
 	mockStore.AssertExpectations(t)
 }

--- a/clearnode/api/app_session_v1/testing.go
+++ b/clearnode/api/app_session_v1/testing.go
@@ -225,6 +225,14 @@ func NewMockSigner() sign.Signer {
 	return signer
 }
 
+// NewMockChannelSigner creates a mock channel signer for testing.
+// It wraps a raw signer with the channel signature prefix byte.
+func NewMockChannelSigner() *core.ChannelDefaultSigner {
+	s := NewMockSigner()
+	cs, _ := core.NewChannelDefaultSigner(s)
+	return cs
+}
+
 // TestAppSessionWallet is a test helper for creating properly signed app session signatures.
 // It generates a real ECDSA key pair and wraps it in an AppSessionSignerV1 (wallet type)
 // so that signatures include the required 0xA1 type prefix.

--- a/clearnode/api/app_session_v1/testing.go
+++ b/clearnode/api/app_session_v1/testing.go
@@ -285,3 +285,14 @@ func (w *TestAppSessionWallet) SignCreateRequest(t *testing.T, def app.AppDefini
 
 	return hexutil.Encode(sig)
 }
+
+// VerifyNodeSignature verifies that a hex-encoded channel signature was produced by the expected node address.
+func VerifyNodeSignature(t *testing.T, nodeAddr string, data []byte, sigHex string) {
+	t.Helper()
+	sigBytes, err := hexutil.Decode(sigHex)
+	require.NoError(t, err, "Failed to decode node signature")
+
+	sigValidator := core.NewChannelSigValidator(nil)
+	err = sigValidator.Verify(nodeAddr, data, sigBytes)
+	require.NoError(t, err, "Node signature verification failed: expected signer %s", nodeAddr)
+}

--- a/clearnode/api/channel_v1/request_creation_test.go
+++ b/clearnode/api/channel_v1/request_creation_test.go
@@ -161,6 +161,9 @@ func TestRequestCreation_Success(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, response.Signature)
 
+	// Verify the node signature is valid and recoverable to the node address
+	VerifyNodeSignature(t, nodeAddress, packedState, response.Signature)
+
 	// Verify all mocks were called
 	mockMemoryStore.AssertExpectations(t)
 	mockAssetStore.AssertExpectations(t)
@@ -307,6 +310,9 @@ func TestRequestCreation_Acknowledgement_Success(t *testing.T) {
 	err = ctx.Response.Payload.Translate(&response)
 	require.NoError(t, err)
 	assert.NotEmpty(t, response.Signature)
+
+	// Verify the node signature is valid and recoverable to the node address
+	VerifyNodeSignature(t, nodeAddress, packedState, response.Signature)
 
 	// Verify all mocks were called - notably RecordTransaction should NOT have been called
 	mockMemoryStore.AssertExpectations(t)

--- a/clearnode/api/channel_v1/submit_state_test.go
+++ b/clearnode/api/channel_v1/submit_state_test.go
@@ -185,6 +185,9 @@ func TestSubmitState_TransferSend_Success(t *testing.T) {
 	assert.Nil(t, ctx.Response.Error())
 	assert.NotEmpty(t, response.Signature, "Node signature should be present")
 
+	// Verify the node signature is valid and recoverable to the node address
+	VerifyNodeSignature(t, nodeAddress, packedSenderState, response.Signature)
+
 	// Verify all mock expectations
 	mockTxStore.AssertExpectations(t)
 }
@@ -341,6 +344,9 @@ func TestSubmitState_EscrowLock_Success(t *testing.T) {
 	assert.Nil(t, ctx.Response.Error())
 	assert.NotEmpty(t, response.Signature, "Node signature should be present")
 
+	// Verify the node signature is valid and recoverable to the node address
+	VerifyNodeSignature(t, nodeAddress, packedState, response.Signature)
+
 	// Verify all mock expectations
 	mockTxStore.AssertExpectations(t)
 }
@@ -496,6 +502,9 @@ func TestSubmitState_EscrowWithdraw_Success(t *testing.T) {
 	assert.Nil(t, ctx.Response.Error())
 	assert.NotEmpty(t, response.Signature, "Node signature should be present")
 
+	// Verify the node signature is valid and recoverable to the node address
+	VerifyNodeSignature(t, nodeAddress, packedState, response.Signature)
+
 	// Verify all mock expectations
 	mockTxStore.AssertExpectations(t)
 }
@@ -627,6 +636,9 @@ func TestSubmitState_HomeDeposit_Success(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, ctx.Response.Error())
 	assert.NotEmpty(t, response.Signature, "Node signature should be present")
+
+	// Verify the node signature is valid and recoverable to the node address
+	VerifyNodeSignature(t, nodeAddress, packedState, response.Signature)
 
 	// Verify all mock expectations
 	mockTxStore.AssertExpectations(t)
@@ -760,6 +772,9 @@ func TestSubmitState_HomeWithdrawal_Success(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, ctx.Response.Error())
 	assert.NotEmpty(t, response.Signature, "Node signature should be present")
+
+	// Verify the node signature is valid and recoverable to the node address
+	VerifyNodeSignature(t, nodeAddress, packedState, response.Signature)
 
 	// Verify all mock expectations
 	mockTxStore.AssertExpectations(t)
@@ -916,6 +931,9 @@ func TestSubmitState_MutualLock_Success(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, ctx.Response.Error())
 	assert.NotEmpty(t, response.Signature, "Node signature should be present")
+
+	// Verify the node signature is valid and recoverable to the node address
+	VerifyNodeSignature(t, nodeAddress, packedState, response.Signature)
 
 	// Verify all mock expectations
 	mockTxStore.AssertExpectations(t)
@@ -1074,6 +1092,9 @@ func TestSubmitState_EscrowDeposit_Success(t *testing.T) {
 	assert.Nil(t, ctx.Response.Error())
 	assert.NotEmpty(t, response.Signature, "Node signature should be present")
 
+	// Verify the node signature is valid and recoverable to the node address
+	VerifyNodeSignature(t, nodeAddress, packedState, response.Signature)
+
 	// Verify all mock expectations
 	mockTxStore.AssertExpectations(t)
 }
@@ -1209,6 +1230,9 @@ func TestSubmitState_Finalize_Success(t *testing.T) {
 	assert.Nil(t, ctx.Response.Error())
 	assert.NotEmpty(t, response.Signature, "Node signature should be present")
 
+	// Verify the node signature is valid and recoverable to the node address
+	VerifyNodeSignature(t, nodeAddress, packedState, response.Signature)
+
 	// Verify all mock expectations
 	mockTxStore.AssertExpectations(t)
 
@@ -1334,6 +1358,9 @@ func TestSubmitState_Acknowledgement_Success(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, ctx.Response.Error())
 	assert.NotEmpty(t, response.Signature, "Node signature should be present")
+
+	// Verify the node signature is valid and recoverable to the node address
+	VerifyNodeSignature(t, nodeAddress, packedState, response.Signature)
 
 	// Verify all mock expectations - notably RecordTransaction should NOT have been called
 	mockTxStore.AssertExpectations(t)

--- a/clearnode/api/channel_v1/testing.go
+++ b/clearnode/api/channel_v1/testing.go
@@ -1,12 +1,15 @@
 package channel_v1
 
 import (
+	"strings"
+	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/layer-3/nitrolite/clearnode/action_gateway"
 	"github.com/layer-3/nitrolite/pkg/core"
@@ -209,4 +212,15 @@ type MockActionGateway struct {
 
 func (m *MockActionGateway) AllowAction(_ action_gateway.Store, _ string, _ core.GatedAction) error {
 	return m.Err
+}
+
+// VerifyNodeSignature verifies that a hex-encoded channel signature was produced by the expected node address.
+func VerifyNodeSignature(t *testing.T, nodeAddr string, data []byte, sigHex string) {
+	t.Helper()
+	sigBytes, err := hexutil.Decode(sigHex)
+	require.NoError(t, err, "Failed to decode node signature")
+
+	sigValidator := core.NewChannelSigValidator(nil)
+	err = sigValidator.Verify(strings.ToLower(nodeAddr), data, sigBytes)
+	require.NoError(t, err, "Node signature verification failed: expected signer %s", nodeAddr)
 }

--- a/clearnode/api/rpc_router.go
+++ b/clearnode/api/rpc_router.go
@@ -101,7 +101,7 @@ func NewRPCRouter(
 	}
 
 	channelV1Handler := channel_v1.NewHandler(useChannelV1StoreInTx, memoryStore, actionGateway, nodeChannelSigner, stateAdvancer, statePacker, nodeAddress, cfg.MinChallenge, cfg.MaxChallenge, runtimeMetrics, cfg.MaxSessionKeyIDs)
-	appSessionV1Handler := app_session_v1.NewHandler(useAppSessionV1StoreInTx, memoryStore, actionGateway, signer, stateAdvancer, statePacker, nodeAddress, runtimeMetrics,
+	appSessionV1Handler := app_session_v1.NewHandler(useAppSessionV1StoreInTx, memoryStore, actionGateway, nodeChannelSigner, stateAdvancer, statePacker, nodeAddress, runtimeMetrics,
 		cfg.MaxParticipants, cfg.MaxSessionDataLen, cfg.MaxSessionKeyIDs, cfg.MaxRebalanceSignedUpdates)
 	appsV1Handler := apps_v1.NewHandler(dbStore, useAppV1StoreInTx, actionGateway, cfg.MaxAppMetadataLen)
 	nodeV1Handler := node_v1.NewHandler(memoryStore, nodeAddress, cfg.NodeVersion)


### PR DESCRIPTION
## Description

The app-session router constructs two different signing paths. The channel API is initialized with a channel signer, while the app-session API is initialized with the generic signer directly.

```go
channelV1Handler := channel_v1.NewHandler(useChannelV1StoreInTx, memoryStore, actionGateway, nodeChannelSigner, stateAdvancer, statePacker, nodeAddress, cfg.MinChallenge, runtimeMetrics, cfg.MaxSessionKeyIDs)
appSessionV1Handler := app_session_v1.NewHandler(useAppSessionV1StoreInTx, memoryStore, actionGateway, signer, stateAdvancer, statePacker, nodeAddress, runtimeMetrics, cfg.MaxParticipants, cfg.MaxSessionDataLen, cfg.MaxSessionKeyIDs, cfg.MaxRebalanceSignedUpdates)
```

When an app deposit is processed, the handler verifies that the submitted user channel state uses the channel signature format, then packs that channel state and signs `NodeSig` with the generic app-session signer before storing it. The same pattern is used when app withdrawals and app closes issue release channel states. The release helper packs a channel state, signs it with the generic signer, and stores it as the node signature for that channel state.
This is inconsistent with the channel approach. Channel signatures are not plain Ethereum signatures. The channel signer wraps the underlying signature with a leading signer-type byte.

```go
func (s *ChannelDefaultSigner) Sign(data []byte) (sign.Signature, error) {
    sig, err := s.Signer.Sign(data)
    if err != nil {
        return sign.Signature{}, err
    }

    return append([]byte{byte(ChannelSignerType_Default)}, sig...), nil
}
```

That prefix is required because both the off-chain verifier and the ChannelHub contract treat the first byte of the signature as the validator/signer identifier and verify only the remaining bytes. Because the app-session flows write raw signatures into `core.State.NodeSig`, the first byte of the signature body is misinterpreted as the signer type. The stored value is therefore not a valid channel signature, and it is persisted as if it were.
As a result, app deposits, withdrawals, and closes can store channel states with invalid `NodeSig` values. Later checkpoint, challenge, or settlement flows will reject those states, making the latest app-produced state unusable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures across multiple test suites to use channel-specific mock signer implementation.

* **Refactor**
  * Updated handler signer dependency type to channel-specific implementation.
  * Adjusted RPC router configuration to align signer routing with handler requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->