### PR TITLE
H-L09: feat(contracts/ChannelEngine): add non-home migration version check

### DIFF
--- a/contracts/src/ChannelEngine.sol
+++ b/contracts/src/ChannelEngine.sol
@@ -522,6 +522,12 @@ library ChannelEngine {
         } else if (ctx.status == ChannelStatus.OPERATING || ctx.status == ChannelStatus.DISPUTED) {
             // OLD HOME CHAIN (OUT): Release funds and move to MIGRATED_OUT
             // homeLedger represents old home (current chain)
+            require(candidate.homeLedger.chainId == block.chainid, IncorrectHomeChainId());
+            if (ctx.prevState.intent == StateIntent.INITIATE_MIGRATION) {
+                require(candidate.version == ctx.prevState.version + 1, IncorrectStateVersion());
+            } else {
+                require(candidate.version > ctx.prevState.version + 1, IncorrectStateVersion());
+            }
 
             // Validate homeLedger
             require(candidate.homeLedger.userAllocation == 0, IncorrectUserAllocation());


### PR DESCRIPTION
## Description

The OLD HOME CHAIN path in `_calculateFinalizeMigrationEffects` (L519-535) lacks the `require(ctx.prevState.intent == StateIntent.INITIATE_MIGRATION)` check that the NEW HOME CHAIN path enforces at L500. This asymmetric validation breaks the intended INITIATE→FINALIZE two-step state machine, allowing `finalizeMigration()` to be called on any OPERATING or DISPUTED channel where INITIATE_MIGRATION was never called. A malicious node can construct a FINALIZE_MIGRATION state where `nodeNfDelta = -lockedFunds`, directing ALL locked channel funds to the node vault while `userFundsDelta` remains 0 (never set in this path). The channel closes as MIGRATED_OUT with no counterpart channel on any new chain.

However, according to the Nitrolite protocol, migration initiate state is not obligatory to be submitted to the old home chain (but they are on the non-home chain). Therefore, when FINALIZE_MIGRATION state is submitted on the old home chain, there is no guarantee the contract knows about the corresponding INITIATE_MIGRATION state. Thus, the suggested check can not always be performed.

Additionally, the provided PoC exploit is only possible because the FINALIZE_MIGRATION state was issued NOT after INITIATE_MIGRATION one, which is a requirement in the protocol.

Still, it is worth adding a lighter check for the old-home chain:
if a previous (known on-chain) state is INITIATE_MIGRATION, then candidate.version == prevState.version + 1, and candidate.version > prevState.version + 1 otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation checks to the channel migration logic to ensure correct chain ID verification and enforce proper version sequencing during state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->