### PR TITLE
fix(clearnode): resolve a set of audit findings

### DIFF
--- a/clearnode/api/app_session_v1/rebalance_app_sessions.go
+++ b/clearnode/api/app_session_v1/rebalance_app_sessions.go
@@ -162,6 +162,14 @@ func (h *Handler) RebalanceAppSessions(c *rpc.Context) {
 						alloc.Amount, alloc.Asset, update.AppStateUpdate.AppSessionID)
 				}
 
+				// Reject duplicate (participant, asset) entries
+				if newAllocations[alloc.Participant] != nil {
+					if _, exists := newAllocations[alloc.Participant][alloc.Asset]; exists {
+						return rpc.Errorf("duplicate allocation for participant %s, asset %s in session %s",
+							alloc.Participant, alloc.Asset, update.AppStateUpdate.AppSessionID)
+					}
+				}
+
 				if newAllocations[alloc.Participant] == nil {
 					newAllocations[alloc.Participant] = make(map[string]decimal.Decimal)
 				}

--- a/clearnode/api/app_session_v1/rebalance_app_sessions_test.go
+++ b/clearnode/api/app_session_v1/rebalance_app_sessions_test.go
@@ -1124,3 +1124,133 @@ func TestRebalanceAppSessions_AppRegistryDisabled(t *testing.T) {
 	mockStore.AssertNotCalled(t, "GetApp", mock.Anything)
 	mockStore.AssertExpectations(t)
 }
+
+func TestRebalanceAppSessions_Error_DuplicateAllocation(t *testing.T) {
+	mockStore := new(MockStore)
+
+	storeTxProvider := func(fn StoreTxHandler) error {
+		return fn(mockStore)
+	}
+
+	handler := NewHandler(
+		storeTxProvider,
+		nil,
+		&MockActionGateway{},
+		nil,
+		nil,
+		nil,
+		"0xNode",
+		true,
+		metrics.NewNoopRuntimeMetricExporter(),
+		32, 1024, 256, 16,
+	)
+
+	wallet1 := NewTestAppSessionWallet(t)
+	wallet2 := NewTestAppSessionWallet(t)
+
+	sessionID1 := "0x1111111111111111111111111111111111111111111111111111111111111111"
+	sessionID2 := "0x2222222222222222222222222222222222222222222222222222222222222222"
+
+	session1 := &app.AppSessionV1{
+		SessionID:     sessionID1,
+		ApplicationID: "test-app",
+		Participants: []app.AppParticipantV1{
+			{WalletAddress: wallet1.Address, SignatureWeight: 10},
+		},
+		Quorum:  10,
+		Status:  app.AppSessionStatusOpen,
+		Version: 1,
+	}
+
+	session2 := &app.AppSessionV1{
+		SessionID:     sessionID2,
+		ApplicationID: "test-app",
+		Participants: []app.AppParticipantV1{
+			{WalletAddress: wallet2.Address, SignatureWeight: 10},
+		},
+		Quorum:  10,
+		Status:  app.AppSessionStatusOpen,
+		Version: 1,
+	}
+
+	currentAllocations1 := map[string]map[string]decimal.Decimal{
+		wallet1.Address: {"USDC": decimal.NewFromInt(200)},
+	}
+
+	currentAllocations2 := map[string]map[string]decimal.Decimal{
+		wallet2.Address: {"USDC": decimal.NewFromInt(50)},
+	}
+
+	// Session 1 has duplicate (wallet1, USDC) allocations
+	appStateUpdate1 := app.AppStateUpdateV1{
+		AppSessionID: sessionID1,
+		Intent:       app.AppStateUpdateIntentRebalance,
+		Version:      2,
+		Allocations: []app.AppAllocationV1{
+			{Participant: wallet1.Address, Asset: "USDC", Amount: decimal.NewFromInt(100)},
+			{Participant: wallet1.Address, Asset: "USDC", Amount: decimal.NewFromInt(50)}, // duplicate
+		},
+	}
+	sig1 := wallet1.SignAppStateUpdate(t, appStateUpdate1)
+
+	appStateUpdate2 := app.AppStateUpdateV1{
+		AppSessionID: sessionID2,
+		Intent:       app.AppStateUpdateIntentRebalance,
+		Version:      2,
+		Allocations: []app.AppAllocationV1{
+			{Participant: wallet2.Address, Asset: "USDC", Amount: decimal.NewFromInt(100)},
+		},
+	}
+	sig2 := wallet2.SignAppStateUpdate(t, appStateUpdate2)
+
+	reqPayload := rpc.AppSessionsV1RebalanceAppSessionsRequest{
+		SignedUpdates: []rpc.SignedAppStateUpdateV1{
+			{
+				AppStateUpdate: rpc.AppStateUpdateV1{
+					AppSessionID: sessionID1,
+					Intent:       app.AppStateUpdateIntentRebalance,
+					Version:      "2",
+					Allocations: []rpc.AppAllocationV1{
+						{Participant: wallet1.Address, Asset: "USDC", Amount: "100"},
+						{Participant: wallet1.Address, Asset: "USDC", Amount: "50"}, // duplicate
+					},
+				},
+				QuorumSigs: []string{sig1},
+			},
+			{
+				AppStateUpdate: rpc.AppStateUpdateV1{
+					AppSessionID: sessionID2,
+					Intent:       app.AppStateUpdateIntentRebalance,
+					Version:      "2",
+					Allocations: []rpc.AppAllocationV1{
+						{Participant: wallet2.Address, Asset: "USDC", Amount: "100"},
+					},
+				},
+				QuorumSigs: []string{sig2},
+			},
+		},
+	}
+
+	mockStore.On("GetApp", mock.Anything).Return(&app.AppInfoV1{
+		App: app.AppV1{ID: "test-app", OwnerWallet: "0x0000000000000000000000000000000000000001"},
+	}, nil)
+	mockStore.On("GetAppSession", sessionID1).Return(session1, nil)
+	mockStore.On("GetParticipantAllocations", sessionID1).Return(currentAllocations1, nil)
+	// Session 2 mocks in case session 1 processing doesn't fail first
+	mockStore.On("GetAppSession", sessionID2).Return(session2, nil).Maybe()
+	mockStore.On("GetParticipantAllocations", sessionID2).Return(currentAllocations2, nil).Maybe()
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, "app_sessions.v1.rebalance_app_sessions", payload),
+	}
+
+	handler.RebalanceAppSessions(ctx)
+
+	assertError(t, ctx, "duplicate allocation")
+
+	mockStore.AssertNotCalled(t, "RecordLedgerEntry", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}

--- a/clearnode/api/app_session_v1/submit_app_state.go
+++ b/clearnode/api/app_session_v1/submit_app_state.go
@@ -205,6 +205,13 @@ func (h *Handler) handleOperateIntent(
 			return rpc.Errorf("invalid amount for allocation with asset %s and participant %s: %w", alloc.Asset, alloc.Participant, err)
 		}
 
+		// Reject duplicate (participant, asset) entries
+		if incomingAllocations[alloc.Participant] != nil {
+			if _, exists := incomingAllocations[alloc.Participant][alloc.Asset]; exists {
+				return rpc.Errorf("duplicate allocation for participant %s, asset %s", alloc.Participant, alloc.Asset)
+			}
+		}
+
 		// Sum up allocations per asset
 		if existing, ok := allocationSum[alloc.Asset]; ok {
 			allocationSum[alloc.Asset] = existing.Add(alloc.Amount)
@@ -317,6 +324,13 @@ func (h *Handler) handleWithdrawIntent(
 			return rpc.Errorf("negative allocation: %s for asset %s", alloc.Amount, alloc.Asset)
 		}
 
+		// Reject duplicate (participant, asset) entries
+		if incomingAllocations[alloc.Participant] != nil {
+			if _, exists := incomingAllocations[alloc.Participant][alloc.Asset]; exists {
+				return rpc.Errorf("duplicate allocation for participant %s, asset %s", alloc.Participant, alloc.Asset)
+			}
+		}
+
 		// Check for new allocations (reject if current is zero but incoming is non-zero)
 		if !alloc.Amount.IsZero() {
 			currentAmount := decimal.Zero
@@ -403,6 +417,13 @@ func (h *Handler) handleCloseIntent(
 
 		if alloc.Amount.IsNegative() {
 			return rpc.Errorf("negative allocation: %s for asset %s", alloc.Amount, alloc.Asset)
+		}
+
+		// Reject duplicate (participant, asset) entries
+		if incomingAllocations[alloc.Participant] != nil {
+			if _, exists := incomingAllocations[alloc.Participant][alloc.Asset]; exists {
+				return rpc.Errorf("duplicate allocation for participant %s, asset %s", alloc.Participant, alloc.Asset)
+			}
 		}
 
 		if incomingAllocations[alloc.Participant] == nil {

--- a/clearnode/api/app_session_v1/submit_app_state_test.go
+++ b/clearnode/api/app_session_v1/submit_app_state_test.go
@@ -1720,3 +1720,109 @@ func TestSubmitAppState_AppRegistryDisabled(t *testing.T) {
 	mockStore.AssertNotCalled(t, "GetApp", mock.Anything)
 	mockStore.AssertExpectations(t)
 }
+
+func TestSubmitAppState_OperateIntent_DuplicateAllocation_Rejected(t *testing.T) {
+	// Setup
+	mockStore := new(MockStore)
+	storeTxProvider := func(fn StoreTxHandler) error {
+		return fn(mockStore)
+	}
+
+	mockSigner := NewMockChannelSigner()
+	mockAssetStore := new(MockAssetStore)
+	mockStatePacker := new(MockStatePacker)
+
+	handler := NewHandler(
+		storeTxProvider,
+		mockAssetStore,
+		&MockActionGateway{},
+		mockSigner,
+		core.NewStateAdvancerV1(mockAssetStore),
+		mockStatePacker,
+		"0xNode",
+		true,
+		metrics.NewNoopRuntimeMetricExporter(),
+		32, 1024, 256, 16,
+	)
+
+	appSessionID := "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+	wallet1 := NewTestAppSessionWallet(t)
+	participant1 := wallet1.Address
+	participant2 := "0x2222222222222222222222222222222222222222"
+
+	existingSession := &app.AppSessionV1{
+		SessionID:     appSessionID,
+		ApplicationID: "test-app",
+		Participants: []app.AppParticipantV1{
+			{WalletAddress: participant1, SignatureWeight: 5},
+			{WalletAddress: participant2, SignatureWeight: 5},
+		},
+		Quorum:  5,
+		Status:  app.AppSessionStatusOpen,
+		Version: 1,
+	}
+
+	currentAllocations := map[string]map[string]decimal.Decimal{
+		participant1: {"USDC": decimal.NewFromInt(50)},
+		participant2: {"USDC": decimal.NewFromInt(50)},
+	}
+
+	// Craft a malicious payload with duplicate (participant, asset) entries.
+	// The first entry inflates the sum to pass balance validation while
+	// the second overwrites the per-participant map to zero out balances.
+	appStateUpdateCore := app.AppStateUpdateV1{
+		AppSessionID: appSessionID,
+		Intent:       app.AppStateUpdateIntentOperate,
+		Version:      2,
+		Allocations: []app.AppAllocationV1{
+			{Participant: participant1, Asset: "USDC", Amount: decimal.NewFromInt(100)}, // inflates sum
+			{Participant: participant1, Asset: "USDC", Amount: decimal.NewFromInt(0)},   // duplicate overwrites to 0
+			{Participant: participant2, Asset: "USDC", Amount: decimal.NewFromInt(0)},
+		},
+	}
+	sig1 := wallet1.SignAppStateUpdate(t, appStateUpdateCore)
+
+	reqPayload := rpc.AppSessionsV1SubmitAppStateRequest{
+		AppStateUpdate: rpc.AppStateUpdateV1{
+			AppSessionID: appSessionID,
+			Intent:       app.AppStateUpdateIntentOperate,
+			Version:      "2",
+			Allocations: []rpc.AppAllocationV1{
+				{Participant: participant1, Asset: "USDC", Amount: "100"},
+				{Participant: participant1, Asset: "USDC", Amount: "0"}, // duplicate
+				{Participant: participant2, Asset: "USDC", Amount: "0"},
+			},
+		},
+		QuorumSigs: []string{sig1},
+	}
+
+	sessionBalances := map[string]decimal.Decimal{
+		"USDC": decimal.NewFromInt(100),
+	}
+
+	mockStore.On("GetApp", "test-app").Return(&app.AppInfoV1{
+		App: app.AppV1{ID: "test-app", OwnerWallet: "0x0000000000000000000000000000000000000001"},
+	}, nil).Maybe()
+	mockStore.On("GetAppSession", appSessionID).Return(existingSession, nil)
+	mockStore.On("GetParticipantAllocations", appSessionID).Return(currentAllocations, nil)
+	mockStore.On("GetAppSessionBalances", appSessionID).Return(sessionBalances, nil)
+	mockAssetStore.On("GetAssetDecimals", "USDC").Return(uint8(6), nil)
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, string(rpc.AppSessionsV1SubmitAppStateMethod), payload),
+	}
+
+	handler.SubmitAppState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.NotNil(t, respErr, "expected error for duplicate allocation")
+	assert.Contains(t, respErr.Error(), "duplicate allocation")
+
+	// RecordLedgerEntry must never be called — the request should be rejected before ledger writes
+	mockStore.AssertNotCalled(t, "RecordLedgerEntry", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}

--- a/clearnode/api/app_session_v1/submit_app_state_test.go
+++ b/clearnode/api/app_session_v1/submit_app_state_test.go
@@ -1721,6 +1721,189 @@ func TestSubmitAppState_AppRegistryDisabled(t *testing.T) {
 	mockStore.AssertExpectations(t)
 }
 
+func TestSubmitAppState_WithdrawIntent_DuplicateAllocation_Rejected(t *testing.T) {
+	mockStore := new(MockStore)
+	storeTxProvider := func(fn StoreTxHandler) error {
+		return fn(mockStore)
+	}
+
+	mockSigner := NewMockChannelSigner()
+	mockAssetStore := new(MockAssetStore)
+	mockStatePacker := new(MockStatePacker)
+
+	handler := NewHandler(
+		storeTxProvider,
+		mockAssetStore,
+		&MockActionGateway{},
+		mockSigner,
+		core.NewStateAdvancerV1(mockAssetStore),
+		mockStatePacker,
+		"0xNode",
+		true,
+		metrics.NewNoopRuntimeMetricExporter(),
+		32, 1024, 256, 16,
+	)
+
+	appSessionID := "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+	wallet1 := NewTestAppSessionWallet(t)
+	participant1 := wallet1.Address
+
+	existingSession := &app.AppSessionV1{
+		SessionID:     appSessionID,
+		ApplicationID: "test-app",
+		Participants: []app.AppParticipantV1{
+			{WalletAddress: participant1, SignatureWeight: 10},
+		},
+		Quorum:  10,
+		Status:  app.AppSessionStatusOpen,
+		Version: 1,
+	}
+
+	currentAllocations := map[string]map[string]decimal.Decimal{
+		participant1: {"USDC": decimal.NewFromInt(100)},
+	}
+
+	// Duplicate (participant1, USDC) entries in withdraw intent
+	appStateUpdateCore := app.AppStateUpdateV1{
+		AppSessionID: appSessionID,
+		Intent:       app.AppStateUpdateIntentWithdraw,
+		Version:      2,
+		Allocations: []app.AppAllocationV1{
+			{Participant: participant1, Asset: "USDC", Amount: decimal.NewFromInt(60)},
+			{Participant: participant1, Asset: "USDC", Amount: decimal.NewFromInt(40)}, // duplicate
+		},
+	}
+	sig1 := wallet1.SignAppStateUpdate(t, appStateUpdateCore)
+
+	reqPayload := rpc.AppSessionsV1SubmitAppStateRequest{
+		AppStateUpdate: rpc.AppStateUpdateV1{
+			AppSessionID: appSessionID,
+			Intent:       app.AppStateUpdateIntentWithdraw,
+			Version:      "2",
+			Allocations: []rpc.AppAllocationV1{
+				{Participant: participant1, Asset: "USDC", Amount: "60"},
+				{Participant: participant1, Asset: "USDC", Amount: "40"}, // duplicate
+			},
+		},
+		QuorumSigs: []string{sig1},
+	}
+
+	mockStore.On("GetApp", "test-app").Return(&app.AppInfoV1{
+		App: app.AppV1{ID: "test-app", OwnerWallet: "0x0000000000000000000000000000000000000001"},
+	}, nil).Maybe()
+	mockStore.On("GetAppSession", appSessionID).Return(existingSession, nil)
+	mockStore.On("GetParticipantAllocations", appSessionID).Return(currentAllocations, nil)
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, string(rpc.AppSessionsV1SubmitAppStateMethod), payload),
+	}
+
+	handler.SubmitAppState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.NotNil(t, respErr, "expected error for duplicate allocation")
+	assert.Contains(t, respErr.Error(), "duplicate allocation")
+
+	mockStore.AssertNotCalled(t, "RecordLedgerEntry", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestSubmitAppState_CloseIntent_DuplicateAllocation_Rejected(t *testing.T) {
+	mockStore := new(MockStore)
+	storeTxProvider := func(fn StoreTxHandler) error {
+		return fn(mockStore)
+	}
+
+	mockSigner := NewMockChannelSigner()
+	mockAssetStore := new(MockAssetStore)
+	mockStatePacker := new(MockStatePacker)
+
+	handler := NewHandler(
+		storeTxProvider,
+		mockAssetStore,
+		&MockActionGateway{},
+		mockSigner,
+		core.NewStateAdvancerV1(mockAssetStore),
+		mockStatePacker,
+		"0xNode",
+		true,
+		metrics.NewNoopRuntimeMetricExporter(),
+		32, 1024, 256, 16,
+	)
+
+	appSessionID := "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+	wallet1 := NewTestAppSessionWallet(t)
+	participant1 := wallet1.Address
+
+	existingSession := &app.AppSessionV1{
+		SessionID:     appSessionID,
+		ApplicationID: "test-app",
+		Participants: []app.AppParticipantV1{
+			{WalletAddress: participant1, SignatureWeight: 10},
+		},
+		Quorum:  10,
+		Status:  app.AppSessionStatusOpen,
+		Version: 1,
+	}
+
+	currentAllocations := map[string]map[string]decimal.Decimal{
+		participant1: {"USDC": decimal.NewFromInt(100)},
+	}
+
+	// Duplicate (participant1, USDC) entries in close intent
+	appStateUpdateCore := app.AppStateUpdateV1{
+		AppSessionID: appSessionID,
+		Intent:       app.AppStateUpdateIntentClose,
+		Version:      2,
+		Allocations: []app.AppAllocationV1{
+			{Participant: participant1, Asset: "USDC", Amount: decimal.NewFromInt(100)},
+			{Participant: participant1, Asset: "USDC", Amount: decimal.NewFromInt(100)}, // duplicate
+		},
+	}
+	sig1 := wallet1.SignAppStateUpdate(t, appStateUpdateCore)
+
+	reqPayload := rpc.AppSessionsV1SubmitAppStateRequest{
+		AppStateUpdate: rpc.AppStateUpdateV1{
+			AppSessionID: appSessionID,
+			Intent:       app.AppStateUpdateIntentClose,
+			Version:      "2",
+			Allocations: []rpc.AppAllocationV1{
+				{Participant: participant1, Asset: "USDC", Amount: "100"},
+				{Participant: participant1, Asset: "USDC", Amount: "100"}, // duplicate
+			},
+		},
+		QuorumSigs: []string{sig1},
+	}
+
+	mockStore.On("GetApp", "test-app").Return(&app.AppInfoV1{
+		App: app.AppV1{ID: "test-app", OwnerWallet: "0x0000000000000000000000000000000000000001"},
+	}, nil).Maybe()
+	mockStore.On("GetAppSession", appSessionID).Return(existingSession, nil)
+	mockStore.On("GetParticipantAllocations", appSessionID).Return(currentAllocations, nil)
+	mockAssetStore.On("GetAssetDecimals", "USDC").Return(uint8(6), nil).Maybe()
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, string(rpc.AppSessionsV1SubmitAppStateMethod), payload),
+	}
+
+	handler.SubmitAppState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.NotNil(t, respErr, "expected error for duplicate allocation")
+	assert.Contains(t, respErr.Error(), "duplicate allocation")
+
+	mockStore.AssertNotCalled(t, "RecordLedgerEntry", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
 func TestSubmitAppState_OperateIntent_DuplicateAllocation_Rejected(t *testing.T) {
 	// Setup
 	mockStore := new(MockStore)

--- a/clearnode/api/app_session_v1/submit_deposit_state.go
+++ b/clearnode/api/app_session_v1/submit_deposit_state.go
@@ -182,6 +182,13 @@ func (h *Handler) SubmitDepositState(c *rpc.Context) {
 				return rpc.Errorf("negative allocation: %s for asset %s", alloc.Amount, alloc.Asset)
 			}
 
+			// Reject duplicate (participant, asset) entries
+			if incomingAllocations[alloc.Participant] != nil {
+				if _, exists := incomingAllocations[alloc.Participant][alloc.Asset]; exists {
+					return rpc.Errorf("duplicate allocation for participant %s, asset %s", alloc.Participant, alloc.Asset)
+				}
+			}
+
 			participantAllocs := currentAllocations[alloc.Participant]
 			if participantAllocs == nil {
 				participantAllocs = make(map[string]decimal.Decimal, 0)

--- a/clearnode/api/app_session_v1/submit_deposit_state.go
+++ b/clearnode/api/app_session_v1/submit_deposit_state.go
@@ -182,6 +182,15 @@ func (h *Handler) SubmitDepositState(c *rpc.Context) {
 				return rpc.Errorf("negative allocation: %s for asset %s", alloc.Amount, alloc.Asset)
 			}
 
+			decimals, err := h.assetStore.GetAssetDecimals(alloc.Asset)
+			if err != nil {
+				return rpc.Errorf("failed to get asset decimals: %v", err)
+			}
+
+			if err := core.ValidateDecimalPrecision(alloc.Amount, decimals); err != nil {
+				return rpc.Errorf("invalid amount for allocation with asset %s and participant %s: %w", alloc.Asset, alloc.Participant, err)
+			}
+
 			// Reject duplicate (participant, asset) entries
 			if incomingAllocations[alloc.Participant] != nil {
 				if _, exists := incomingAllocations[alloc.Participant][alloc.Asset]; exists {

--- a/clearnode/api/app_session_v1/submit_deposit_state_test.go
+++ b/clearnode/api/app_session_v1/submit_deposit_state_test.go
@@ -693,3 +693,265 @@ func TestSubmitDepositState_AppRegistryDisabled(t *testing.T) {
 	mockStore.AssertNotCalled(t, "GetApp", mock.Anything)
 	mockStore.AssertExpectations(t)
 }
+
+func TestSubmitDepositState_DuplicateAllocation_Rejected(t *testing.T) {
+	mockStore := new(MockStore)
+	mockSigner := NewMockChannelSigner()
+	nodeAddress := mockSigner.PublicKey().Address().String()
+	mockAssetStore := new(MockAssetStore)
+	mockStatePacker := new(MockStatePacker)
+
+	handler := &Handler{
+		assetStore:    mockAssetStore,
+		actionGateway: &MockActionGateway{},
+		stateAdvancer: core.NewStateAdvancerV1(mockAssetStore),
+		statePacker:   mockStatePacker,
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockStore)
+		},
+		signer:             mockSigner,
+		nodeAddress:        nodeAddress,
+		appRegistryEnabled: true,
+		metrics:            metrics.NewNoopRuntimeMetricExporter(),
+		maxParticipants:    32,
+		maxSessionData:     1024,
+		maxSessionKeyIDs:   256,
+		maxSignedUpdates:   16,
+	}
+
+	userRawSigner := NewMockSigner()
+	channelWalletSigner, _ := core.NewChannelDefaultSigner(userRawSigner)
+	appWalletSigner, _ := app.NewAppSessionWalletSignerV1(userRawSigner)
+	participant1 := strings.ToLower(userRawSigner.PublicKey().Address().String())
+	participant2 := "0x2222222222222222222222222222222222222222"
+	asset := "USDC"
+	homeChannelID := "0xHomeChannel123"
+	appSessionID := "0xAppSession123"
+
+	existingAppSession := &app.AppSessionV1{
+		SessionID:     appSessionID,
+		ApplicationID: "test-app",
+		Participants: []app.AppParticipantV1{
+			{WalletAddress: participant1, SignatureWeight: 1},
+			{WalletAddress: participant2, SignatureWeight: 1},
+		},
+		Quorum:  1,
+		Nonce:   12345,
+		Status:  app.AppSessionStatusOpen,
+		Version: 1,
+	}
+
+	currentUserState := core.State{
+		ID:         core.GetStateID(participant1, asset, 1, 1),
+		Transition: core.Transition{Type: core.TransitionTypeVoid},
+		Asset:      asset, UserWallet: participant1, Epoch: 1, Version: 1,
+		HomeChannelID: &homeChannelID,
+		HomeLedger: core.Ledger{
+			TokenAddress: "0xTokenAddress", BlockchainID: 1,
+			UserBalance: decimal.NewFromInt(500), UserNetFlow: decimal.NewFromInt(500),
+		},
+	}
+
+	depositAmount := decimal.NewFromInt(100)
+	incomingUserState := currentUserState.NextState()
+	_, err := incomingUserState.ApplyCommitTransition(appSessionID, depositAmount)
+	require.NoError(t, err)
+
+	mockStatePacker.On("PackState", mock.Anything).Return([]byte("packed"), nil)
+	packedUserState, _ := mockStatePacker.PackState(*incomingUserState)
+	userSig, _ := channelWalletSigner.Sign(packedUserState)
+	userSigStr := userSig.String()
+	incomingUserState.UserSig = &userSigStr
+
+	// Duplicate (participant1, USDC) allocations — first inflates sum, second overwrites
+	appStateUpdateCore := app.AppStateUpdateV1{
+		AppSessionID: appSessionID,
+		Intent:       app.AppStateUpdateIntentDeposit,
+		Version:      2,
+		Allocations: []app.AppAllocationV1{
+			{Participant: participant1, Asset: asset, Amount: depositAmount},
+			{Participant: participant1, Asset: asset, Amount: decimal.Zero}, // duplicate
+		},
+	}
+	packedAppUpdate, _ := app.PackAppStateUpdateV1(appStateUpdateCore)
+	appSigBytes, _ := appWalletSigner.Sign(packedAppUpdate)
+	appSigHex := hexutil.Encode(appSigBytes)
+
+	appStateUpdate := rpc.AppStateUpdateV1{
+		AppSessionID: appSessionID,
+		Intent:       app.AppStateUpdateIntentDeposit,
+		Version:      "2",
+		Allocations: []rpc.AppAllocationV1{
+			{Participant: participant1, Asset: asset, Amount: depositAmount.String()},
+			{Participant: participant1, Asset: asset, Amount: "0"}, // duplicate
+		},
+	}
+
+	mockStore.On("GetApp", "test-app").Return(&app.AppInfoV1{
+		App: app.AppV1{ID: "test-app", OwnerWallet: "0x0000000000000000000000000000000000000001"},
+	}, nil).Maybe()
+	mockStore.On("GetAppSession", appSessionID).Return(existingAppSession, nil).Once()
+	mockStore.On("LockUserState", participant1, asset).Return(decimal.Zero, nil).Once()
+	mockStore.On("CheckOpenChannel", participant1, asset).Return("0x03", true, nil).Once()
+	mockStore.On("GetLastUserState", participant1, asset, false).Return(currentUserState, nil).Once()
+	mockStore.On("EnsureNoOngoingStateTransitions", participant1, asset).Return(nil).Once()
+	mockAssetStore.On("GetAssetDecimals", asset).Return(uint8(6), nil)
+	mockStore.On("GetParticipantAllocations", appSessionID).Return(
+		map[string]map[string]decimal.Decimal{}, nil,
+	).Once()
+
+	// The first (non-duplicate) allocation may be processed before the duplicate is detected,
+	// so RecordLedgerEntry might be called for the first entry. Allow it.
+	mockStore.On("RecordLedgerEntry", participant1, appSessionID, asset, depositAmount).Return(nil).Maybe()
+
+	rpcState := toRPCState(*incomingUserState)
+	reqPayload := rpc.AppSessionsV1SubmitDepositStateRequest{
+		AppStateUpdate: appStateUpdate,
+		QuorumSigs:     []string{appSigHex},
+		UserState:      rpcState,
+	}
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, string(rpc.AppSessionsV1SubmitDepositStateMethod), payload),
+	}
+
+	handler.SubmitDepositState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.NotNil(t, respErr, "expected error for duplicate allocation")
+	assert.Contains(t, respErr.Error(), "duplicate allocation")
+}
+
+func TestSubmitDepositState_InvalidDecimalPrecision_Rejected(t *testing.T) {
+	mockStore := new(MockStore)
+	mockSigner := NewMockChannelSigner()
+	nodeAddress := mockSigner.PublicKey().Address().String()
+	mockAssetStore := new(MockAssetStore)
+	mockStatePacker := new(MockStatePacker)
+
+	handler := &Handler{
+		assetStore:    mockAssetStore,
+		actionGateway: &MockActionGateway{},
+		stateAdvancer: core.NewStateAdvancerV1(mockAssetStore),
+		statePacker:   mockStatePacker,
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockStore)
+		},
+		signer:             mockSigner,
+		nodeAddress:        nodeAddress,
+		appRegistryEnabled: true,
+		metrics:            metrics.NewNoopRuntimeMetricExporter(),
+		maxParticipants:    32,
+		maxSessionData:     1024,
+		maxSessionKeyIDs:   256,
+		maxSignedUpdates:   16,
+	}
+
+	userRawSigner := NewMockSigner()
+	channelWalletSigner, _ := core.NewChannelDefaultSigner(userRawSigner)
+	appWalletSigner, _ := app.NewAppSessionWalletSignerV1(userRawSigner)
+	participant1 := strings.ToLower(userRawSigner.PublicKey().Address().String())
+	participant2 := "0x2222222222222222222222222222222222222222"
+	asset := "USDC"
+	homeChannelID := "0xHomeChannel123"
+	appSessionID := "0xAppSession123"
+
+	existingAppSession := &app.AppSessionV1{
+		SessionID:     appSessionID,
+		ApplicationID: "test-app",
+		Participants: []app.AppParticipantV1{
+			{WalletAddress: participant1, SignatureWeight: 1},
+			{WalletAddress: participant2, SignatureWeight: 1},
+		},
+		Quorum:  1,
+		Nonce:   12345,
+		Status:  app.AppSessionStatusOpen,
+		Version: 1,
+	}
+
+	// Amount with 7 decimal places for USDC (which has 6)
+	invalidAmount, _ := decimal.NewFromString("100.1234567")
+	depositAmount := invalidAmount
+
+	currentUserState := core.State{
+		ID:         core.GetStateID(participant1, asset, 1, 1),
+		Transition: core.Transition{Type: core.TransitionTypeVoid},
+		Asset:      asset, UserWallet: participant1, Epoch: 1, Version: 1,
+		HomeChannelID: &homeChannelID,
+		HomeLedger: core.Ledger{
+			TokenAddress: "0xTokenAddress", BlockchainID: 1,
+			UserBalance: decimal.NewFromInt(500), UserNetFlow: decimal.NewFromInt(500),
+		},
+	}
+
+	incomingUserState := currentUserState.NextState()
+	_, err := incomingUserState.ApplyCommitTransition(appSessionID, depositAmount)
+	require.NoError(t, err)
+
+	mockStatePacker.On("PackState", mock.Anything).Return([]byte("packed"), nil)
+	packedUserState, _ := mockStatePacker.PackState(*incomingUserState)
+	userSig, _ := channelWalletSigner.Sign(packedUserState)
+	userSigStr := userSig.String()
+	incomingUserState.UserSig = &userSigStr
+
+	appStateUpdateCore := app.AppStateUpdateV1{
+		AppSessionID: appSessionID,
+		Intent:       app.AppStateUpdateIntentDeposit,
+		Version:      2,
+		Allocations: []app.AppAllocationV1{
+			{Participant: participant1, Asset: asset, Amount: invalidAmount},
+		},
+	}
+	packedAppUpdate, _ := app.PackAppStateUpdateV1(appStateUpdateCore)
+	appSigBytes, _ := appWalletSigner.Sign(packedAppUpdate)
+	appSigHex := hexutil.Encode(appSigBytes)
+
+	appStateUpdate := rpc.AppStateUpdateV1{
+		AppSessionID: appSessionID,
+		Intent:       app.AppStateUpdateIntentDeposit,
+		Version:      "2",
+		Allocations: []rpc.AppAllocationV1{
+			{Participant: participant1, Asset: asset, Amount: "100.1234567"},
+		},
+	}
+
+	mockStore.On("GetApp", "test-app").Return(&app.AppInfoV1{
+		App: app.AppV1{ID: "test-app", OwnerWallet: "0x0000000000000000000000000000000000000001"},
+	}, nil).Maybe()
+	mockStore.On("GetAppSession", appSessionID).Return(existingAppSession, nil).Once()
+	mockStore.On("LockUserState", participant1, asset).Return(decimal.Zero, nil).Once()
+	mockStore.On("CheckOpenChannel", participant1, asset).Return("0x03", true, nil).Once()
+	mockStore.On("GetLastUserState", participant1, asset, false).Return(currentUserState, nil).Once()
+	mockStore.On("EnsureNoOngoingStateTransitions", participant1, asset).Return(nil).Once()
+	mockAssetStore.On("GetAssetDecimals", asset).Return(uint8(6), nil)
+	mockStore.On("GetParticipantAllocations", appSessionID).Return(
+		map[string]map[string]decimal.Decimal{}, nil,
+	).Once()
+
+	rpcState := toRPCState(*incomingUserState)
+	reqPayload := rpc.AppSessionsV1SubmitDepositStateRequest{
+		AppStateUpdate: appStateUpdate,
+		QuorumSigs:     []string{appSigHex},
+		UserState:      rpcState,
+	}
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, string(rpc.AppSessionsV1SubmitDepositStateMethod), payload),
+	}
+
+	handler.SubmitDepositState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.NotNil(t, respErr, "Expected error for invalid decimal precision")
+	assert.Contains(t, respErr.Error(), "amount exceeds maximum decimal precision")
+}

--- a/clearnode/api/channel_v1/handler.go
+++ b/clearnode/api/channel_v1/handler.go
@@ -2,6 +2,7 @@ package channel_v1
 
 import (
 	"context"
+	"strings"
 
 	"github.com/layer-3/nitrolite/clearnode/metrics"
 	"github.com/layer-3/nitrolite/pkg/core"
@@ -73,7 +74,7 @@ func (h *Handler) issueTransferReceiverState(ctx context.Context, tx Store, send
 		return nil, rpc.Errorf("invalid receiver wallet address: %v", err)
 	}
 
-	if senderState.UserWallet == receiverWallet {
+	if strings.EqualFold(senderState.UserWallet, receiverWallet) {
 		return nil, rpc.Errorf("sender and receiver wallets are the same")
 	}
 

--- a/clearnode/api/channel_v1/request_creation.go
+++ b/clearnode/api/channel_v1/request_creation.go
@@ -186,6 +186,11 @@ func (h *Handler) RequestCreation(c *rpc.Context) {
 		nodeSig = _nodeSig.String()
 		incomingState.NodeSig = &nodeSig
 
+		// Store the pending state
+		if err := tx.StoreUserState(incomingState); err != nil {
+			return rpc.Errorf("failed to store state: %v", err)
+		}
+
 		incomingTransition := incomingState.Transition
 
 		if incomingTransition.Type != core.TransitionTypeAcknowledgement {
@@ -226,10 +231,6 @@ func (h *Handler) RequestCreation(c *rpc.Context) {
 				"to", transaction.ToAccount,
 				"asset", transaction.Asset,
 				"amount", transaction.Amount.String())
-		}
-		// Store the pending state
-		if err := tx.StoreUserState(incomingState); err != nil {
-			return rpc.Errorf("failed to store state: %v", err)
 		}
 
 		logger.Info("channel creation request processed",

--- a/clearnode/api/channel_v1/submit_state.go
+++ b/clearnode/api/channel_v1/submit_state.go
@@ -132,6 +132,12 @@ func (h *Handler) SubmitState(c *rpc.Context) {
 		nodeSig = _nodeSig.String()
 		incomingState.NodeSig = &nodeSig
 
+		// Store user state early — it's fully validated and signed at this point.
+		// The wrapping DB transaction ensures rollback if any subsequent step fails.
+		if err := tx.StoreUserState(incomingState); err != nil {
+			return rpc.Errorf("failed to store user state: %v", err)
+		}
+
 		if incomingTransition.Type != core.TransitionTypeAcknowledgement {
 			var transaction *core.Transaction
 			switch incomingTransition.Type {
@@ -223,10 +229,6 @@ func (h *Handler) SubmitState(c *rpc.Context) {
 				"to", transaction.ToAccount,
 				"asset", transaction.Asset,
 				"amount", transaction.Amount.String())
-		}
-
-		if err := tx.StoreUserState(incomingState); err != nil {
-			return rpc.Errorf("failed to store user state: %v", err)
 		}
 
 		// TODO: consider state checkpoint if channel is challenged

--- a/clearnode/api/channel_v1/submit_state_test.go
+++ b/clearnode/api/channel_v1/submit_state_test.go
@@ -310,6 +310,11 @@ func TestSubmitState_TransferSend_ReceiverWithEscrowLock_Rejected(t *testing.T) 
 	mockTxStore.On("EnsureNoOngoingStateTransitions", senderWallet, asset).Return(nil)
 	mockStatePacker.On("PackState", mock.Anything).Return(packedSenderState, nil).Maybe()
 
+	// Sender state is stored before the transition-specific logic
+	mockTxStore.On("StoreUserState", mock.MatchedBy(func(state core.State) bool {
+		return state.UserWallet == senderWallet && state.NodeSig != nil
+	})).Return(nil)
+
 	// For issueTransferReceiverState - receiver has an active escrow lock
 	mockTxStore.On("LockUserState", receiverWallet, asset).Return(decimal.Zero, nil)
 	mockTxStore.On("GetLastUserState", receiverWallet, asset, false).Return(currentReceiverState, nil)
@@ -421,6 +426,11 @@ func TestSubmitState_TransferSend_SameWalletCaseInsensitive_Rejected(t *testing.
 	mockTxStore.On("EnsureNoOngoingStateTransitions", senderWallet, asset).Return(nil)
 	mockStatePacker.On("PackState", mock.Anything).Return(packedSenderState, nil).Maybe()
 
+	// Sender state is stored before the transition-specific logic
+	mockTxStore.On("StoreUserState", mock.MatchedBy(func(state core.State) bool {
+		return state.UserWallet == senderWallet && state.NodeSig != nil
+	})).Return(nil)
+
 	rpcState := toRPCState(*incomingSenderState)
 	reqPayload := rpc.ChannelsV1SubmitStateRequest{
 		State: rpcState,
@@ -446,8 +456,7 @@ func TestSubmitState_TransferSend_SameWalletCaseInsensitive_Rejected(t *testing.
 	require.NotNil(t, respErr, "Expected error when sender and receiver are the same wallet")
 	assert.Contains(t, respErr.Error(), "sender and receiver wallets are the same")
 
-	// StoreUserState for receiver should never be called
-	mockTxStore.AssertNotCalled(t, "StoreUserState", mock.Anything)
+	mockTxStore.AssertExpectations(t)
 }
 
 func TestSubmitState_EscrowLock_Success(t *testing.T) {

--- a/clearnode/api/channel_v1/submit_state_test.go
+++ b/clearnode/api/channel_v1/submit_state_test.go
@@ -3,6 +3,7 @@ package channel_v1
 import (
 	"context"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/shopspring/decimal"
@@ -342,6 +343,111 @@ func TestSubmitState_TransferSend_ReceiverWithEscrowLock_Rejected(t *testing.T) 
 	assert.Contains(t, respErr.Error(), "last signed state is a lock with escrow channel")
 
 	mockTxStore.AssertExpectations(t)
+}
+
+func TestSubmitState_TransferSend_SameWalletCaseInsensitive_Rejected(t *testing.T) {
+	// Verify that the sender==receiver check is case-insensitive.
+	// Ethereum addresses are hex and may differ only in case (checksummed vs lowercased).
+	mockTxStore := new(MockStore)
+	mockMemoryStore := new(MockMemoryStore)
+	mockAssetStore := new(MockAssetStore)
+	mockSigner := NewMockSigner()
+	nodeSigner, _ := core.NewChannelDefaultSigner(mockSigner)
+	nodeAddress := mockSigner.PublicKey().Address().String()
+	minChallenge := uint32(3600)
+	mockStatePacker := new(MockStatePacker)
+
+	handler := &Handler{
+		stateAdvancer: core.NewStateAdvancerV1(mockAssetStore),
+		statePacker:   mockStatePacker,
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockTxStore)
+		},
+		memoryStore:      mockMemoryStore,
+		nodeSigner:       nodeSigner,
+		nodeAddress:      nodeAddress,
+		minChallenge:     minChallenge,
+		metrics:          metrics.NewNoopRuntimeMetricExporter(),
+		maxSessionKeyIDs: 256,
+		actionGateway:    &MockActionGateway{},
+	}
+
+	// Derive senderWallet from a real key — Address().String() returns checksummed (mixed case)
+	userSigner := NewMockSigner()
+	userWalletSigner, _ := core.NewChannelDefaultSigner(userSigner)
+	senderWallet := userSigner.PublicKey().Address().String() // checksummed, e.g. "0xAbCdEf..."
+
+	// Use uppercased hex digits for the same address so the test guarantees a case mismatch.
+	// Without EqualFold, "0xAbCdEf..." != "0xABCDEF..." would bypass the self-transfer check.
+	receiverWallet := "0x" + strings.ToUpper(senderWallet[2:])
+
+	asset := "USDC"
+	homeChannelID := "0xHomeChannel123"
+	transferAmount := decimal.NewFromInt(100)
+
+	currentSenderState := core.State{
+		ID:            core.GetStateID(senderWallet, asset, 1, 1),
+		Transition:    core.Transition{},
+		Asset:         asset,
+		UserWallet:    senderWallet,
+		Epoch:         1,
+		Version:       1,
+		HomeChannelID: &homeChannelID,
+		HomeLedger: core.Ledger{
+			TokenAddress: "0xTokenAddress",
+			BlockchainID: 1,
+			UserBalance:  decimal.NewFromInt(500),
+			UserNetFlow:  decimal.NewFromInt(500),
+			NodeBalance:  decimal.NewFromInt(0),
+			NodeNetFlow:  decimal.NewFromInt(0),
+		},
+	}
+
+	incomingSenderState := currentSenderState.NextState()
+	_, err := incomingSenderState.ApplyTransferSendTransition(receiverWallet, transferAmount)
+	require.NoError(t, err)
+
+	mockAssetStore.On("GetTokenDecimals", uint64(1), "0xTokenAddress").Return(uint8(6), nil).Maybe()
+	packedSenderState, _ := core.PackState(*incomingSenderState, mockAssetStore)
+	userSig, _ := userWalletSigner.Sign(packedSenderState)
+	userSigStr := userSig.String()
+	incomingSenderState.UserSig = &userSigStr
+
+	// Mock expectations — should reach the issueTransferReceiverState check
+	mockAssetStore.On("GetAssetDecimals", asset).Return(uint8(6), nil)
+	mockTxStore.On("LockUserState", senderWallet, asset).Return(decimal.Zero, nil)
+	mockTxStore.On("CheckOpenChannel", senderWallet, asset).Return("0x03", true, nil)
+	mockTxStore.On("GetLastUserState", senderWallet, asset, false).Return(currentSenderState, nil)
+	mockTxStore.On("EnsureNoOngoingStateTransitions", senderWallet, asset).Return(nil)
+	mockStatePacker.On("PackState", mock.Anything).Return(packedSenderState, nil).Maybe()
+
+	rpcState := toRPCState(*incomingSenderState)
+	reqPayload := rpc.ChannelsV1SubmitStateRequest{
+		State: rpcState,
+	}
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	rpcRequest := rpc.Message{
+		Method:  "channels.v1.submit_state",
+		Payload: payload,
+	}
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpcRequest,
+	}
+
+	handler.SubmitState(ctx)
+
+	// Should fail because sender and receiver are the same address (different case)
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.NotNil(t, respErr, "Expected error when sender and receiver are the same wallet")
+	assert.Contains(t, respErr.Error(), "sender and receiver wallets are the same")
+
+	// StoreUserState for receiver should never be called
+	mockTxStore.AssertNotCalled(t, "StoreUserState", mock.Anything)
 }
 
 func TestSubmitState_EscrowLock_Success(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Wallet comparison is now case-insensitive to prevent false "same wallet" rejections.
  * Requests containing duplicate participant+asset allocations are rejected with clear error messaging.

* **New Features**
  * Validation of asset decimal precision for allocation amounts to enforce allowed decimals.

* **Tests**
  * Added tests covering duplicate-allocation rejection, deposit precision validation, rebalance duplicate handling, and same-wallet case-insensitive rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->