### PR TITLE
M-H11: reject issuance of receiver state during escrow ops

### DIFF
--- a/clearnode/api/app_session_v1/handler.go
+++ b/clearnode/api/app_session_v1/handler.go
@@ -147,18 +147,11 @@ func (h *Handler) issueReleaseReceiverState(ctx context.Context, tx Store, recei
 	}
 
 	// TODO: move to DB query
-	shouldSign := true
-	if lastSignedState != nil {
-		lastStateTransition := lastSignedState.Transition
-
-		if lastStateTransition.Type == core.TransitionTypeMutualLock ||
-			lastStateTransition.Type == core.TransitionTypeEscrowLock {
-			shouldSign = false
-		}
-
+	if lastSignedState != nil && lastSignedState.EscrowChannelID != nil {
+		return rpc.Errorf("cannot issue release receiver state: last signed state is a lock with escrow channel %s", *lastSignedState.EscrowChannelID)
 	}
 
-	if newState.HomeChannelID != nil && shouldSign {
+	if newState.HomeChannelID != nil {
 		// Pack and sign the state
 		packedState, err := h.statePacker.PackState(*newState)
 		if err != nil {

--- a/clearnode/api/app_session_v1/submit_app_state_test.go
+++ b/clearnode/api/app_session_v1/submit_app_state_test.go
@@ -387,6 +387,136 @@ func TestSubmitAppState_WithdrawIntent_Success(t *testing.T) {
 	mockStore.AssertExpectations(t)
 }
 
+func TestSubmitAppState_WithdrawIntent_ReceiverWithEscrowLock_Rejected(t *testing.T) {
+	// Setup
+	mockStore := new(MockStore)
+	mockSigner := NewMockChannelSigner()
+
+	storeTxProvider := func(fn StoreTxHandler) error {
+		return fn(mockStore)
+	}
+
+	mockAssetStore := new(MockAssetStore)
+	mockStatePacker := new(MockStatePacker)
+
+	handler := NewHandler(
+		storeTxProvider,
+		mockAssetStore,
+		&MockActionGateway{},
+		mockSigner,
+		core.NewStateAdvancerV1(mockAssetStore),
+		mockStatePacker,
+		"0xNode",
+		metrics.NewNoopRuntimeMetricExporter(),
+		32, 1024, 256, 16,
+	)
+
+	appSessionID := "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+	wallet1 := NewTestAppSessionWallet(t)
+	participant1 := wallet1.Address
+
+	existingSession := &app.AppSessionV1{
+		SessionID:     appSessionID,
+		ApplicationID: "test-app",
+		Participants: []app.AppParticipantV1{
+			{WalletAddress: participant1, SignatureWeight: 10},
+		},
+		Quorum:      10,
+		Status:      app.AppSessionStatusOpen,
+		Version:     1,
+		SessionData: "",
+	}
+
+	currentAllocations := map[string]map[string]decimal.Decimal{
+		participant1: {
+			"USDC": decimal.NewFromInt(100),
+		},
+	}
+
+	// Build the core app state update for signing
+	appStateUpdateCore := app.AppStateUpdateV1{
+		AppSessionID: appSessionID,
+		Intent:       app.AppStateUpdateIntentWithdraw,
+		Version:      2,
+		Allocations: []app.AppAllocationV1{
+			{Participant: participant1, Asset: "USDC", Amount: decimal.NewFromInt(60)},
+		},
+		SessionData: "",
+	}
+	sig1 := wallet1.SignAppStateUpdate(t, appStateUpdateCore)
+
+	reqPayload := rpc.AppSessionsV1SubmitAppStateRequest{
+		AppStateUpdate: rpc.AppStateUpdateV1{
+			AppSessionID: appSessionID,
+			Intent:       app.AppStateUpdateIntentWithdraw,
+			Version:      "2",
+			Allocations: []rpc.AppAllocationV1{
+				{Participant: participant1, Asset: "USDC", Amount: "60"},
+			},
+			SessionData: "",
+		},
+		QuorumSigs: []string{sig1},
+	}
+
+	// Mock expectations
+	mockStore.On("GetApp", "test-app").Return(&app.AppInfoV1{
+		App: app.AppV1{ID: "test-app", OwnerWallet: "0x0000000000000000000000000000000000000001"},
+	}, nil).Maybe()
+	mockStore.On("GetAppSession", appSessionID).Return(existingSession, nil)
+	mockStore.On("GetParticipantAllocations", appSessionID).Return(currentAllocations, nil)
+	mockAssetStore.On("GetAssetDecimals", "USDC").Return(uint8(6), nil)
+	mockStore.On("RecordLedgerEntry", participant1, appSessionID, "USDC", decimal.NewFromInt(-40)).Return(nil)
+
+	// Mock expectations for channel state issuance (issueReleaseReceiverState)
+	homeChannelID := "0xHomeChannel"
+	existingUserState := core.State{
+		Asset:         "USDC",
+		UserWallet:    participant1,
+		Epoch:         1,
+		Version:       1,
+		HomeChannelID: &homeChannelID,
+		HomeLedger: core.Ledger{
+			UserBalance: decimal.NewFromInt(200),
+			UserNetFlow: decimal.NewFromInt(200),
+		},
+	}
+
+	// Last signed state has an active escrow channel
+	escrowChannelID := "0xEscrowChannel456"
+	lastSignedState := core.State{
+		Asset:           "USDC",
+		UserWallet:      participant1,
+		Epoch:           1,
+		Version:         1,
+		HomeChannelID:   &homeChannelID,
+		EscrowChannelID: &escrowChannelID,
+	}
+
+	mockStore.On("LockUserState", participant1, "USDC").Return(decimal.Zero, nil)
+	mockStore.On("GetLastUserState", participant1, "USDC", false).Return(existingUserState, nil)
+	mockStore.On("GetLastUserState", participant1, "USDC", true).Return(lastSignedState, nil)
+
+	// Create RPC context
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, string(rpc.AppSessionsV1SubmitAppStateMethod), payload),
+	}
+
+	// Execute
+	handler.SubmitAppState(ctx)
+
+	// Assert - should fail because participant has an active escrow lock
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.NotNil(t, respErr, "Expected error when participant has active escrow lock")
+	assert.Contains(t, respErr.Error(), "last signed state is a lock with escrow channel")
+
+	mockStore.AssertExpectations(t)
+}
+
 func TestSubmitAppState_CloseIntent_Success(t *testing.T) {
 	// Setup
 	mockStore := new(MockStore)

--- a/clearnode/api/channel_v1/handler.go
+++ b/clearnode/api/channel_v1/handler.go
@@ -112,16 +112,11 @@ func (h *Handler) issueTransferReceiverState(ctx context.Context, tx Store, send
 	}
 
 	// TODO: move to DB query
-	shouldSign := true
-	if lastSignedState != nil {
-		lastStateTransition := lastSignedState.Transition
-		if lastStateTransition.Type == core.TransitionTypeMutualLock ||
-			lastStateTransition.Type == core.TransitionTypeEscrowLock {
-			shouldSign = false
-		}
+	if lastSignedState != nil && lastSignedState.EscrowChannelID != nil {
+		return nil, rpc.Errorf("cannot issue release receiver state: last signed state is a lock with escrow channel %s", *lastSignedState.EscrowChannelID)
 	}
 
-	if newState.HomeChannelID != nil && shouldSign {
+	if newState.HomeChannelID != nil {
 		packedState, err := h.statePacker.PackState(*newState)
 		if err != nil {
 			return nil, rpc.Errorf("failed to pack receiver state: %v", err)

--- a/clearnode/api/channel_v1/submit_state_test.go
+++ b/clearnode/api/channel_v1/submit_state_test.go
@@ -192,6 +192,158 @@ func TestSubmitState_TransferSend_Success(t *testing.T) {
 	mockTxStore.AssertExpectations(t)
 }
 
+func TestSubmitState_TransferSend_ReceiverWithEscrowLock_Rejected(t *testing.T) {
+	// Setup
+	mockTxStore := new(MockStore)
+	mockMemoryStore := new(MockMemoryStore)
+	mockAssetStore := new(MockAssetStore)
+	mockSigner := NewMockSigner()
+	nodeSigner, _ := core.NewChannelDefaultSigner(mockSigner)
+	nodeAddress := mockSigner.PublicKey().Address().String()
+	minChallenge := uint32(3600)
+	mockStatePacker := new(MockStatePacker)
+
+	handler := &Handler{
+		stateAdvancer: core.NewStateAdvancerV1(mockAssetStore),
+		statePacker:   mockStatePacker,
+		useStoreInTx: func(handler StoreTxHandler) error {
+			err := handler(mockTxStore)
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+		memoryStore:      mockMemoryStore,
+		nodeSigner:       nodeSigner,
+		nodeAddress:      nodeAddress,
+		minChallenge:     minChallenge,
+		metrics:          metrics.NewNoopRuntimeMetricExporter(),
+		maxSessionKeyIDs: 256,
+		actionGateway:    &MockActionGateway{},
+	}
+
+	// Test data - derive senderWallet from a user signer key
+	userSigner := NewMockSigner()
+	userWalletSigner, _ := core.NewChannelDefaultSigner(userSigner)
+	senderWallet := userSigner.PublicKey().Address().String()
+	receiverWallet := "0x0987654321098765432109876543210987654321"
+	asset := "USDC"
+	homeChannelID := "0xHomeChannel123"
+	transferAmount := decimal.NewFromInt(100)
+
+	// Create sender's current state (before transfer)
+	currentSenderState := core.State{
+		ID:            core.GetStateID(senderWallet, asset, 1, 1),
+		Transition:    core.Transition{},
+		Asset:         asset,
+		UserWallet:    senderWallet,
+		Epoch:         1,
+		Version:       1,
+		HomeChannelID: &homeChannelID,
+		HomeLedger: core.Ledger{
+			TokenAddress: "0xTokenAddress",
+			BlockchainID: 1,
+			UserBalance:  decimal.NewFromInt(500),
+			UserNetFlow:  decimal.NewFromInt(500),
+			NodeBalance:  decimal.NewFromInt(0),
+			NodeNetFlow:  decimal.NewFromInt(0),
+		},
+		EscrowLedger: nil,
+		UserSig:      nil,
+		NodeSig:      nil,
+	}
+
+	// Create incoming sender state (with transfer send transition)
+	incomingSenderState := currentSenderState.NextState()
+
+	// Apply the transfer send transition to update balances
+	_, err := incomingSenderState.ApplyTransferSendTransition(receiverWallet, transferAmount)
+	require.NoError(t, err)
+
+	// Sign the incoming sender state with user's wallet signer (adds 0x01 prefix)
+	mockAssetStore.On("GetTokenDecimals", uint64(1), "0xTokenAddress").Return(uint8(6), nil).Once()
+	packedSenderState, _ := core.PackState(*incomingSenderState, mockAssetStore)
+	userSig, _ := userWalletSigner.Sign(packedSenderState)
+	userSigStr := userSig.String()
+	incomingSenderState.UserSig = &userSigStr
+
+	// Create receiver's current state
+	currentReceiverState := core.State{
+		ID:            core.GetStateID(receiverWallet, asset, 1, 1),
+		Transition:    core.Transition{},
+		Asset:         asset,
+		UserWallet:    receiverWallet,
+		Epoch:         1,
+		Version:       1,
+		HomeChannelID: &homeChannelID,
+		HomeLedger: core.Ledger{
+			TokenAddress: "0xTokenAddress",
+			BlockchainID: 1,
+			UserBalance:  decimal.NewFromInt(200),
+			UserNetFlow:  decimal.NewFromInt(200),
+			NodeBalance:  decimal.NewFromInt(0),
+			NodeNetFlow:  decimal.NewFromInt(0),
+		},
+		EscrowLedger: nil,
+		UserSig:      nil,
+		NodeSig:      nil,
+	}
+
+	// Receiver's last signed state has an active escrow channel
+	escrowChannelID := "0xEscrowChannel456"
+	lastSignedReceiverState := core.State{
+		Asset:           asset,
+		UserWallet:      receiverWallet,
+		Epoch:           1,
+		Version:         1,
+		HomeChannelID:   &homeChannelID,
+		EscrowChannelID: &escrowChannelID,
+	}
+
+	// Mock expectations
+	mockAssetStore.On("GetAssetDecimals", asset).Return(uint8(6), nil)
+	mockAssetStore.On("GetTokenDecimals", uint64(1), "0xTokenAddress").Return(uint8(6), nil)
+	mockTxStore.On("LockUserState", senderWallet, asset).Return(decimal.Zero, nil)
+	mockTxStore.On("CheckOpenChannel", senderWallet, asset).Return("0x03", true, nil)
+	mockTxStore.On("GetLastUserState", senderWallet, asset, false).Return(currentSenderState, nil)
+	mockTxStore.On("EnsureNoOngoingStateTransitions", senderWallet, asset).Return(nil)
+	mockStatePacker.On("PackState", mock.Anything).Return(packedSenderState, nil).Maybe()
+
+	// For issueTransferReceiverState - receiver has an active escrow lock
+	mockTxStore.On("LockUserState", receiverWallet, asset).Return(decimal.Zero, nil)
+	mockTxStore.On("GetLastUserState", receiverWallet, asset, false).Return(currentReceiverState, nil)
+	mockTxStore.On("GetLastUserState", receiverWallet, asset, true).Return(lastSignedReceiverState, nil)
+
+	// Create RPC request
+	rpcState := toRPCState(*incomingSenderState)
+	reqPayload := rpc.ChannelsV1SubmitStateRequest{
+		State: rpcState,
+	}
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	rpcRequest := rpc.Message{
+		Method:  "channels.v1.submit_state",
+		Payload: payload,
+	}
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpcRequest,
+	}
+
+	// Execute
+	handler.SubmitState(ctx)
+
+	// Assert - should fail because receiver has an active escrow lock
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.NotNil(t, respErr, "Expected error when receiver has active escrow lock")
+	assert.Contains(t, respErr.Error(), "last signed state is a lock with escrow channel")
+
+	mockTxStore.AssertExpectations(t)
+}
+
 func TestSubmitState_EscrowLock_Success(t *testing.T) {
 	t.Skip("transition is not supported yet")
 	// Setup


### PR DESCRIPTION
## Description

When a sender submits a `TransferSend`, the node automatically enters the receiver-side path and calls `issueTransferReceiverState`. That function creates and stores a new `TransferReceive` state for the receiver’s channel, even if the receiver’s latest signed state is already in an escrow phase such as `MutualLock` or `EscrowLock`.  As a result, an inbound transfer still advances the receiver’s channel state while the receiver is in the middle of a suspended escrow flow.
That breaks the normal completion path when the receiver later tries to complete the escrow flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added validation to reject release or transfer operations when the receiver has an active escrow lock, with appropriate error messaging.

* **Tests**
  * Added test cases to validate error handling for escrow lock scenarios in both app session and channel operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->