### PR TITLE
M-H11: revert empty signatures on quorum verification

### DIFF
--- a/clearnode/api/app_session_v1/create_app_session.go
+++ b/clearnode/api/app_session_v1/create_app_session.go
@@ -154,6 +154,10 @@ func (h *Handler) CreateAppSession(c *rpc.Context) {
 			return rpc.NewError(err)
 		}
 
+		if err := h.verifyQuorum(tx, appSessionID, appDef.ApplicationID, participantWeights, appDef.Quorum, packedRequest, reqPayload.QuorumSigs); err != nil {
+			return err
+		}
+
 		// Create app session with 0 allocations
 		appSession := app.AppSessionV1{
 			SessionID:     appSessionID,
@@ -170,10 +174,6 @@ func (h *Handler) CreateAppSession(c *rpc.Context) {
 
 		if err := tx.CreateAppSession(appSession); err != nil {
 			return rpc.Errorf("failed to create app session: %v", err)
-		}
-
-		if err := h.verifyQuorum(tx, appSessionID, appDef.ApplicationID, participantWeights, appDef.Quorum, packedRequest, reqPayload.QuorumSigs); err != nil {
-			return err
 		}
 
 		return nil

--- a/clearnode/api/app_session_v1/handler.go
+++ b/clearnode/api/app_session_v1/handler.go
@@ -70,10 +70,14 @@ func (h *Handler) verifyQuorum(tx Store, appSessionId, applicationID string, par
 		},
 	)
 
-	for _, sigHex := range signatures {
+	for i, sigHex := range signatures {
 		sigBytes, err := hexutil.Decode(sigHex)
 		if err != nil {
 			return rpc.Errorf("failed to decode signature: %v", err)
+		}
+
+		if len(sigBytes) == 0 {
+			return rpc.Errorf("empty signature after decode at index %d", i)
 		}
 
 		sigType := app.AppSessionSignerTypeV1(sigBytes[0])


### PR DESCRIPTION
## Description

The `verifyQuorum` helper is called from four app-session RPC endpoints: `create_app_session`, `submit_app_state`, `submit_deposit_state`, and `rebalance_app_sessions`. In each case, `quorum_sigs` is user-controlled. Inside `verifyQuorum`, each signature is decoded from hex and the first byte is read immediately to determine the signer type

```go
    for _, sigHex := range signatures {
        sigBytes, err := hexutil.Decode(sigHex)
        if err != nil {
            return rpc.Errorf("failed to decode signature: %v", err)
        }

        sigType := app.AppSessionSignerTypeV1(sigBytes[0])
        userWallet, err := appSessionSignerValidator.Recover(data, sigBytes)
```

This is unsafe because `hexutil.Decode("0x")` returns an empty slice without error. Supplying `quorum_sigs = ["0x"]` causes `sigBytes[0]` to panic with an out-of-range access instead of returning a validation error.
The same helper is also used by app updates, deposits, and rebalance flows, so the bug is reachable through multiple app-session RPC methods. The panic occurs in the request processing path and is not recovered there, so a single malformed request can terminate the service process.
Consequently, any remote caller who can reach these endpoints can cause a denial of service with a malformed signature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to detect and report empty signatures with their position index for improved error diagnostics.

* **Refactor**
  * Reordered quorum verification to execute earlier in the session creation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->