### PR TITLE
H-I01: docs(contracts): note that fee-on-transfer tokens are not supported

### DIFF
--- a/contracts/SECURITY.md
+++ b/contracts/SECURITY.md
@@ -362,14 +362,17 @@ When a **node** employs SessionKeyValidator (NOT RECOMMENDED):
 
 ## Unsupported Token Types
 
+Only standard ERC20 tokens and native ETH are supported. The following token types are incompatible with the static ledger model (`_nodeBalances`, `lockedFunds`) that only updates on explicit deposit and withdrawal events. There is no hard-coded guardrail preventing deposit of these tokens — the contract will accept them, but any discrepancy will produce undefined accounting behavior for all users of that token. Enforcement is off-chain: the Node will not sign states that reference unsupported token types.
+
 ### Rebasing tokens
 
-Rebasing tokens (e.g. stETH, aTokens, rebase stablecoins) are **not supported**. The protocol uses a static ledger (`_nodeBalances`, `lockedFunds`) that only updates on explicit deposit and withdrawal events.
-When a rebasing token adjusts balances autonomously, the ledger permanently diverges from the actual contract balance. A negative rebase creates an insolvency condition: the ledger overstates holdings, so late withdrawers may receive less than recorded or nothing at all, and any deferred reclaim obligations become unfulfillable.
-
-There is no hard-coded guardrail that prevents depositing a rebasing token — the contract will accept it, but any autonomous balance change will diverge from the recorded ledger, producing undefined accounting behavior for all users of that token.
+Rebasing tokens (e.g. stETH, aTokens, rebase stablecoins) are **not supported**. When a rebasing token adjusts balances autonomously, the ledger permanently diverges from the actual contract balance. A negative rebase creates an insolvency condition: the ledger overstates holdings, so late withdrawers may receive less than recorded or nothing at all, and any deferred reclaim obligations become unfulfillable.
 
 Use non-rebasing equivalents where available (e.g. wstETH instead of stETH).
+
+### Fee-on-transfer tokens
+
+Fee-on-transfer tokens are **not supported**. The amount received by the contract is less than the amount recorded in the ledger, causing it to overstate holdings from the very first deposit. This produces the same class of insolvency as a negative rebase: late withdrawers may receive less than recorded or nothing at all.
 
 ---
 

--- a/contracts/src/ChannelHub.sol
+++ b/contracts/src/ChannelHub.sol
@@ -30,6 +30,20 @@ import {EcdsaSignatureUtils} from "./sigValidators/EcdsaSignatureUtils.sol";
  * @title ChannelHub
  * @notice Main contract implementing the Nitrolite state channel protocol (single-chain operations)
  * @dev Uses unified transition pattern with ChannelEngine library for validation
+ *
+ * TOKEN COMPATIBILITY:
+ *
+ * Only standard ERC20 tokens and native ETH are supported. The following token types are
+ * incompatible with the static ledger model and must not be used:
+ *
+ * - Rebasing tokens (e.g. stETH, aTokens): their autonomous balance changes are invisible to the
+ *   ledger and create unrecoverable accounting divergence. Use non-rebasing wrappers (e.g. wstETH).
+ * - Fee-on-transfer tokens: the amount received by the contract is less than the amount recorded,
+ *   causing the ledger to overstate holdings from the very first deposit.
+ *
+ * There is no hard-coded guardrail preventing deposit of these tokens — the contract will accept
+ * them, but any discrepancy will produce undefined accounting behavior for all users of that token.
+ * Enforcement is off-chain: the Node will not sign states that reference unsupported token types.
  */
 contract ChannelHub is ReentrancyGuard {
     using EnumerableSet for EnumerableSet.Bytes32Set;
@@ -301,12 +315,6 @@ contract ChannelHub is ReentrancyGuard {
     // inflate _nodeBalances during ERC777/hook callbacks, enabling read-only reentrancy for
     // external protocols querying getNodeBalance(). Contrast with withdrawFromNode, which uses
     // CEI (decrement before push) to prevent re-entrancy drains.
-    // NOTE: rebasing tokens (e.g. stETH, aTokens) are NOT supported. The node balance accounting
-    // uses a static ledger that does not reflect autonomous balance changes from rebases.
-    // There is no hard-coded guardrail that prevents depositing a rebasing token — the contract
-    // will accept it, but any autonomous balance change will diverge from the recorded ledger,
-    // producing undefined accounting behavior for all users of that token. Use non-rebasing
-    // wrappers instead (e.g. wstETH instead of stETH).
     function depositToNode(address token, uint256 amount) external payable {
         require(amount > 0, IncorrectAmount());
 

--- a/protocol-description.md
+++ b/protocol-description.md
@@ -560,9 +560,12 @@ This works because `prevStoredState` was swapped during `INITIATE_MIGRATION`.
 
 * **Token compatibility**:
 
-only standard (non-rebasing) ERC20 tokens and native ETH are supported. Rebasing tokens (e.g. stETH, aTokens) must not be used — their autonomous balance changes are invisible to the static ledger and create unrecoverable accounting divergence. Use non-rebasing wrappers instead (e.g. wstETH).
+  Only standard ERC20 tokens and native ETH are supported. The following token types are incompatible with the static ledger model:
 
-There is no hard-coded guardrail that prevents depositing a rebasing token — the contract will accept it, but any autonomous balance change will diverge from the recorded ledger, producing undefined accounting behavior for all users of that token.
+  * **Rebasing tokens** (e.g. stETH, aTokens): their autonomous balance changes are invisible to the ledger and create unrecoverable accounting divergence. Use non-rebasing wrappers instead (e.g. wstETH).
+  * **Fee-on-transfer tokens**: the amount received by the contract is less than the amount recorded, causing the ledger to overstate holdings from the very first deposit.
+
+  There is no hard-coded guardrail preventing deposit of these tokens — the contract will accept them, but any discrepancy will produce undefined accounting behavior for all users of that token. Enforcement is off-chain: the Node will not sign states that reference unsupported token types.
 
 * **Transfer failure resilience**: Outbound transfers (to users) never revert on failure:
 


### PR DESCRIPTION
## Description

The `_pullFunds(...)` function credits accounting entries with the full requested amount without verifying actual tokens received, causing permanent insolvency with fee-on-transfer tokens. When `depositToVault(...)`, channel funding operations, or cross-chain escrow operations pull fee-on-transfer tokens, the contract receives less than credited (e.g., 900 tokens received but 1000 credited). This creates accounting shortfalls that compound with each deposit. The asymmetry with `_pushFunds(...)` (which explicitly checks balance changes with comment 'Use balance-checking approach for maximum robustness' at L1329) confirms this is unintended. The vulnerability affects vault deposits, channel state transitions, and cross-chain escrow operations. The permissionless nature of `depositToVault(...)` (anyone can deposit any token to any node's vault) enables griefing attacks. Popular upgradeable tokens like USDT/USDC could add fees via upgrade, instantly triggering network-wide insolvency.

## Impact

Permanent protocol insolvency and loss of funds. Last withdrawers cannot claim their funds as demonstrated in the PoC. Affects three critical areas:

1. Node vault operations - accounting inflation prevents withdrawals
2. Channel operations - locked funds accounting becomes corrupted when users deposit fee-on-transfer tokens
3. Cross-chain escrow - creates accounting mismatches across chains

No recovery mechanism exists. Attackers can intentionally poison all nodes by depositing minimal amounts of fee-on-transfer tokens. If major stablecoins like USDT/USDC add fees via upgrade, every node using these tokens becomes instantly insolvent, causing systematic protocol failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified token compatibility across security and protocol documentation
  * Explicitly documented that only standard ERC20 tokens and native ETH are supported
  * Added detailed explanation of incompatibility with rebasing tokens and fee-on-transfer tokens
  * Documented off-chain enforcement of unsupported token restrictions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->