### PR TITLE
M-L05: docs(contracts): document native token deposits

### DIFF
--- a/contracts/SECURITY.md
+++ b/contracts/SECURITY.md
@@ -377,6 +377,34 @@ Fee-on-transfer tokens are **not supported**. The amount received by the contrac
 
 ---
 
+## Native ETH vs ERC20 Deposit Asymmetry
+
+`_pullFunds(from, token, amount)` enforces different funding mechanics depending on the asset type:
+
+- **ERC20 (`token != address(0)`)**: Calls `IERC20.safeTransferFrom(from, address(this), amount)`. Funds are pulled from the `from` address using a prior ERC20 allowance. Any caller can submit a signed state that triggers a deposit, and the funds come from the user's approval — the caller does not need to supply capital.
+
+- **Native ETH (`token == address(0)`)**: Requires `msg.value == amount`. The **caller** must attach the exact ETH amount, regardless of who the logical `from` address is. The `from` parameter is effectively ignored for the funding step.
+
+### Affected operations
+
+This asymmetry applies to every operation where `_pullFunds` is called with `from = user`:
+
+| Call site | Context |
+|-----------|---------|
+| `_applyEffects` | Channel deposits (`DEPOSIT` intent) |
+| `_applyEscrowDepositEffects` | Escrow deposit initiation (user funds on non-home chain) |
+| `_applyEscrowWithdrawalEffects` | Escrow withdrawal finalization (user funds on non-home chain) |
+
+`depositToNode()` is not affected — it always uses `from = msg.sender`.
+
+### Practical consequence
+
+For ERC20 channels, any party holding a valid signed state that requires a user deposit can submit it on-chain, and the user's pre-approved funds are pulled automatically. For native ETH channels, only a caller willing to supply the required `msg.value` can submit such a state. In practice, this means native ETH deposit states must be submitted by the user themselves (or by a party willing to front the ETH on their behalf).
+
+Integrators building relayers or third-party submission flows should account for this difference: ERC20 state submissions are permissionless given prior user approval, while native ETH state submissions that require user funds are not.
+
+---
+
 ## ERC20 Transfer Failure Attack Vectors
 
 ### Background

--- a/contracts/SECURITY.md
+++ b/contracts/SECURITY.md
@@ -379,23 +379,21 @@ Fee-on-transfer tokens are **not supported**. The amount received by the contrac
 
 ## Native ETH vs ERC20 Deposit Asymmetry
 
-`_pullFunds(from, token, amount)` enforces different funding mechanics depending on the asset type:
+When pulling funds from a user, ERC20 and native ETH behave differently:
 
-- **ERC20 (`token != address(0)`)**: Calls `IERC20.safeTransferFrom(from, address(this), amount)`. Funds are pulled from the `from` address using a prior ERC20 allowance. Any caller can submit a signed state that triggers a deposit, and the funds come from the user's approval — the caller does not need to supply capital.
+- **ERC20**: Funds are pulled via `transferFrom` using a prior user allowance. Any caller can submit a signed state that triggers a deposit — the funds come from the user's approval.
 
-- **Native ETH (`token == address(0)`)**: Requires `msg.value == amount`. The **caller** must attach the exact ETH amount, regardless of who the logical `from` address is. The `from` parameter is effectively ignored for the funding step.
+- **Native ETH**: The caller must attach the exact `msg.value`. Whoever submits the transaction must supply the ETH, regardless of who the logical depositor is.
 
 ### Affected operations
 
-This asymmetry applies to every operation where `_pullFunds` is called with `from = user`:
+This asymmetry applies to every operation that pulls funds from the user:
 
-| Call site | Context |
-|-----------|---------|
-| `_applyEffects` | Channel deposits (`DEPOSIT` intent) |
-| `_applyEscrowDepositEffects` | Escrow deposit initiation (user funds on non-home chain) |
-| `_applyEscrowWithdrawalEffects` | Escrow withdrawal finalization (user funds on non-home chain) |
-
-`depositToNode()` is not affected — it always uses `from = msg.sender`.
+| Function | Context |
+|----------|---------|
+| `createChannel` | Initial deposit on channel creation (`DEPOSIT` intent) |
+| `depositToChannel` | Channel deposit |
+| `initiateEscrowDeposit` | Escrow deposit initiation (non-home chain) |
 
 ### Practical consequence
 

--- a/contracts/src/ChannelHub.sol
+++ b/contracts/src/ChannelHub.sol
@@ -44,6 +44,12 @@ import {EcdsaSignatureUtils} from "./sigValidators/EcdsaSignatureUtils.sol";
  * There is no hard-coded guardrail preventing deposit of these tokens — the contract will accept
  * them, but any discrepancy will produce undefined accounting behavior for all users of that token.
  * Enforcement is off-chain: the Node will not sign states that reference unsupported token types.
+ *
+ * NATIVE ETH vs ERC20 DEPOSIT ASYMMETRY:
+ *
+ * When user funds are pulled, ERC20 uses `transferFrom` (caller-agnostic, requires prior approval),
+ * while native ETH requires `msg.value == amount` (the transaction submitter must supply the ETH).
+ * For native ETH channels, deposit states must therefore be submitted by the user or a willing proxy.
  */
 contract ChannelHub is ReentrancyGuard {
     using EnumerableSet for EnumerableSet.Bytes32Set;
@@ -500,6 +506,7 @@ contract ChannelHub is ReentrancyGuard {
     // Create channel with DEPOSIT, WITHDRAW, or OPERATE intent
     // This enables users who already have off-chain virtual states with non-zero version
     // to create a channel and perform initial operation simultaneously
+    // NOTE: For native ETH channels with DEPOSIT intent, msg.sender must supply msg.value == deposit amount.
     function createChannel(ChannelDefinition calldata def, State calldata initState) external payable {
         require(
             initState.intent == StateIntent.DEPOSIT || initState.intent == StateIntent.WITHDRAW
@@ -537,6 +544,7 @@ contract ChannelHub is ReentrancyGuard {
         emit ChannelCreated(channelId, user, def, initState);
     }
 
+    // NOTE: For native ETH channels, msg.sender must supply msg.value == deposit amount.
     function depositToChannel(bytes32 channelId, State calldata candidate) public payable {
         require(candidate.intent == StateIntent.DEPOSIT, IncorrectStateIntent());
 
@@ -674,6 +682,7 @@ contract ChannelHub is ReentrancyGuard {
 
     // ========= Cross-Chain Functions ==========
 
+    // NOTE: On non-home chain, user funds are pulled. For native ETH, msg.sender must supply msg.value == deposit amount.
     function initiateEscrowDeposit(ChannelDefinition calldata def, State calldata candidate) external payable {
         require(candidate.intent == StateIntent.INITIATE_ESCROW_DEPOSIT, IncorrectStateIntent());
         _requireValidDefinition(def);

--- a/protocol-description.md
+++ b/protocol-description.md
@@ -211,6 +211,8 @@ Off-chain activity can continue indefinitely between enforcements.
   * funds are pulled from User,
   * locked into the channel.
 
+**Native ETH vs ERC20 deposit mechanics:** For ERC20 tokens, the contract pulls funds from the user's address via `safeTransferFrom` using a prior allowance — any party can submit the signed state and the user's approved funds are transferred. For native ETH (`token = address(0)`), the **caller** must attach the required amount as `msg.value`. This means native ETH deposit states must be submitted by the user (or by a party willing to supply the ETH on their behalf). This asymmetry also applies to escrow deposit initiation and escrow withdrawal finalization on the non-home chain.
+
 ---
 
 ### 4. Withdrawal (single-chain)


### PR DESCRIPTION
## Description

`_pullFunds()` enforces different funding mechanics for native assets vs ERC20. When `token == address(0)`, it requires `msg.value == amount`, so the caller must supply native funds even if the logical funding party is `def.user`. By contrast, the ERC20 path uses `IERC20.safeTransferFrom()` with the from address’ allowance.
In result, state submissions that require funds movement cannot be enforced by anyone, unless they are willing to pay for it. This asymmetry is not obvious from `createChannel()` / `depositToChannel()` and can surprise integrators who assume identical funding mechanics across asset types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation clarifying deposit mechanics for native ETH versus ERC20 tokens, detailing submission requirements and transaction caller responsibilities across deposit flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->