### PR TITLE
H-L07: fix(contracts/ChannelHub): restrict createChannel to non-existing channels

### DIFF
--- a/contracts/src/ChannelHub.sol
+++ b/contracts/src/ChannelHub.sol
@@ -491,6 +491,8 @@ contract ChannelHub is ReentrancyGuard {
         }
 
         bytes32 channelId = Utils.getChannelId(def, VERSION);
+        require(_channels[channelId].status == ChannelStatus.VOID, IncorrectChannelStatus());
+
         address user = def.user;
 
         _requireValidDefinition(def);

--- a/contracts/test/ChannelHub_units/ChannelHub_createChannel.t.sol
+++ b/contracts/test/ChannelHub_units/ChannelHub_createChannel.t.sol
@@ -4,11 +4,15 @@ pragma solidity 0.8.30;
 import {ChannelHubTest_Base} from "../ChannelHub_Base.t.sol";
 
 import {ChannelHub} from "../../src/ChannelHub.sol";
-import {ChannelDefinition, State, StateIntent} from "../../src/interfaces/Types.sol";
+import {Utils} from "../../src/Utils.sol";
+import {ChannelDefinition, ChannelStatus, State, StateIntent, Ledger} from "../../src/interfaces/Types.sol";
 import {TestUtils} from "../TestUtils.sol";
 
 contract ChannelHubTest_createChannel is ChannelHubTest_Base {
     ChannelDefinition internal def;
+    bytes32 internal channelId;
+
+    State initialDepositState;
 
     function setUp() public override {
         super.setUp();
@@ -20,6 +24,136 @@ contract ChannelHubTest_createChannel is ChannelHubTest_Base {
             approvedSignatureValidators: 0,
             metadata: bytes32(0)
         });
+        channelId = Utils.getChannelId(def, CHANNEL_HUB_VERSION);
+
+        initialDepositState = State({
+            version: 0,
+            intent: StateIntent.DEPOSIT,
+            metadata: bytes32(0),
+            homeLedger: Ledger({
+                chainId: uint64(block.chainid),
+                token: address(token),
+                decimals: 18,
+                userAllocation: DEPOSIT_AMOUNT,
+                userNetFlow: int256(DEPOSIT_AMOUNT),
+                nodeAllocation: 0,
+                nodeNetFlow: 0
+            }),
+            nonHomeLedger: TestUtils.emptyLedger(),
+            userSig: "",
+            nodeSig: ""
+        });
+    }
+
+    // ========== Success: create on VOID channel ==========
+
+    function test_createChannel_depositIntent() public {
+        State memory state = mutualSignStateBothWithEcdsaValidator(initialDepositState, channelId, ALICE_PK);
+
+        vm.prank(alice);
+        cHub.createChannel(def, state);
+
+        verifyChannelData(
+            channelId,
+            ChannelStatus.OPERATING,
+            0,
+            0,
+            "Channel status should be OPERATING after createChannel with DEPOSIT intent"
+        );
+    }
+
+    function test_createChannel_withdrawIntent() public {
+        // Represents an off-chain state (version > 0) where the node funded the user directly.
+        // userNetFlow < 0: net funds flowed out to user; nodeNetFlow > 0: node vault funds that.
+        // allocsSum must equal netFlowsSum (= 0), so both allocations are 0.
+        State memory state = TestUtils.nextState(
+            initialDepositState,
+            StateIntent.WITHDRAW,
+            [uint256(0), 0],
+            [-int256(DEPOSIT_AMOUNT), int256(DEPOSIT_AMOUNT)]
+        );
+        state = mutualSignStateBothWithEcdsaValidator(state, channelId, ALICE_PK);
+
+        vm.prank(alice);
+        cHub.createChannel(def, state);
+
+        verifyChannelData(
+            channelId,
+            ChannelStatus.OPERATING,
+            1,
+            0,
+            "Channel status should be OPERATING after createChannel with WITHDRAW intent"
+        );
+    }
+
+    function test_createChannel_operateIntent() public {
+        // Represents an off-chain state (version > 0) with no on-chain fund movement yet.
+        State memory state =
+            TestUtils.nextState(initialDepositState, StateIntent.OPERATE, [uint256(0), 0], [int256(0), 0]);
+        state = mutualSignStateBothWithEcdsaValidator(state, channelId, ALICE_PK);
+
+        vm.prank(alice);
+        cHub.createChannel(def, state);
+
+        verifyChannelData(
+            channelId,
+            ChannelStatus.OPERATING,
+            1,
+            0,
+            "Channel status should be OPERATING after createChannel with OPERATE intent"
+        );
+    }
+
+    // ========== Revert: createChannel on existing channel ==========
+
+    function _createDefaultChannel() internal {
+        State memory state = mutualSignStateBothWithEcdsaValidator(initialDepositState, channelId, ALICE_PK);
+        vm.prank(alice);
+        cHub.createChannel(def, state);
+    }
+
+    function test_revert_ifChannelExists_depositIntent() public {
+        _createDefaultChannel();
+
+        State memory state = TestUtils.nextState(
+            initialDepositState,
+            StateIntent.DEPOSIT,
+            [DEPOSIT_AMOUNT, 0],
+            [-int256(DEPOSIT_AMOUNT), int256(DEPOSIT_AMOUNT)]
+        );
+        state = mutualSignStateBothWithEcdsaValidator(state, channelId, ALICE_PK);
+
+        vm.prank(alice);
+        vm.expectRevert(ChannelHub.IncorrectChannelStatus.selector);
+        cHub.createChannel(def, state);
+    }
+
+    function test_revert_ifChannelExists_withdrawIntent() public {
+        _createDefaultChannel();
+
+        State memory state = TestUtils.nextState(
+            initialDepositState,
+            StateIntent.WITHDRAW,
+            [DEPOSIT_AMOUNT, 0],
+            [-int256(DEPOSIT_AMOUNT), int256(DEPOSIT_AMOUNT)]
+        );
+        state = mutualSignStateBothWithEcdsaValidator(state, channelId, ALICE_PK);
+
+        vm.prank(alice);
+        vm.expectRevert(ChannelHub.IncorrectChannelStatus.selector);
+        cHub.createChannel(def, state);
+    }
+
+    function test_revert_ifChannelExists_operateIntent() public {
+        _createDefaultChannel();
+
+        State memory state =
+            TestUtils.nextState(initialDepositState, StateIntent.OPERATE, [uint256(0), 0], [int256(0), 0]);
+        state = mutualSignStateBothWithEcdsaValidator(state, channelId, ALICE_PK);
+
+        vm.prank(alice);
+        vm.expectRevert(ChannelHub.IncorrectChannelStatus.selector);
+        cHub.createChannel(def, state);
     }
 
     // ========== Payable ==========


### PR DESCRIPTION
## Description

The `createChannel(..)` function unconditionally emits `ChannelCreated(..)` event at line 491 even when operating on existing channels. The function allows `DEPOSIT`, `WITHDRAW`, and `OPERATE` intents on channels with status `OPERATING`, `DISPUTED`, or `MIGRATING_IN` (not just `VOID`), as confirmed in the intent-specific validation functions. When called on an existing channel to deposit additional funds or perform operations, it still emits `ChannelCreated(channelId, def.user, def.node, def, initState)`, misleading off-chain indexers and UIs. The channel definition is only stored if `status == VOID` (line 1064-1066), confirming that subsequent calls are updates, not creations. This behavior is inconsistent with the protocol's established pattern seen in `EscrowDepositEngine.sol:165` and `EscrowWithdrawalEngine.sol:161`, which explicitly check `require(ctx.status == EscrowStatus.VOID, EscrowAlreadyExists())` to prevent operations on existing escrows.

## Impact

Off-chain indexers listening for `ChannelCreated` events will incorrectly count the same channel multiple times, leading to inflated channel creation metrics. UIs that display channels based on `ChannelCreated` events may show duplicate channel listings, confusing users. Analytics dashboards and monitoring systems will report incorrect data about channel creation activity. While on-chain state remains correct (the definition is only stored once when `status == VOID`), the misleading events create data integrity issues for off-chain systems.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced channel creation validation with early status verification to prevent invalid state transitions.

* **Tests**
  * Expanded test coverage for channel creation scenarios, including success cases for multiple operation intents and revert conditions for invalid channel states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->