### PR TITLE
H-I02: docs(contracts): add a note that rebasing tokens are not supported

### DIFF
--- a/contracts/SECURITY.md
+++ b/contracts/SECURITY.md
@@ -367,6 +367,8 @@ When a **node** employs SessionKeyValidator (NOT RECOMMENDED):
 Rebasing tokens (e.g. stETH, aTokens, rebase stablecoins) are **not supported**. The protocol uses a static ledger (`_nodeBalances`, `lockedFunds`) that only updates on explicit deposit and withdrawal events.
 When a rebasing token adjusts balances autonomously, the ledger permanently diverges from the actual contract balance. A negative rebase creates an insolvency condition: the ledger overstates holdings, so late withdrawers may receive less than recorded or nothing at all, and any deferred reclaim obligations become unfulfillable.
 
+There is no hard-coded guardrail that prevents depositing a rebasing token — the contract will accept it, but any autonomous balance change will diverge from the recorded ledger, producing undefined accounting behavior for all users of that token.
+
 Use non-rebasing equivalents where available (e.g. wstETH instead of stETH).
 
 ---

--- a/contracts/SECURITY.md
+++ b/contracts/SECURITY.md
@@ -360,6 +360,17 @@ When a **node** employs SessionKeyValidator (NOT RECOMMENDED):
 
 ---
 
+## Unsupported Token Types
+
+### Rebasing tokens
+
+Rebasing tokens (e.g. stETH, aTokens, rebase stablecoins) are **not supported**. The protocol uses a static ledger (`_nodeBalances`, `lockedFunds`) that only updates on explicit deposit and withdrawal events.
+When a rebasing token adjusts balances autonomously, the ledger permanently diverges from the actual contract balance. A negative rebase creates an insolvency condition: the ledger overstates holdings, so late withdrawers may receive less than recorded or nothing at all, and any deferred reclaim obligations become unfulfillable.
+
+Use non-rebasing equivalents where available (e.g. wstETH instead of stETH).
+
+---
+
 ## ERC20 Transfer Failure Attack Vectors
 
 ### Background

--- a/contracts/src/ChannelHub.sol
+++ b/contracts/src/ChannelHub.sol
@@ -296,6 +296,8 @@ contract ChannelHub is ReentrancyGuard {
 
     // ========= Node ==========
 
+    // NOTE: rebasing tokens (e.g. stETH, aTokens) are NOT supported. The node balance accounting
+    // uses a static ledger that does not reflect autonomous balance changes from rebases.
     function depositToNode(address token, uint256 amount) external payable {
         require(amount > 0, IncorrectAmount());
 

--- a/contracts/src/ChannelHub.sol
+++ b/contracts/src/ChannelHub.sol
@@ -298,6 +298,10 @@ contract ChannelHub is ReentrancyGuard {
 
     // NOTE: rebasing tokens (e.g. stETH, aTokens) are NOT supported. The node balance accounting
     // uses a static ledger that does not reflect autonomous balance changes from rebases.
+    // There is no hard-coded guardrail that prevents depositing a rebasing token — the contract
+    // will accept it, but any autonomous balance change will diverge from the recorded ledger,
+    // producing undefined accounting behavior for all users of that token. Use non-rebasing
+    // wrappers instead (e.g. wstETH instead of stETH).
     function depositToNode(address token, uint256 amount) external payable {
         require(amount > 0, IncorrectAmount());
 

--- a/protocol-description.md
+++ b/protocol-description.md
@@ -558,7 +558,11 @@ This works because `prevStoredState` was swapped during `INITIATE_MIGRATION`.
   * challenges always resolve by enforcing the newest valid state,
   * stalled cross-chain operations can always be completed or reverted.
 
-* **Token compatibility**: only standard (non-rebasing) ERC20 tokens and native ETH are supported. Rebasing tokens (e.g. stETH, aTokens) must not be used — their autonomous balance changes are invisible to the static ledger and create unrecoverable accounting divergence. Use non-rebasing wrappers instead (e.g. wstETH).
+* **Token compatibility**:
+
+only standard (non-rebasing) ERC20 tokens and native ETH are supported. Rebasing tokens (e.g. stETH, aTokens) must not be used — their autonomous balance changes are invisible to the static ledger and create unrecoverable accounting divergence. Use non-rebasing wrappers instead (e.g. wstETH).
+
+There is no hard-coded guardrail that prevents depositing a rebasing token — the contract will accept it, but any autonomous balance change will diverge from the recorded ledger, producing undefined accounting behavior for all users of that token.
 
 * **Transfer failure resilience**: Outbound transfers (to users) never revert on failure:
 

--- a/protocol-description.md
+++ b/protocol-description.md
@@ -558,6 +558,8 @@ This works because `prevStoredState` was swapped during `INITIATE_MIGRATION`.
   * challenges always resolve by enforcing the newest valid state,
   * stalled cross-chain operations can always be completed or reverted.
 
+* **Token compatibility**: only standard (non-rebasing) ERC20 tokens and native ETH are supported. Rebasing tokens (e.g. stETH, aTokens) must not be used — their autonomous balance changes are invisible to the static ledger and create unrecoverable accounting divergence. Use non-rebasing wrappers instead (e.g. wstETH).
+
 * **Transfer failure resilience**: Outbound transfers (to users) never revert on failure:
 
   * Failed transfers (due to blacklists, hooks, or token features) accumulate in a reclaim balance,


### PR DESCRIPTION
## Description

The ChannelHub contract tracks node balances using a static `_nodeBalances` mapping that is fundamentally incompatible with rebasing tokens (e.g., stETH, aTokens, rebase stablecoins). When rebasing tokens rebase, their balances change autonomously without any transfer occurring, creating a critical desynchronization between the accounting tracked in `_nodeBalances` and the actual token balance held by the contract.

When a rebasing token experiences a negative rebase (balance decrease), the actual contract balance decreases proportionally while `_nodeBalances` remains completely unchanged. This creates an insolvency scenario where the sum of all recorded node balances in `_nodeBalances` exceeds the actual tokens held by the contract.

The vulnerability manifests in a first-come-first-served pattern: early withdrawers successfully withdraw their full recorded amounts, while later withdrawers face silent transfer failures. The ChannelHub's transfer failure handling mechanism (`_pushFunds`) catches these failures and adds the amounts to a reclaim queue (`_reclaims` mapping), but critically, these are unfulfillable obligations - the tokens simply don't exist in the contract to satisfy these debts. When users attempt to claim their reclaimed funds via `claimFunds()`, the transaction reverts because the contract lacks sufficient tokens.

The issue affects all vault operations (`depositToVault`, `withdrawFromVault`, `purgeEscrowDeposits`) and channel operations that rely on `_nodeBalances` for accounting. No balance reconciliation mechanism exists to detect or handle this mismatch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification that rebasing tokens (e.g., stETH, aTokens) are not supported due to accounting incompatibility.
  * Provided guidance to use non-rebasing token alternatives (e.g., wstETH instead of stETH).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->