### PR TITLE
H-I03: fix(contracts/ChannelHub): use CIE pattern in depositToHub

### DIFF
--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -11,10 +11,10 @@ optimizer_runs = 1_000_000
 
 # special compiler profile for ChannelHub to prevent code size overflow
 additional_compiler_profiles = [
-  { name = "channelhub", optimizer_runs = 250 }
+  { name = "channelhub", optimizer_runs = 750 }
 ]
 
 # compile ChannelHub with lower optimizer runs to stay within size limits
 compilation_restrictions = [
-  { paths = "src/ChannelHub.sol", optimizer_runs = 250 }
+  { paths = "src/ChannelHub.sol", optimizer_runs = 750 }
 ]

--- a/contracts/src/ChannelHub.sol
+++ b/contracts/src/ChannelHub.sol
@@ -296,6 +296,11 @@ contract ChannelHub is ReentrancyGuard {
 
     // ========= Node ==========
 
+    // Intentionally CIE (Checks-Interactions-Effects): pull funds before updating accounting.
+    // Deposit state must only reflect tokens that have actually arrived — updating first would
+    // inflate _nodeBalances during ERC777/hook callbacks, enabling read-only reentrancy for
+    // external protocols querying getNodeBalance(). Contrast with withdrawFromNode, which uses
+    // CEI (decrement before push) to prevent re-entrancy drains.
     // NOTE: rebasing tokens (e.g. stETH, aTokens) are NOT supported. The node balance accounting
     // uses a static ledger that does not reflect autonomous balance changes from rebases.
     // There is no hard-coded guardrail that prevents depositing a rebasing token — the contract

--- a/contracts/src/ChannelHub.sol
+++ b/contracts/src/ChannelHub.sol
@@ -305,10 +305,10 @@ contract ChannelHub is ReentrancyGuard {
     function depositToNode(address token, uint256 amount) external payable {
         require(amount > 0, IncorrectAmount());
 
+        _pullFunds(msg.sender, token, amount);
+
         uint256 updatedBalance = _nodeBalances[token] + amount;
         _nodeBalances[token] = updatedBalance;
-
-        _pullFunds(msg.sender, token, amount);
 
         emit Deposited(token, amount);
         emit NodeBalanceUpdated(token, updatedBalance);


### PR DESCRIPTION
## Description

The `depositToVault(..)` and `withdrawFromVault(..)` functions violate the Checks-Effects-Interactions (CEI) pattern by updating the `_nodeBalances` state before completing external token transfers. In `depositToVault(..)`, `_nodeBalances` is incremented (L286-287) before calling `_pullFunds(..)` (L289), which executes `safeTransferFrom(..)`. Similarly, `withdrawFromVault(..)` decrements `_nodeBalances` (L303-304) before calling `_pushFunds(..)` (L306). For tokens with pre-transfer hooks (ERC777, ERC1363, custom ERC20s), these hooks fire before the token's internal balances are updated, creating a window where ChannelHub's accounting shows updated values but the actual token transfer hasn't completed. During this callback window, external protocols querying getAccountBalance receive inflated or deflated balance values that don't reflect the actual tokens held by ChannelHub.

## Impact

External protocols integrating with ChannelHub face read-only reentrancy risk when tokens with pre-transfer hooks are deposited. During the inconsistent state window, protocols querying `getAccountBalance(...)` for collateral calculations, credit assessments, or oracle data receive values that temporarily don't match actual token holdings. While transaction atomicity provides protection in simple scenarios (if the deposit fails, all state changes revert), complex multi-protocol interactions could still be exploited. The PoC demonstrates that during the callback, ChannelHub's accounting shows 10,000 tokens while the actual token balance is 0, and external oracles can record this inflated data. Although the inconsistency resolves by transaction end, this pattern puts external integrators at risk if they're not aware of the potential for read-only reentrancy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Compiler configuration has been optimized for improved build efficiency.

* **Bug Fixes**
  * Deposit operation flow has been refined to improve fund handling reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->