### PR TITLE
M-H08: enforce strict transition ordering after MutualLock and EscrowLock

### DIFF
--- a/pkg/core/state_advancer.go
+++ b/pkg/core/state_advancer.go
@@ -94,6 +94,17 @@ func (v *StateAdvancerV1) ValidateAdvancement(currentState, proposedState State)
 
 	lastTransition := currentState.Transition
 
+	switch lastTransition.Type {
+	case TransitionTypeMutualLock:
+		if newTransition.Type != TransitionTypeEscrowDeposit {
+			return fmt.Errorf("after mutual lock, only escrow deposit is allowed, got: %d", newTransition.Type)
+		}
+	case TransitionTypeEscrowLock:
+		if newTransition.Type != TransitionTypeEscrowWithdraw {
+			return fmt.Errorf("after escrow lock, only escrow withdraw is allowed, got: %d", newTransition.Type)
+		}
+	}
+
 	switch newTransition.Type {
 	case TransitionTypeVoid:
 		return fmt.Errorf("cannot apply void transition as new transition")

--- a/pkg/core/state_advancer_test.go
+++ b/pkg/core/state_advancer_test.go
@@ -31,6 +31,66 @@ func newMutualLockState(t *testing.T, amount decimal.Decimal) *State {
 	return state
 }
 
+func newEscrowLockState(t *testing.T, amount decimal.Decimal) *State {
+	t.Helper()
+	userWallet := "0xUser"
+	asset := "USDC"
+	chanID := "0xHomeChannelId"
+
+	state := NewVoidState(asset, userWallet)
+	state.Version = 5
+	state.HomeChannelID = &chanID
+	state.ID = GetStateID(userWallet, asset, 0, 5)
+	state.HomeLedger.TokenAddress = "0xToken"
+	state.HomeLedger.BlockchainID = 1
+	state.HomeLedger.UserBalance = amount
+
+	_, err := state.ApplyEscrowLockTransition(2, "0xForeignToken", amount)
+	require.NoError(t, err)
+
+	sig := "0xSig"
+	state.UserSig = &sig
+	state.NodeSig = &sig
+
+	return state
+}
+
+func TestValidateAdvancement_StrictTransitionOrdering(t *testing.T) {
+	t.Parallel()
+
+	advancer := NewStateAdvancerV1(newMockAssetStore())
+	amount := decimal.NewFromInt(10)
+	sig := "0xSig"
+
+	t.Run("reject_non_escrow_deposit_after_mutual_lock", func(t *testing.T) {
+		t.Parallel()
+		mutualLockState := newMutualLockState(t, amount)
+
+		proposed := mutualLockState.NextState()
+		_, err := proposed.ApplyHomeDepositTransition(amount)
+		require.NoError(t, err)
+		proposed.UserSig = &sig
+
+		err = advancer.ValidateAdvancement(*mutualLockState, *proposed)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "after mutual lock, only escrow deposit is allowed")
+	})
+
+	t.Run("reject_non_escrow_withdraw_after_escrow_lock", func(t *testing.T) {
+		t.Parallel()
+		escrowLockState := newEscrowLockState(t, amount)
+
+		proposed := escrowLockState.NextState()
+		_, err := proposed.ApplyHomeDepositTransition(amount)
+		require.NoError(t, err)
+		proposed.UserSig = &sig
+
+		err = advancer.ValidateAdvancement(*escrowLockState, *proposed)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "after escrow lock, only escrow withdraw is allowed")
+	})
+}
+
 func TestValidateAdvancement_EscrowDeposit(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -264,7 +264,7 @@ func TestClient_SubmitAppSessionDeposit(t *testing.T) {
 				Decimals:              6,
 				SuggestedBlockchainID: "137",
 				Tokens: []rpc.TokenV1{
-					{BlockchainID: "137", Address: "0xToken"},
+					{BlockchainID: "137", Address: "0xToken", Decimals: 6},
 				},
 			},
 		},


### PR DESCRIPTION
## Description
The state advancer validated that `EscrowDeposit` must follow `MutualLock` and `EscrowWithdraw` must follow `EscrowLock`, but did not enforce the inverse constraint. After a `MutualLock` transition, any other transition type (e.g., `HomeDeposit`, `TransferSend`, `Commit`) could be proposed and would bypass the escrow deposit requirement. The same applied to `EscrowLock` — transitions other than `EscrowWithdraw` were not rejected.

### Impact
A user could skip the escrow deposit/withdraw step after locking, potentially leaving the channel in an inconsistent state where funds are locked but the corresponding escrow operation never completes.