### PR TITLE
M-H13: feat(contract): add validateChallengeSignature, revert in SK validator

### DIFF
--- a/contracts/SECURITY.md
+++ b/contracts/SECURITY.md
@@ -231,13 +231,15 @@ The protocol maintains clear separation between protocol concerns (ChannelHub) a
    - Automatically tries EIP-191 (with Ethereum prefix) and raw ECDSA
    - 65-byte signatures: `[r: 32 bytes][s: 32 bytes][v: 1 byte]`
    - Recommended for all users and nodes
+   - `validateChallengeSignature`: appends `"challenge"` suffix to the signing data
 
 2. **SessionKeyValidator** (`src/sigValidators/SessionKeyValidator.sol`)
    - Session key delegation with metadata
    - Enables temporary signing authority (hot wallets, time-limited access)
    - Two-level validation: participant authorizes session key, session key signs state
    - **Safe for user usage** (with Clearnode validation)
-   - **NOT safe for node usage** (no user-side validation) - see SessionKeyValidator Security Considerations below
+   - **NOT safe for node usage** (no user-side validation) — see SessionKeyValidator Security Considerations below
+   - `validateChallengeSignature`: **not supported** — always reverts with `ChallengeWithSessionKeyNotSupported`
 
 See `signature-validators.md` for detailed documentation on each validator.
 
@@ -358,6 +360,12 @@ When a **node** employs SessionKeyValidator (NOT RECOMMENDED):
    - User has no protection against misuse
 
 4. **Asymmetric security**: User-side session keys are safe (Clearnode validates), node-side session keys are unsafe (no user-side validator)
+
+#### Challenge Restriction
+
+Session keys cannot be used for challenge signatures. `SessionKeyValidator.validateChallengeSignature` always reverts with `ChallengeWithSessionKeyNotSupported`.
+
+**Rationale**: A session key authorization — once signed by the user — is permanently valid on-chain because the contract only checks the cryptographic signature, not expiration or revocation. If session keys were allowed to challenge, an expired or revoked key could put any channel (where the validator is approved) into `DISPUTED` state unilaterally, bypassing Clearnode's off-chain enforcement and causing a DoS on the channel.
 
 ---
 

--- a/contracts/signature-validators.md
+++ b/contracts/signature-validators.md
@@ -8,11 +8,12 @@ This document describes the pluggable signature validation system in the Nitroli
 
 The protocol supports flexible signature validation through the `ISignatureValidator` interface. All validators implement:
 
-- `validateSignature(channelId, signingData, signature, participant)` - Validates a participant's signature
+- `validateSignature(channelId, signingData, signature, participant)` — Validates a state signature
+- `validateChallengeSignature(channelId, signingData, signature, participant)` — Validates a challenge signature
 
 Validators receive the core state data (`signingData`) and `channelId` separately, allowing them to construct the full message according to their signing scheme.
 
-For challenge signatures, ChannelHub appends `"challenge"` to the signing data before calling `validateSignature`.
+For challenge signatures, ChannelHub calls `validateChallengeSignature` rather than `validateSignature`. Each validator is responsible for constructing the challenge message and enforcing any validator-specific constraints (e.g., temporal bounds for session keys).
 
 ---
 
@@ -154,6 +155,10 @@ Default validator supporting standard ECDSA signatures. Automatically tries both
 2. If fails, try raw ECDSA recovery
 3. Return `VALIDATION_SUCCESS` if recovered address matches participant, `VALIDATION_FAILURE` otherwise
 
+### Challenge Validation
+
+`validateChallengeSignature` delegates to `validateSignature` with the signing data extended by a `"challenge"` suffix. The signer must sign `pack(channelId, signingData || "challenge")`. No temporal or scope checks apply — ECDSA keys do not expire.
+
 ### Use Cases
 
 - Standard wallet signatures (MetaMask, WalletConnect, hardware wallets)
@@ -194,6 +199,12 @@ Both use EIP-191 first, then raw ECDSA if that fails.
 ### Metadata
 
 Application-defined data encoding expiration, allowed channels, and permissions. **Validated off-chain by Clearnode, not on-chain.**
+
+### Challenge Signatures
+
+`validateChallengeSignature` is **not supported** and always reverts with `ChallengeWithSessionKeyNotSupported`.
+
+This is to prevent a vulnerability: since session key authorizations are permanently valid on-chain (expiration is opaque in metadataHash), allowing session keys to challenge would let any expired or revoked key put channels into `DISPUTED` state unilaterally, bypassing Clearnode's off-chain enforcement and causing a DoS on the channel.
 
 ---
 

--- a/contracts/src/ChannelHub.sol
+++ b/contracts/src/ChannelHub.sol
@@ -1041,9 +1041,8 @@ contract ChannelHub is ReentrancyGuard {
         ParticipantIndex challengerIdx
     ) internal view {
         bytes memory signingData = Utils.toSigningData(state);
-        bytes memory challengerSigningData = abi.encodePacked(signingData, "challenge");
         address challenger = challengerIdx == ParticipantIndex.USER ? user : NODE;
-        ValidationResult result = validator.validateSignature(channelId, challengerSigningData, sigData, challenger);
+        ValidationResult result = validator.validateChallengeSignature(channelId, signingData, sigData, challenger);
         require(ValidationResult.unwrap(result) != ValidationResult.unwrap(VALIDATION_FAILURE), IncorrectSignature());
     }
 

--- a/contracts/src/interfaces/ISignatureValidator.sol
+++ b/contracts/src/interfaces/ISignatureValidator.sol
@@ -39,4 +39,22 @@ interface ISignatureValidator {
         bytes calldata signature,
         address participant
     ) external view returns (ValidationResult);
+
+    /**
+     * @notice Validates a challenge signature
+     * @dev The validator constructs the challenge message internally (e.g., appending "challenge"
+     *      and any validator-specific data to signingData). This allows each validator to define
+     *      its own challenge signature format and enforce validator-specific constraints.
+     * @param channelId The channel identifier to be included in the signed message
+     * @param signingData The encoded state data
+     * @param signature The challenge signature to validate
+     * @param participant The expected challenger's address
+     * @return result ValidationResult indicating success or failure
+     */
+    function validateChallengeSignature(
+        bytes32 channelId,
+        bytes calldata signingData,
+        bytes calldata signature,
+        address participant
+    ) external view returns (ValidationResult);
 }

--- a/contracts/src/sigValidators/ECDSAValidator.sol
+++ b/contracts/src/sigValidators/ECDSAValidator.sol
@@ -29,12 +29,11 @@ contract ECDSAValidator is ISignatureValidator {
      * @param participant The expected signer's address
      * @return result VALIDATION_SUCCESS if valid, VALIDATION_FAILURE otherwise
      */
-    function validateSignature(
-        bytes32 channelId,
-        bytes calldata signingData,
-        bytes calldata signature,
-        address participant
-    ) external pure returns (ValidationResult) {
+    function validateSignature(bytes32 channelId, bytes memory signingData, bytes memory signature, address participant)
+        public
+        pure
+        returns (ValidationResult)
+    {
         require(channelId != bytes32(0), EmptyChannelId());
         require(participant != address(0), InvalidSignerAddress());
 
@@ -44,5 +43,23 @@ contract ECDSAValidator is ISignatureValidator {
         } else {
             return VALIDATION_FAILURE;
         }
+    }
+
+    /**
+     * @notice Validates a challenge signature
+     * @dev Appends "challenge" to the packed message and verifies the ECDSA signature.
+     * @param channelId The channel identifier to include in the signed message
+     * @param signingData The encoded state data (without channelId, signatures, or challenge suffix)
+     * @param signature The challenge signature to validate (format: [r: 32][s: 32][v: 1], 65 bytes)
+     * @param participant The expected challenger's address
+     * @return result VALIDATION_SUCCESS if valid, VALIDATION_FAILURE otherwise
+     */
+    function validateChallengeSignature(
+        bytes32 channelId,
+        bytes calldata signingData,
+        bytes calldata signature,
+        address participant
+    ) external pure returns (ValidationResult) {
+        return validateSignature(channelId, abi.encodePacked(signingData, "challenge"), signature, participant);
     }
 }

--- a/contracts/src/sigValidators/SessionKeyValidator.sol
+++ b/contracts/src/sigValidators/SessionKeyValidator.sol
@@ -53,6 +53,8 @@ function toSigningData(SessionKeyAuthorization memory skAuth) pure returns (byte
  * - Participants are responsible for session key management
  */
 contract SessionKeyValidator is ISignatureValidator {
+    error ChallengeWithSessionKeyNotSupported();
+
     /**
      * @notice Validates a signature using a delegated session key
      * @dev Validates:
@@ -92,5 +94,16 @@ contract SessionKeyValidator is ISignatureValidator {
         } else {
             return VALIDATION_FAILURE;
         }
+    }
+
+    /**
+     * @notice Challenge signatures via session keys are not supported
+     */
+    function validateChallengeSignature(bytes32, bytes calldata, bytes calldata, address)
+        external
+        pure
+        returns (ValidationResult)
+    {
+        revert ChallengeWithSessionKeyNotSupported();
     }
 }

--- a/contracts/test/ChannelHub_challenge/ChannelHub_challengeSessionKeyValidator.t.sol
+++ b/contracts/test/ChannelHub_challenge/ChannelHub_challengeSessionKeyValidator.t.sol
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.30;
+
+import {ChannelHubTest_Challenge_Base} from "./ChannelHub_Challenge_Base.t.sol";
+
+import {Utils} from "../../src/Utils.sol";
+import {TestUtils, SESSION_KEY_VALIDATOR_ID} from "../TestUtils.sol";
+import {ChannelDefinition, State, StateIntent, Ledger, ParticipantIndex} from "../../src/interfaces/Types.sol";
+import {ChannelHub} from "../../src/ChannelHub.sol";
+import {SessionKeyValidator, SessionKeyAuthorization} from "../../src/sigValidators/SessionKeyValidator.sol";
+
+/*
+ * @dev Black-box tests verifying that all three challenge functions revert with
+ *      ChallengeWithSessionKeyNotSupported when the challenger signature uses the
+ *      SessionKeyValidator. The channel/escrow must have the SessionKeyValidator
+ *      approved (bit SESSION_KEY_VALIDATOR_ID set in approvedSignatureValidators) so
+ *      that _extractValidator routes to the validator before the revert is triggered.
+ */
+
+abstract contract ChannelHubTest_Challenge_SkApproved_Base is ChannelHubTest_Challenge_Base {
+    function setUp() public virtual override {
+        super.setUp();
+
+        def = ChannelDefinition({
+            challengeDuration: CHALLENGE_DURATION,
+            user: alice,
+            node: node,
+            nonce: NONCE,
+            approvedSignatureValidators: 1 << SESSION_KEY_VALIDATOR_ID,
+            metadata: bytes32(0)
+        });
+        channelId = Utils.getChannelId(def, CHANNEL_HUB_VERSION);
+    }
+
+    function buildSkChallengerSig(bytes32 channelId_, State memory state, uint256 signerPk, address skAddress)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        bytes32 metadataHash = keccak256("metadata");
+        SessionKeyAuthorization memory skAuth = TestUtils.buildAndSignSkAuth(vm, skAddress, metadataHash, signerPk);
+        // no need to change challenge signature in any way — just well-formatted would suffice
+        return TestUtils.signStateEip191WithSkValidator(vm, channelId_, state, ALICE_SK1_PK, skAuth);
+    }
+}
+
+// forge-lint: disable-start(unsafe-typecast)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// challengeChannel
+// ─────────────────────────────────────────────────────────────────────────────
+
+contract ChannelHubTest_Challenge_HomeChain_SessionKeyValidator is ChannelHubTest_Challenge_SkApproved_Base {
+    function setUp() public override {
+        super.setUp();
+        createChannelWithDeposit();
+    }
+
+    function test_revert_challengeChannel_withSkValidator_asUser() public {
+        bytes memory challengerSig = buildSkChallengerSig(channelId, initState, ALICE_PK, aliceSk1);
+
+        vm.prank(alice);
+        vm.expectRevert(SessionKeyValidator.ChallengeWithSessionKeyNotSupported.selector);
+        cHub.challengeChannel(channelId, initState, challengerSig, ParticipantIndex.USER);
+    }
+
+    function test_revert_challengeChannel_withSkValidator_asNode() public {
+        bytes memory challengerSig = buildSkChallengerSig(channelId, initState, NODE_PK, aliceSk1);
+
+        vm.prank(node);
+        vm.expectRevert(SessionKeyValidator.ChallengeWithSessionKeyNotSupported.selector);
+        cHub.challengeChannel(channelId, initState, challengerSig, ParticipantIndex.NODE);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// challengeEscrowDeposit
+// ─────────────────────────────────────────────────────────────────────────────
+
+contract ChannelHubTest_Challenge_NonHomeChain_EscrowDeposit_SessionKeyValidator is
+    ChannelHubTest_Challenge_SkApproved_Base
+{
+    uint64 constant ESCROW_VERSION = 1;
+    uint256 constant ESCROW_AMOUNT = 500;
+
+    bytes32 escrowId;
+    State initiateEscrowDepositState;
+
+    function setUp() public override {
+        super.setUp();
+
+        // Non-home chain: NON_HOME_CHAIN_ID (42) is the home chain, block.chainid is the non-home chain.
+        // No on-chain channel exists on the current chain — initiateEscrowDeposit takes the non-home path.
+        initiateEscrowDepositState = State({
+            version: ESCROW_VERSION,
+            intent: StateIntent.INITIATE_ESCROW_DEPOSIT,
+            metadata: bytes32(0),
+            homeLedger: Ledger({
+                chainId: NON_HOME_CHAIN_ID,
+                token: NON_HOME_TOKEN,
+                decimals: 18,
+                userAllocation: 500,
+                userNetFlow: 500,
+                nodeAllocation: ESCROW_AMOUNT,
+                nodeNetFlow: int256(ESCROW_AMOUNT)
+            }),
+            nonHomeLedger: Ledger({
+                chainId: uint64(block.chainid),
+                token: address(token),
+                decimals: 18,
+                userAllocation: ESCROW_AMOUNT,
+                userNetFlow: int256(ESCROW_AMOUNT),
+                nodeAllocation: 0,
+                nodeNetFlow: 0
+            }),
+            userSig: "",
+            nodeSig: ""
+        });
+        initiateEscrowDepositState =
+            mutualSignStateBothWithEcdsaValidator(initiateEscrowDepositState, channelId, ALICE_PK);
+
+        vm.prank(alice);
+        cHub.initiateEscrowDeposit(def, initiateEscrowDepositState);
+
+        escrowId = Utils.getEscrowId(channelId, ESCROW_VERSION);
+    }
+
+    function test_revert_challengeEscrowDeposit_withSkValidator_asUser() public {
+        bytes memory challengerSig = buildSkChallengerSig(channelId, initiateEscrowDepositState, ALICE_PK, aliceSk1);
+
+        vm.prank(alice);
+        vm.expectRevert(SessionKeyValidator.ChallengeWithSessionKeyNotSupported.selector);
+        cHub.challengeEscrowDeposit(escrowId, challengerSig, ParticipantIndex.USER);
+    }
+
+    function test_revert_challengeEscrowDeposit_withSkValidator_asNode() public {
+        bytes memory challengerSig = buildSkChallengerSig(channelId, initiateEscrowDepositState, NODE_PK, aliceSk1);
+
+        vm.prank(node);
+        vm.expectRevert(SessionKeyValidator.ChallengeWithSessionKeyNotSupported.selector);
+        cHub.challengeEscrowDeposit(escrowId, challengerSig, ParticipantIndex.NODE);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// challengeEscrowWithdrawal
+// ─────────────────────────────────────────────────────────────────────────────
+
+contract ChannelHubTest_Challenge_NonHomeChain_EscrowWithdrawal_SessionKeyValidator is
+    ChannelHubTest_Challenge_SkApproved_Base
+{
+    uint64 constant WITHDRAWAL_VERSION = 1;
+    uint256 constant WITHDRAWAL_AMOUNT = 300;
+
+    bytes32 escrowId;
+    State initiateEscrowWithdrawalState;
+
+    function setUp() public override {
+        super.setUp();
+
+        // Non-home chain: NON_HOME_CHAIN_ID (42) is the home chain, block.chainid is the non-home chain.
+        initiateEscrowWithdrawalState = State({
+            version: WITHDRAWAL_VERSION,
+            intent: StateIntent.INITIATE_ESCROW_WITHDRAWAL,
+            metadata: bytes32(0),
+            homeLedger: Ledger({
+                chainId: NON_HOME_CHAIN_ID,
+                token: NON_HOME_TOKEN,
+                decimals: 18,
+                userAllocation: 500,
+                userNetFlow: 500,
+                nodeAllocation: 0,
+                nodeNetFlow: 0
+            }),
+            nonHomeLedger: Ledger({
+                chainId: uint64(block.chainid),
+                token: address(token),
+                decimals: 18,
+                userAllocation: 0,
+                userNetFlow: 0,
+                nodeAllocation: WITHDRAWAL_AMOUNT,
+                nodeNetFlow: int256(WITHDRAWAL_AMOUNT)
+            }),
+            userSig: "",
+            nodeSig: ""
+        });
+        initiateEscrowWithdrawalState =
+            mutualSignStateBothWithEcdsaValidator(initiateEscrowWithdrawalState, channelId, ALICE_PK);
+
+        vm.prank(alice);
+        cHub.initiateEscrowWithdrawal(def, initiateEscrowWithdrawalState);
+
+        escrowId = Utils.getEscrowId(channelId, WITHDRAWAL_VERSION);
+    }
+
+    function test_revert_challengeEscrowWithdrawal_withSkValidator_asUser() public {
+        bytes memory challengerSig = buildSkChallengerSig(channelId, initiateEscrowWithdrawalState, ALICE_PK, aliceSk1);
+
+        vm.prank(alice);
+        vm.expectRevert(SessionKeyValidator.ChallengeWithSessionKeyNotSupported.selector);
+        cHub.challengeEscrowWithdrawal(escrowId, challengerSig, ParticipantIndex.USER);
+    }
+
+    function test_revert_challengeEscrowWithdrawal_withSkValidator_asNode() public {
+        bytes memory challengerSig = buildSkChallengerSig(channelId, initiateEscrowWithdrawalState, NODE_PK, aliceSk1);
+
+        vm.prank(node);
+        vm.expectRevert(SessionKeyValidator.ChallengeWithSessionKeyNotSupported.selector);
+        cHub.challengeEscrowWithdrawal(escrowId, challengerSig, ParticipantIndex.NODE);
+    }
+}
+// forge-lint: disable-end(unsafe-typecast)

--- a/contracts/test/sigValidators/ECDSAValidator.t.sol
+++ b/contracts/test/sigValidators/ECDSAValidator.t.sol
@@ -81,3 +81,62 @@ contract ECDSAValidatorTest_validateSignature is ECDSAValidatorTest_Base {
         assertEq(ValidationResult.unwrap(result), ValidationResult.unwrap(VALIDATION_FAILURE));
     }
 }
+
+contract ECDSAValidatorTest_validateChallengeSignature is ECDSAValidatorTest_Base {
+    function _signChallenge(uint256 pk, bool eip191) internal pure returns (bytes memory) {
+        bytes memory challengeSigningData = abi.encodePacked(SIGNING_DATA, "challenge");
+        bytes memory message = Utils.pack(CHANNEL_ID, challengeSigningData);
+        return eip191 ? TestUtils.signEip191(vm, pk, message) : TestUtils.signRaw(vm, pk, message);
+    }
+
+    function test_success_withEip191Sig() public view {
+        bytes memory signature = _signChallenge(USER_PK, true);
+        ValidationResult result = validator.validateChallengeSignature(CHANNEL_ID, SIGNING_DATA, signature, user);
+        assertEq(ValidationResult.unwrap(result), ValidationResult.unwrap(VALIDATION_SUCCESS));
+    }
+
+    function test_success_withRawEcdsaSig() public view {
+        bytes memory signature = _signChallenge(USER_PK, false);
+        ValidationResult result = validator.validateChallengeSignature(CHANNEL_ID, SIGNING_DATA, signature, user);
+        assertEq(ValidationResult.unwrap(result), ValidationResult.unwrap(VALIDATION_SUCCESS));
+    }
+
+    function test_appends_challenge_suffix() public view {
+        // A signature valid for plain signingData must NOT pass challenge validation
+        bytes memory plainMessage = Utils.pack(CHANNEL_ID, SIGNING_DATA);
+        bytes memory signature = TestUtils.signEip191(vm, USER_PK, plainMessage);
+
+        ValidationResult result = validator.validateChallengeSignature(CHANNEL_ID, SIGNING_DATA, signature, user);
+        assertEq(ValidationResult.unwrap(result), ValidationResult.unwrap(VALIDATION_FAILURE));
+    }
+
+    function test_failure_withWrongSigner_eip191() public view {
+        bytes memory signature = _signChallenge(OTHER_SIGNER_PK, true);
+        ValidationResult result = validator.validateChallengeSignature(CHANNEL_ID, SIGNING_DATA, signature, user);
+        assertEq(ValidationResult.unwrap(result), ValidationResult.unwrap(VALIDATION_FAILURE));
+    }
+
+    function test_failure_withWrongSigner_raw() public view {
+        bytes memory signature = _signChallenge(OTHER_SIGNER_PK, false);
+        ValidationResult result = validator.validateChallengeSignature(CHANNEL_ID, SIGNING_DATA, signature, user);
+        assertEq(ValidationResult.unwrap(result), ValidationResult.unwrap(VALIDATION_FAILURE));
+    }
+
+    function test_failure_withOtherChannelId_eip191() public view {
+        bytes memory challengeSigningData = abi.encodePacked(SIGNING_DATA, "challenge");
+        bytes memory message = Utils.pack(OTHER_CHANNEL_ID, challengeSigningData);
+        bytes memory signature = TestUtils.signEip191(vm, USER_PK, message);
+
+        ValidationResult result = validator.validateChallengeSignature(CHANNEL_ID, SIGNING_DATA, signature, user);
+        assertEq(ValidationResult.unwrap(result), ValidationResult.unwrap(VALIDATION_FAILURE));
+    }
+
+    function test_failure_withOtherChannelId_raw() public view {
+        bytes memory challengeSigningData = abi.encodePacked(SIGNING_DATA, "challenge");
+        bytes memory message = Utils.pack(OTHER_CHANNEL_ID, challengeSigningData);
+        bytes memory signature = TestUtils.signRaw(vm, USER_PK, message);
+
+        ValidationResult result = validator.validateChallengeSignature(CHANNEL_ID, SIGNING_DATA, signature, user);
+        assertEq(ValidationResult.unwrap(result), ValidationResult.unwrap(VALIDATION_FAILURE));
+    }
+}

--- a/contracts/test/sigValidators/SessionKeyValidator.t.sol
+++ b/contracts/test/sigValidators/SessionKeyValidator.t.sol
@@ -209,3 +209,20 @@ contract SessionKeyValidatorTest_validateSignature is SessionKeyValidatorTest_Ba
         assertEq(ValidationResult.unwrap(result), ValidationResult.unwrap(VALIDATION_FAILURE));
     }
 }
+
+contract SessionKeyValidatorTest_validateChallengeSignature is SessionKeyValidatorTest_Base {
+    function test_revert_challengeWithSessionKeyNotSupported() public {
+        // Signature contents are irrelevant — the method always reverts regardless of input.
+        SessionKeyAuthorization memory skAuth = createSkAuth(sessionKey1, METADATA_HASH, USER_PK, true);
+        bytes memory skSignature = signChallengeWithSk(CHANNEL_ID, SIGNING_DATA, SESSION_KEY1_PK, true);
+        bytes memory signature = abi.encode(skAuth, skSignature);
+
+        vm.expectRevert(SessionKeyValidator.ChallengeWithSessionKeyNotSupported.selector);
+        validator.validateChallengeSignature(CHANNEL_ID, SIGNING_DATA, signature, user);
+    }
+
+    function test_revert_challengeWithSessionKeyNotSupported_emptySignature() public {
+        vm.expectRevert(SessionKeyValidator.ChallengeWithSessionKeyNotSupported.selector);
+        validator.validateChallengeSignature(CHANNEL_ID, SIGNING_DATA, "", user);
+    }
+}


### PR DESCRIPTION
## **Description**

Users can authorize session keys to sign on their behalf. To use such session key, they must sign`ChannelSessionKeyStateV1`.

```go
		UserAddress: strings.ToLower(state.UserAddress),
		SessionKey:  strings.ToLower(state.SessionKey),
		Version:     version,
		Assets:      assets,
		ExpiresAt:   time.Unix(expiresAtUnix, 0),
```

The node will then add this state to its DB and when the session key requests a new state, the node will sign it after it performs a validation related to the expiry and the asset scoped.

On-chain, the `SessionKeyValidator.validateSignature()` validates that:

1. the user signed the `SessionKeyAuthorization`
2. the session key signed the correct state data

However, `SessionKeyAuthorization` contains only `sessionKey` and a hash of the rest of the data

```
    address sessionKey;
    bytes32 metadataHash;
```

As mentioned in the comments, it doesn't check if the authorization expired or if it's tied to a different asset. While this allows submission of old states, it gives the session key the permanent ability to execute unilateral signature flows for all the channels of the user. One such flow is `challengeChannel()` - an unauthorized session key can challenge every channel of the user with the latest available state. The `ChannelChallenged` event will be picked up by the node and it will stop issuing newer states. The user will be forced to close their channel and their funds will remain stuck for the duration of the challenge period.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated challenge-signature validation entry so challenge messages are handled explicitly.

* **Bug Fixes**
  * Session-key based signatures are now explicitly rejected for challenge operations, preventing unsafe challenge use.

* **Tests**
  * Added tests covering challenge validation behavior for different validator types and edge cases.

* **Documentation**
  * Updated security and validator docs to describe challenge handling, rejection behavior, and rationale.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->