### PR TITLE
YNU-900: stamp application_id on writes and expose via SDKs

### DIFF
--- a/clearnode/api/app_session_v1/create_app_session.go
+++ b/clearnode/api/app_session_v1/create_app_session.go
@@ -41,6 +41,10 @@ func (h *Handler) CreateAppSession(c *rpc.Context) {
 		c.Fail(nil, "application id is required")
 		return
 	}
+	if !app.IsValidApplicationID(reqPayload.Definition.Application) {
+		c.Fail(rpc.Errorf("invalid application id: must match %s", app.ApplicationIDRegex.String()), "")
+		return
+	}
 
 	appDef, err := unmapAppDefinitionV1(reqPayload.Definition)
 	if err != nil {

--- a/clearnode/api/app_session_v1/handler.go
+++ b/clearnode/api/app_session_v1/handler.go
@@ -114,7 +114,7 @@ func (h *Handler) verifyQuorum(tx Store, appSessionId, applicationID string, par
 
 // issueReleaseReceiverState creates a new channel state for a participant receiving funds from app session.
 // This follows the same pattern as issueTransferReceiverState in channel_v1 for transfer_receive transitions.
-func (h *Handler) issueReleaseReceiverState(ctx context.Context, tx Store, receiverWallet, asset, appSessionID string, amount decimal.Decimal) error {
+func (h *Handler) issueReleaseReceiverState(ctx context.Context, tx Store, receiverWallet, asset, appSessionID string, amount decimal.Decimal, applicationID string) error {
 	logger := log.FromContext(ctx)
 
 	// Lock the receiver's state to prevent concurrent modifications
@@ -175,7 +175,7 @@ func (h *Handler) issueReleaseReceiverState(ctx context.Context, tx Store, recei
 	}
 
 	// Store the new state
-	if err := tx.StoreUserState(*newState); err != nil {
+	if err := tx.StoreUserState(*newState, applicationID); err != nil {
 		return rpc.Errorf("failed to store receiver state: %v", err)
 	}
 
@@ -184,7 +184,7 @@ func (h *Handler) issueReleaseReceiverState(ctx context.Context, tx Store, recei
 		return rpc.Errorf("failed to create transaction: %v", err)
 	}
 
-	if err := tx.RecordTransaction(*transaction); err != nil {
+	if err := tx.RecordTransaction(*transaction, applicationID); err != nil {
 		return rpc.Errorf("failed to record transaction: %v", err)
 	}
 	logger.Info("recorded transaction",

--- a/clearnode/api/app_session_v1/handler.go
+++ b/clearnode/api/app_session_v1/handler.go
@@ -14,6 +14,15 @@ import (
 	"github.com/layer-3/nitrolite/pkg/rpc"
 )
 
+// Handlers in this package stamp DB writes with the session's stored
+// ApplicationID (persisted at app_session creation) rather than the
+// connection-scoped tag returned by rpc.GetApplicationID. This keeps app
+// session state attributable to the owning application even when a caller
+// connects without an app_id query parameter or with a different one —
+// e.g., a co-participant, a relay, or a re-connection. Channel-level
+// handlers (see clearnode/api/channel_v1) have no session to anchor to and
+// therefore use the connection tag.
+
 // Handler manages app session operations and provides RPC endpoints for app session management.
 type Handler struct {
 	useStoreInTx       StoreTxProvider

--- a/clearnode/api/app_session_v1/interface.go
+++ b/clearnode/api/app_session_v1/interface.go
@@ -23,7 +23,9 @@ type Store interface {
 	// Ledger operations
 	RecordLedgerEntry(userWallet, accountID, asset string, amount decimal.Decimal) error
 
-	RecordTransaction(tx core.Transaction) error
+	// RecordTransaction records a transaction. applicationID is the client-declared
+	// origin tag (rpc.ApplicationIDQueryParam); empty string is persisted as NULL.
+	RecordTransaction(tx core.Transaction, applicationID string) error
 
 	// Channel state operations
 
@@ -35,7 +37,9 @@ type Store interface {
 	// and returns the approved signature validators if such a channel exists.
 	CheckOpenChannel(wallet, asset string) (string, bool, error)
 	GetLastUserState(wallet, asset string, signed bool) (*core.State, error)
-	StoreUserState(state core.State) error
+	// StoreUserState persists a user state. applicationID is the client-declared
+	// origin tag (rpc.ApplicationIDQueryParam); empty string is persisted as NULL.
+	StoreUserState(state core.State, applicationID string) error
 	EnsureNoOngoingStateTransitions(wallet, asset string) error
 
 	// App Session key state operations

--- a/clearnode/api/app_session_v1/rebalance_app_sessions.go
+++ b/clearnode/api/app_session_v1/rebalance_app_sessions.go
@@ -75,6 +75,8 @@ func (h *Handler) RebalanceAppSessions(c *rpc.Context) {
 	}
 
 	var batchID string
+	// applicationID is the shared application of all rebalanced sessions; enforced below.
+	var applicationID string
 	err := h.useStoreInTx(func(tx Store) error {
 		// Generate deterministic batch ID from session IDs and versions
 		sessionVersions := make([]app.AppSessionVersionV1, len(updates))
@@ -95,13 +97,20 @@ func (h *Handler) RebalanceAppSessions(c *rpc.Context) {
 		assetTotalDiff := make(map[string]decimal.Decimal)                       // asset -> total change
 
 		// Validate and process each session
-		for _, update := range updates {
+		for i, update := range updates {
 			appSession, err := tx.GetAppSession(update.AppStateUpdate.AppSessionID)
 			if err != nil {
 				return rpc.Errorf("failed to get app session %s: %v", update.AppStateUpdate.AppSessionID, err)
 			}
 			if appSession == nil {
 				return rpc.Errorf("app session not found: %s", update.AppStateUpdate.AppSessionID)
+			}
+
+			// All rebalanced sessions must belong to the same application.
+			if i == 0 {
+				applicationID = appSession.ApplicationID
+			} else if appSession.ApplicationID != applicationID {
+				return rpc.Errorf("cannot rebalance app sessions from different applications: %s vs %s", applicationID, appSession.ApplicationID)
 			}
 			if h.appRegistryEnabled {
 				registeredApp, err := tx.GetApp(appSession.ApplicationID)
@@ -302,7 +311,7 @@ func (h *Handler) RebalanceAppSessions(c *rpc.Context) {
 					amount,
 				)
 
-				if err := tx.RecordTransaction(*transaction); err != nil {
+				if err := tx.RecordTransaction(*transaction, applicationID); err != nil {
 					return rpc.Errorf("failed to record transaction for session %s: %v", sessionID, err)
 				}
 

--- a/clearnode/api/app_session_v1/rebalance_app_sessions.go
+++ b/clearnode/api/app_session_v1/rebalance_app_sessions.go
@@ -107,10 +107,12 @@ func (h *Handler) RebalanceAppSessions(c *rpc.Context) {
 			}
 
 			// All rebalanced sessions must belong to the same application.
+			// Quoting keeps legacy (untagged, "") sessions visually
+			// distinguishable from tagged ones in the error message.
 			if i == 0 {
 				applicationID = appSession.ApplicationID
 			} else if appSession.ApplicationID != applicationID {
-				return rpc.Errorf("cannot rebalance app sessions from different applications: %s vs %s", applicationID, appSession.ApplicationID)
+				return rpc.Errorf("cannot rebalance app sessions from different applications: '%s' vs '%s'", applicationID, appSession.ApplicationID)
 			}
 			if h.appRegistryEnabled {
 				registeredApp, err := tx.GetApp(appSession.ApplicationID)

--- a/clearnode/api/app_session_v1/rebalance_app_sessions.go
+++ b/clearnode/api/app_session_v1/rebalance_app_sessions.go
@@ -75,9 +75,9 @@ func (h *Handler) RebalanceAppSessions(c *rpc.Context) {
 	}
 
 	var batchID string
-	// applicationID is the shared application of all rebalanced sessions; enforced below.
-	var applicationID string
 	err := h.useStoreInTx(func(tx Store) error {
+		// applicationID is the shared application of all rebalanced sessions; enforced below.
+		var applicationID string
 		// Generate deterministic batch ID from session IDs and versions
 		sessionVersions := make([]app.AppSessionVersionV1, len(updates))
 		for i, u := range updates {

--- a/clearnode/api/app_session_v1/rebalance_app_sessions_test.go
+++ b/clearnode/api/app_session_v1/rebalance_app_sessions_test.go
@@ -179,7 +179,7 @@ func TestRebalanceAppSessions_Success_TwoSessions(t *testing.T) {
 	mockStore.On("RecordLedgerEntry", wallet2.Address, sessionID2, "USDC", decimal.NewFromInt(100)).Return(nil)
 	mockStore.On("RecordTransaction", mock.MatchedBy(func(tx core.Transaction) bool {
 		return tx.TxType == core.TransactionTypeRebalance && tx.Asset == "USDC"
-	})).Return(nil).Twice()
+	}), mock.Anything).Return(nil).Twice()
 
 	// Create RPC context
 	payload, err := rpc.NewPayload(reqPayload)
@@ -346,7 +346,7 @@ func TestRebalanceAppSessions_Success_MultiAsset(t *testing.T) {
 	mockStore.On("RecordLedgerEntry", wallet1.Address, sessionID1, "ETH", decimal.RequireFromString("0.5")).Return(nil)
 	mockStore.On("RecordLedgerEntry", wallet2.Address, sessionID2, "USDC", decimal.NewFromInt(100)).Return(nil)
 	mockStore.On("RecordLedgerEntry", wallet2.Address, sessionID2, "ETH", decimal.RequireFromString("-0.5")).Return(nil)
-	mockStore.On("RecordTransaction", mock.Anything).Return(nil).Times(4) // 2 assets x 2 sessions
+	mockStore.On("RecordTransaction", mock.Anything, mock.Anything).Return(nil).Times(4) // 2 assets x 2 sessions
 
 	// Create RPC context
 	payload, err := rpc.NewPayload(reqPayload)
@@ -1106,7 +1106,7 @@ func TestRebalanceAppSessions_AppRegistryDisabled(t *testing.T) {
 	mockStore.On("RecordLedgerEntry", wallet2.Address, sessionID2, "USDC", decimal.NewFromInt(100)).Return(nil)
 	mockStore.On("RecordTransaction", mock.MatchedBy(func(tx core.Transaction) bool {
 		return tx.TxType == core.TransactionTypeRebalance && tx.Asset == "USDC"
-	})).Return(nil).Twice()
+	}), mock.Anything).Return(nil).Twice()
 
 	payload, err := rpc.NewPayload(reqPayload)
 	require.NoError(t, err)
@@ -1253,4 +1253,106 @@ func TestRebalanceAppSessions_Error_DuplicateAllocation(t *testing.T) {
 	assertError(t, ctx, "duplicate allocation")
 
 	mockStore.AssertNotCalled(t, "RecordLedgerEntry", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestRebalanceAppSessions_Error_DifferentApplications(t *testing.T) {
+	mockStore := new(MockStore)
+	storeTxProvider := func(fn StoreTxHandler) error {
+		return fn(mockStore)
+	}
+
+	handler := NewHandler(
+		storeTxProvider,
+		nil,
+		&MockActionGateway{},
+		nil,
+		nil,
+		nil,
+		"0xNode",
+		false, // registry disabled — simpler: skip GetApp path
+		metrics.NewNoopRuntimeMetricExporter(),
+		32, 1024, 256, 16,
+	)
+
+	wallet1 := NewTestAppSessionWallet(t)
+	wallet2 := NewTestAppSessionWallet(t)
+
+	sessionID1 := "0x1111111111111111111111111111111111111111111111111111111111111111"
+	sessionID2 := "0x2222222222222222222222222222222222222222222222222222222222222222"
+
+	session1 := &app.AppSessionV1{
+		SessionID:     sessionID1,
+		ApplicationID: "app-one",
+		Participants:  []app.AppParticipantV1{{WalletAddress: wallet1.Address, SignatureWeight: 10}},
+		Quorum:        10,
+		Status:        app.AppSessionStatusOpen,
+		Version:       5,
+	}
+	session2 := &app.AppSessionV1{
+		SessionID:     sessionID2,
+		ApplicationID: "app-two", // Different application
+		Participants:  []app.AppParticipantV1{{WalletAddress: wallet2.Address, SignatureWeight: 10}},
+		Quorum:        10,
+		Status:        app.AppSessionStatusOpen,
+		Version:       3,
+	}
+
+	appStateUpdate1 := app.AppStateUpdateV1{
+		AppSessionID: sessionID1,
+		Intent:       app.AppStateUpdateIntentRebalance,
+		Version:      6,
+	}
+	sig1 := wallet1.SignAppStateUpdate(t, appStateUpdate1)
+
+	appStateUpdate2 := app.AppStateUpdateV1{
+		AppSessionID: sessionID2,
+		Intent:       app.AppStateUpdateIntentRebalance,
+		Version:      4,
+	}
+	sig2 := wallet2.SignAppStateUpdate(t, appStateUpdate2)
+
+	reqPayload := rpc.AppSessionsV1RebalanceAppSessionsRequest{
+		SignedUpdates: []rpc.SignedAppStateUpdateV1{
+			{
+				AppStateUpdate: rpc.AppStateUpdateV1{
+					AppSessionID: sessionID1,
+					Intent:       app.AppStateUpdateIntentRebalance,
+					Version:      "6",
+				},
+				QuorumSigs: []string{sig1},
+			},
+			{
+				AppStateUpdate: rpc.AppStateUpdateV1{
+					AppSessionID: sessionID2,
+					Intent:       app.AppStateUpdateIntentRebalance,
+					Version:      "4",
+				},
+				QuorumSigs: []string{sig2},
+			},
+		},
+	}
+
+	mockStore.On("GetAppSession", sessionID1).Return(session1, nil)
+	mockStore.On("GetAppSession", sessionID2).Return(session2, nil)
+	// Session 1 is fully processed (tx rolls back on failure); session 2 trips the cross-app check.
+	emptyAllocations := map[string]map[string]decimal.Decimal{}
+	mockStore.On("GetParticipantAllocations", sessionID1).Return(emptyAllocations, nil).Maybe()
+	mockStore.On("UpdateAppSession", mock.Anything).Return(nil).Maybe()
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, "app_sessions.v1.rebalance_app_sessions", payload),
+	}
+
+	handler.RebalanceAppSessions(ctx)
+
+	assertError(t, ctx, "cannot rebalance app sessions from different applications")
+
+	// Ledger/transaction writes happen only after all per-session validation completes,
+	// so the cross-app failure on session 2 must prevent them entirely.
+	mockStore.AssertNotCalled(t, "RecordLedgerEntry", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	mockStore.AssertNotCalled(t, "RecordTransaction", mock.Anything, mock.Anything)
 }

--- a/clearnode/api/app_session_v1/submit_app_state.go
+++ b/clearnode/api/app_session_v1/submit_app_state.go
@@ -118,13 +118,13 @@ func (h *Handler) SubmitAppState(c *rpc.Context) {
 
 		case app.AppStateUpdateIntentWithdraw:
 			// For withdraw intent, validate and record ledger changes
-			if err := h.handleWithdrawIntent(ctx, tx, appStateUpd, currentAllocations, participantWeights); err != nil {
+			if err := h.handleWithdrawIntent(ctx, tx, appStateUpd, currentAllocations, participantWeights, appSession.ApplicationID); err != nil {
 				return err
 			}
 
 		case app.AppStateUpdateIntentClose:
 			// For close intent, validate final allocations and mark session as closed
-			if err := h.handleCloseIntent(ctx, tx, appStateUpd, currentAllocations, participantWeights); err != nil {
+			if err := h.handleCloseIntent(ctx, tx, appStateUpd, currentAllocations, participantWeights, appSession.ApplicationID); err != nil {
 				return err
 			}
 			appSession.Status = app.AppSessionStatusClosed
@@ -311,6 +311,7 @@ func (h *Handler) handleWithdrawIntent(
 	appStateUpd app.AppStateUpdateV1,
 	currentAllocations map[string]map[string]decimal.Decimal,
 	participantWeights map[string]uint8,
+	applicationID string,
 ) error {
 	// Build incoming allocations map for validation
 	incomingAllocations := make(map[string]map[string]decimal.Decimal)
@@ -405,7 +406,7 @@ func (h *Handler) handleWithdrawIntent(
 				}
 
 				// Issue new channel state for participant receiving withdrawn funds
-				if err := h.issueReleaseReceiverState(ctx, tx, participant, asset, appStateUpd.AppSessionID, withdrawAmount); err != nil {
+				if err := h.issueReleaseReceiverState(ctx, tx, participant, asset, appStateUpd.AppSessionID, withdrawAmount, applicationID); err != nil {
 					return rpc.Errorf("failed to issue release state for participant %s: %v", participant, err)
 				}
 			}
@@ -423,6 +424,7 @@ func (h *Handler) handleCloseIntent(
 	appStateUpd app.AppStateUpdateV1,
 	currentAllocations map[string]map[string]decimal.Decimal,
 	participantWeights map[string]uint8,
+	applicationID string,
 ) error {
 	// Build a map of incoming allocations for easy lookup
 	incomingAllocations := make(map[string]map[string]decimal.Decimal)
@@ -516,7 +518,7 @@ func (h *Handler) handleCloseIntent(
 			}
 
 			// Issue new channel state for participant receiving funds back
-			if err := h.issueReleaseReceiverState(ctx, tx, participant, asset, appStateUpd.AppSessionID, amount); err != nil {
+			if err := h.issueReleaseReceiverState(ctx, tx, participant, asset, appStateUpd.AppSessionID, amount, applicationID); err != nil {
 				return rpc.Errorf("failed to issue release state for participant %s: %v", participant, err)
 			}
 		}

--- a/clearnode/api/app_session_v1/submit_app_state_test.go
+++ b/clearnode/api/app_session_v1/submit_app_state_test.go
@@ -352,13 +352,13 @@ func TestSubmitAppState_WithdrawIntent_Success(t *testing.T) {
 	mockStore.On("GetLastUserState", participant1, "USDC", false).Return(existingUserState, nil)
 	mockStore.On("GetLastUserState", participant1, "USDC", true).Return(nil, nil)
 	mockStatePacker.On("PackState", mock.Anything).Return([]byte("packed"), nil)
-	mockStore.On("RecordTransaction", mock.Anything).Return(nil)
+	mockStore.On("RecordTransaction", mock.Anything, mock.Anything).Return(nil)
 
 	var capturedState core.State
 	mockStore.On("StoreUserState", mock.MatchedBy(func(state core.State) bool {
 		capturedState = state
 		return true
-	})).Return(nil)
+	}), mock.Anything).Return(nil)
 
 	mockStore.On("UpdateAppSession", mock.MatchedBy(func(session app.AppSessionV1) bool {
 		return session.Version == 2 && session.Status == app.AppSessionStatusOpen
@@ -640,7 +640,7 @@ func TestSubmitAppState_CloseIntent_Success(t *testing.T) {
 	mockStore.On("GetLastUserState", participant1, "USDC", false).Return(existingUserState1, nil)
 	mockStore.On("GetLastUserState", participant1, "USDC", true).Return(nil, nil)
 	mockStatePacker.On("PackState", mock.Anything).Return([]byte("packed"), nil)
-	mockStore.On("RecordTransaction", mock.Anything).Return(nil)
+	mockStore.On("RecordTransaction", mock.Anything, mock.Anything).Return(nil)
 
 	// Participant 2: 50 USDC
 	mockStore.On("RecordLedgerEntry", participant2, appSessionID, "USDC", decimal.NewFromInt(-50)).Return(nil)
@@ -653,7 +653,7 @@ func TestSubmitAppState_CloseIntent_Success(t *testing.T) {
 	mockStore.On("StoreUserState", mock.MatchedBy(func(state core.State) bool {
 		capturedStates = append(capturedStates, state)
 		return true
-	})).Return(nil)
+	}), mock.Anything).Return(nil)
 
 	mockStore.On("UpdateAppSession", mock.MatchedBy(func(session app.AppSessionV1) bool {
 		return session.Version == 2 && session.Status == app.AppSessionStatusClosed
@@ -989,8 +989,8 @@ func TestSubmitAppState_WithdrawIntent_MissingAllocation_Rejected(t *testing.T) 
 	mockStore.On("LockUserState", participant1, "USDC").Return(decimal.Zero, nil).Maybe()
 	mockStore.On("GetLastUserState", participant1, "USDC", false).Return(nil, nil).Maybe()
 	mockStore.On("GetLastUserState", participant1, "USDC", true).Return(nil, nil).Maybe()
-	mockStore.On("StoreUserState", mock.Anything).Return(nil).Maybe()
-	mockStore.On("RecordTransaction", mock.Anything).Return(nil).Maybe()
+	mockStore.On("StoreUserState", mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockStore.On("RecordTransaction", mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	// Create RPC context
 	payload, err := rpc.NewPayload(reqPayload)

--- a/clearnode/api/app_session_v1/submit_deposit_state.go
+++ b/clearnode/api/app_session_v1/submit_deposit_state.go
@@ -288,7 +288,7 @@ func (h *Handler) SubmitDepositState(c *rpc.Context) {
 		nodeSig = _nodeSig.String()
 		userState.NodeSig = &nodeSig
 
-		if err := tx.StoreUserState(userState); err != nil {
+		if err := tx.StoreUserState(userState, appSession.ApplicationID); err != nil {
 			return rpc.Errorf("failed to store user state: %v", err)
 		}
 
@@ -297,7 +297,7 @@ func (h *Handler) SubmitDepositState(c *rpc.Context) {
 			return rpc.Errorf("failed to create transaction: %v", err)
 		}
 
-		if err := tx.RecordTransaction(*transaction); err != nil {
+		if err := tx.RecordTransaction(*transaction, appSession.ApplicationID); err != nil {
 			return rpc.Errorf("failed to record transaction: %v", err)
 		}
 		logger.Info("recorded transaction",

--- a/clearnode/api/app_session_v1/submit_deposit_state_test.go
+++ b/clearnode/api/app_session_v1/submit_deposit_state_test.go
@@ -182,14 +182,14 @@ func TestSubmitDepositState_Success(t *testing.T) {
 			state.Version == incomingUserState.Version &&
 			state.Transition.Type == core.TransitionTypeCommit &&
 			state.NodeSig != nil
-	})).Return(nil).Once()
+	}), mock.Anything).Return(nil).Once()
 
 	// Mock transaction recording
 	mockStore.On("RecordTransaction", mock.MatchedBy(func(tx core.Transaction) bool {
 		return tx.TxType == core.TransactionTypeCommit &&
 			tx.Amount.Equal(depositAmount) &&
 			tx.ToAccount == appSessionID
-	})).Return(nil).Once()
+	}), mock.Anything).Return(nil).Once()
 
 	// Create RPC request
 	rpcState := toRPCState(*incomingUserState)
@@ -661,10 +661,10 @@ func TestSubmitDepositState_AppRegistryDisabled(t *testing.T) {
 	})).Return(nil).Once()
 	mockStore.On("StoreUserState", mock.MatchedBy(func(state core.State) bool {
 		return state.UserWallet == participant1 && state.NodeSig != nil
-	})).Return(nil).Once()
+	}), mock.Anything).Return(nil).Once()
 	mockStore.On("RecordTransaction", mock.MatchedBy(func(tx core.Transaction) bool {
 		return tx.TxType == core.TransactionTypeCommit && tx.Amount.Equal(depositAmount)
-	})).Return(nil).Once()
+	}), mock.Anything).Return(nil).Once()
 
 	rpcState := toRPCState(*incomingUserState)
 	reqPayload := rpc.AppSessionsV1SubmitDepositStateRequest{

--- a/clearnode/api/app_session_v1/testing.go
+++ b/clearnode/api/app_session_v1/testing.go
@@ -73,8 +73,8 @@ func (m *MockStore) RecordLedgerEntry(userWallet, accountID, asset string, amoun
 	return args.Error(0)
 }
 
-func (m *MockStore) RecordTransaction(tx core.Transaction) error {
-	args := m.Called(tx)
+func (m *MockStore) RecordTransaction(tx core.Transaction, applicationID string) error {
+	args := m.Called(tx, applicationID)
 	return args.Error(0)
 }
 
@@ -97,8 +97,8 @@ func (m *MockStore) GetLastUserState(wallet, asset string, signed bool) (*core.S
 	return &state, args.Error(1)
 }
 
-func (m *MockStore) StoreUserState(state core.State) error {
-	args := m.Called(state)
+func (m *MockStore) StoreUserState(state core.State, applicationID string) error {
+	args := m.Called(state, applicationID)
 	return args.Error(0)
 }
 

--- a/clearnode/api/channel_v1/handler.go
+++ b/clearnode/api/channel_v1/handler.go
@@ -62,7 +62,7 @@ func (h *Handler) getChannelSigValidator(tx Store, asset string) *core.ChannelSi
 // issueTransferReceiverState creates and stores a new state for the receiver of a transfer.
 // It reads the receiver's current state, applies a transfer_receive transition with the same
 // amount and tx hash, signs it with the node's key, and persists it.
-func (h *Handler) issueTransferReceiverState(ctx context.Context, tx Store, senderState core.State) (*core.State, error) {
+func (h *Handler) issueTransferReceiverState(ctx context.Context, tx Store, senderState core.State, applicationID string) (*core.State, error) {
 	logger := log.FromContext(ctx)
 
 	incomingTransition := senderState.Transition
@@ -130,7 +130,7 @@ func (h *Handler) issueTransferReceiverState(ctx context.Context, tx Store, send
 		nodeSig := _nodeSig.String()
 		newState.NodeSig = &nodeSig
 	}
-	if err := tx.StoreUserState(*newState); err != nil {
+	if err := tx.StoreUserState(*newState, applicationID); err != nil {
 		return nil, rpc.Errorf("failed to store receiver state")
 	}
 

--- a/clearnode/api/channel_v1/interface.go
+++ b/clearnode/api/channel_v1/interface.go
@@ -32,7 +32,9 @@ type Store interface {
 	CheckOpenChannel(wallet, asset string) (string, bool, error)
 
 	// StoreUserState persists a new user state to the database.
-	StoreUserState(state core.State) error
+	// applicationID is the client-declared origin tag (rpc.ApplicationIDQueryParam);
+	// empty string is persisted as NULL.
+	StoreUserState(state core.State, applicationID string) error
 
 	// EnsureNoOngoingStateTransitions validates that no blockchain operations are pending
 	// that would conflict with submitting a new state transition.
@@ -44,7 +46,9 @@ type Store interface {
 
 	// RecordTransaction creates a transaction record linking state transitions
 	// to track the history of operations (deposits, withdrawals, transfers, etc.).
-	RecordTransaction(tx core.Transaction) error
+	// applicationID is the client-declared origin tag (rpc.ApplicationIDQueryParam);
+	// empty string is persisted as NULL.
+	RecordTransaction(tx core.Transaction, applicationID string) error
 
 	// CreateChannel creates a new channel entity in the database.
 	// This is called during channel creation before the channel exists on-chain.

--- a/clearnode/api/channel_v1/request_creation.go
+++ b/clearnode/api/channel_v1/request_creation.go
@@ -79,6 +79,8 @@ func (h *Handler) RequestCreation(c *rpc.Context) {
 		return
 	}
 
+	applicationID := rpc.GetApplicationID(c)
+
 	var nodeSig string
 	err = h.useStoreInTx(func(tx Store) error {
 		_, err := tx.LockUserState(incomingState.UserWallet, incomingState.Asset)
@@ -187,7 +189,7 @@ func (h *Handler) RequestCreation(c *rpc.Context) {
 		incomingState.NodeSig = &nodeSig
 
 		// Store the pending state
-		if err := tx.StoreUserState(incomingState); err != nil {
+		if err := tx.StoreUserState(incomingState, applicationID); err != nil {
 			return rpc.Errorf("failed to store state: %v", err)
 		}
 
@@ -208,7 +210,7 @@ func (h *Handler) RequestCreation(c *rpc.Context) {
 
 				// We return Node's signature, the user is expected to submit this on blockchain.
 			case core.TransitionTypeTransferSend:
-				newReceiverState, err := h.issueTransferReceiverState(ctx, tx, incomingState)
+				newReceiverState, err := h.issueTransferReceiverState(ctx, tx, incomingState, applicationID)
 				if err != nil {
 					return rpc.Errorf("failed to issue receiver state: %v", err)
 				}
@@ -220,7 +222,7 @@ func (h *Handler) RequestCreation(c *rpc.Context) {
 				return rpc.Errorf("transition '%s' is not supported by this endpoint", incomingTransition.Type.String())
 			}
 
-			if err := tx.RecordTransaction(*transaction); err != nil {
+			if err := tx.RecordTransaction(*transaction, applicationID); err != nil {
 				return rpc.Errorf("failed to record transaction")
 			}
 

--- a/clearnode/api/channel_v1/request_creation_test.go
+++ b/clearnode/api/channel_v1/request_creation_test.go
@@ -108,7 +108,7 @@ func TestRequestCreation_Success(t *testing.T) {
 		return tx.TxType == core.TransactionTypeHomeDeposit &&
 			tx.ToAccount == userWallet &&
 			tx.FromAccount != "" // homeChannelID will be set by handler
-	})).Return(nil).Once()
+	}), mock.Anything).Return(nil).Once()
 	mockTxStore.On("StoreUserState", mock.MatchedBy(func(state core.State) bool {
 		return state.UserWallet == userWallet &&
 			state.Asset == asset &&
@@ -116,7 +116,7 @@ func TestRequestCreation_Success(t *testing.T) {
 			state.Epoch == 0 &&
 			state.NodeSig != nil &&
 			state.HomeChannelID != nil
-	})).Return(nil).Once()
+	}), mock.Anything).Return(nil).Once()
 
 	// Create RPC request
 	rpcState := toRPCState(*initialState)
@@ -266,7 +266,7 @@ func TestRequestCreation_Acknowledgement_Success(t *testing.T) {
 			state.NodeSig != nil &&
 			state.HomeChannelID != nil &&
 			state.Transition.Type == core.TransitionTypeAcknowledgement
-	})).Return(nil).Once()
+	}), mock.Anything).Return(nil).Once()
 
 	// Create RPC request
 	rpcState := toRPCState(*initialState)
@@ -318,7 +318,7 @@ func TestRequestCreation_Acknowledgement_Success(t *testing.T) {
 	mockMemoryStore.AssertExpectations(t)
 	mockAssetStore.AssertExpectations(t)
 	mockTxStore.AssertExpectations(t)
-	mockTxStore.AssertNotCalled(t, "RecordTransaction", mock.Anything)
+	mockTxStore.AssertNotCalled(t, "RecordTransaction", mock.Anything, mock.Anything)
 }
 
 func TestRequestCreation_InvalidChallenge(t *testing.T) {

--- a/clearnode/api/channel_v1/submit_state.go
+++ b/clearnode/api/channel_v1/submit_state.go
@@ -27,6 +27,8 @@ func (h *Handler) SubmitState(c *rpc.Context) {
 		return
 	}
 
+	applicationID := rpc.GetApplicationID(c)
+
 	var nodeSig string
 	incomingTransition := incomingState.Transition
 	err = h.useStoreInTx(func(tx Store) error {
@@ -134,7 +136,7 @@ func (h *Handler) SubmitState(c *rpc.Context) {
 
 		// Store user state early — it's fully validated and signed at this point.
 		// The wrapping DB transaction ensures rollback if any subsequent step fails.
-		if err := tx.StoreUserState(incomingState); err != nil {
+		if err := tx.StoreUserState(incomingState, applicationID); err != nil {
 			return rpc.Errorf("failed to store user state: %v", err)
 		}
 
@@ -149,7 +151,7 @@ func (h *Handler) SubmitState(c *rpc.Context) {
 				}
 
 			case core.TransitionTypeTransferSend:
-				newReceiverState, err := h.issueTransferReceiverState(ctx, tx, incomingState)
+				newReceiverState, err := h.issueTransferReceiverState(ctx, tx, incomingState, applicationID)
 				if err != nil {
 					return rpc.Errorf("failed to issue receiver state: %v", err)
 				}
@@ -218,7 +220,7 @@ func (h *Handler) SubmitState(c *rpc.Context) {
 				return rpc.Errorf("transition '%s' is not supported by this endpoint", incomingTransition.Type.String())
 			}
 
-			if err := tx.RecordTransaction(*transaction); err != nil {
+			if err := tx.RecordTransaction(*transaction, applicationID); err != nil {
 				return rpc.Errorf("failed to record transaction")
 			}
 

--- a/clearnode/api/channel_v1/submit_state_test.go
+++ b/clearnode/api/channel_v1/submit_state_test.go
@@ -137,7 +137,7 @@ func TestSubmitState_TransferSend_Success(t *testing.T) {
 			state.Version == expectedReceiverState.Version &&
 			state.Transition.Type == core.TransitionTypeTransferReceive &&
 			state.NodeSig != nil
-	})).Return(nil)
+	}), mock.Anything).Return(nil)
 
 	// For recordTransaction
 	mockTxStore.On("RecordTransaction", mock.MatchedBy(func(tx core.Transaction) bool {
@@ -145,7 +145,7 @@ func TestSubmitState_TransferSend_Success(t *testing.T) {
 			tx.Amount.Equal(transferAmount) &&
 			tx.FromAccount == senderWallet &&
 			tx.ToAccount == receiverWallet
-	})).Return(nil)
+	}), mock.Anything).Return(nil)
 
 	// For storing sender state
 	mockTxStore.On("StoreUserState", mock.MatchedBy(func(state core.State) bool {
@@ -154,7 +154,7 @@ func TestSubmitState_TransferSend_Success(t *testing.T) {
 			state.Version == incomingSenderState.Version &&
 			state.Transition.Type == core.TransitionTypeTransferSend &&
 			state.NodeSig != nil
-	})).Return(nil)
+	}), mock.Anything).Return(nil)
 
 	// Create RPC request
 	rpcState := toRPCState(*incomingSenderState)
@@ -313,7 +313,7 @@ func TestSubmitState_TransferSend_ReceiverWithEscrowLock_Rejected(t *testing.T) 
 	// Sender state is stored before the transition-specific logic
 	mockTxStore.On("StoreUserState", mock.MatchedBy(func(state core.State) bool {
 		return state.UserWallet == senderWallet && state.NodeSig != nil
-	})).Return(nil)
+	}), mock.Anything).Return(nil)
 
 	// For issueTransferReceiverState - receiver has an active escrow lock
 	mockTxStore.On("LockUserState", receiverWallet, asset).Return(decimal.Zero, nil)
@@ -429,7 +429,7 @@ func TestSubmitState_TransferSend_SameWalletCaseInsensitive_Rejected(t *testing.
 	// Sender state is stored before the transition-specific logic
 	mockTxStore.On("StoreUserState", mock.MatchedBy(func(state core.State) bool {
 		return state.UserWallet == senderWallet && state.NodeSig != nil
-	})).Return(nil)
+	}), mock.Anything).Return(nil)
 
 	rpcState := toRPCState(*incomingSenderState)
 	reqPayload := rpc.ChannelsV1SubmitStateRequest{
@@ -573,13 +573,13 @@ func TestSubmitState_EscrowLock_Success(t *testing.T) {
 			tx.FromAccount == homeChannelID &&
 			tx.ToAccount == escrowChannelID &&
 			tx.Amount.Equal(lockAmount)
-	})).Return(nil)
+	}), mock.Anything).Return(nil)
 	mockTxStore.On("StoreUserState", mock.MatchedBy(func(state core.State) bool {
 		return state.UserWallet == userWallet &&
 			state.Version == incomingState.Version &&
 			state.Transition.Type == core.TransitionTypeEscrowLock &&
 			state.NodeSig != nil
-	})).Return(nil)
+	}), mock.Anything).Return(nil)
 
 	// Create RPC request
 	rpcState := toRPCState(*incomingState)
@@ -729,7 +729,7 @@ func TestSubmitState_EscrowWithdraw_Success(t *testing.T) {
 			tx.FromAccount == homeChannelID &&
 			tx.ToAccount == escrowChannelID &&
 			tx.Amount.Equal(withdrawAmount)
-	})).Return(nil)
+	}), mock.Anything).Return(nil)
 
 	// Store incoming state with node signature
 	mockTxStore.On("StoreUserState", mock.MatchedBy(func(state core.State) bool {
@@ -737,7 +737,7 @@ func TestSubmitState_EscrowWithdraw_Success(t *testing.T) {
 			state.Version == incomingState.Version &&
 			state.Transition.Type == core.TransitionTypeEscrowWithdraw &&
 			state.NodeSig != nil
-	})).Return(nil)
+	}), mock.Anything).Return(nil)
 
 	// Create RPC request
 	rpcState := toRPCState(*incomingState)
@@ -866,13 +866,13 @@ func TestSubmitState_HomeDeposit_Success(t *testing.T) {
 			tx.FromAccount == homeChannelID &&
 			tx.ToAccount == userWallet &&
 			tx.Amount.Equal(depositAmount)
-	})).Return(nil)
+	}), mock.Anything).Return(nil)
 	mockTxStore.On("StoreUserState", mock.MatchedBy(func(state core.State) bool {
 		return state.UserWallet == userWallet &&
 			state.Version == incomingState.Version &&
 			state.Transition.Type == core.TransitionTypeHomeDeposit &&
 			state.NodeSig != nil
-	})).Return(nil)
+	}), mock.Anything).Return(nil)
 
 	// Create RPC request
 	rpcState := toRPCState(*incomingState)
@@ -1001,14 +1001,14 @@ func TestSubmitState_HomeWithdrawal_Success(t *testing.T) {
 			tx.FromAccount == userWallet &&
 			tx.ToAccount == homeChannelID &&
 			tx.Amount.Equal(withdrawalAmount)
-	})).Return(nil)
+	}), mock.Anything).Return(nil)
 	mockTxStore.On("StoreUserState", mock.MatchedBy(func(state core.State) bool {
 		return state.UserWallet == userWallet &&
 			state.Version == incomingState.Version &&
 
 			state.Transition.Type == core.TransitionTypeHomeWithdrawal &&
 			state.NodeSig != nil
-	})).Return(nil)
+	}), mock.Anything).Return(nil)
 
 	// Create RPC request
 	rpcState := toRPCState(*incomingState)
@@ -1160,14 +1160,14 @@ func TestSubmitState_MutualLock_Success(t *testing.T) {
 			tx.FromAccount == homeChannelID &&
 			tx.ToAccount == escrowChannelID &&
 			tx.Amount.Equal(lockAmount)
-	})).Return(nil)
+	}), mock.Anything).Return(nil)
 	mockTxStore.On("StoreUserState", mock.MatchedBy(func(state core.State) bool {
 		return state.UserWallet == userWallet &&
 			state.Version == incomingState.Version &&
 
 			state.Transition.Type == core.TransitionTypeMutualLock &&
 			state.NodeSig != nil
-	})).Return(nil)
+	}), mock.Anything).Return(nil)
 
 	// Create RPC request
 	rpcState := toRPCState(*incomingState)
@@ -1318,7 +1318,7 @@ func TestSubmitState_EscrowDeposit_Success(t *testing.T) {
 			tx.FromAccount == escrowChannelID &&
 			tx.ToAccount == userWallet &&
 			tx.Amount.Equal(depositAmount)
-	})).Return(nil)
+	}), mock.Anything).Return(nil)
 
 	// Store incoming state with node signature
 	mockTxStore.On("StoreUserState", mock.MatchedBy(func(state core.State) bool {
@@ -1327,7 +1327,7 @@ func TestSubmitState_EscrowDeposit_Success(t *testing.T) {
 
 			state.Transition.Type == core.TransitionTypeEscrowDeposit &&
 			state.NodeSig != nil
-	})).Return(nil)
+	}), mock.Anything).Return(nil)
 
 	// Create RPC request
 	rpcState := toRPCState(*incomingState)
@@ -1456,7 +1456,7 @@ func TestSubmitState_Finalize_Success(t *testing.T) {
 			tx.FromAccount == userWallet &&
 			tx.ToAccount == homeChannelID &&
 			tx.Amount.Equal(userBalance)
-	})).Return(nil)
+	}), mock.Anything).Return(nil)
 	mockTxStore.On("StoreUserState", mock.MatchedBy(func(state core.State) bool {
 		return state.UserWallet == userWallet &&
 			state.Version == incomingState.Version &&
@@ -1465,7 +1465,7 @@ func TestSubmitState_Finalize_Success(t *testing.T) {
 			state.Transition.Amount.Equal(userBalance) &&
 			state.HomeLedger.UserBalance.IsZero() &&
 			state.NodeSig != nil
-	})).Return(nil)
+	}), mock.Anything).Return(nil)
 
 	// Create RPC request
 	rpcState := toRPCState(*incomingState)
@@ -1594,7 +1594,7 @@ func TestSubmitState_Acknowledgement_Success(t *testing.T) {
 			state.Version == incomingState.Version &&
 			state.Transition.Type == core.TransitionTypeAcknowledgement &&
 			state.NodeSig != nil
-	})).Return(nil)
+	}), mock.Anything).Return(nil)
 
 	// Create RPC request
 	rpcState := toRPCState(*incomingState)
@@ -1631,7 +1631,7 @@ func TestSubmitState_Acknowledgement_Success(t *testing.T) {
 
 	// Verify all mock expectations - notably RecordTransaction should NOT have been called
 	mockTxStore.AssertExpectations(t)
-	mockTxStore.AssertNotCalled(t, "RecordTransaction", mock.Anything)
+	mockTxStore.AssertNotCalled(t, "RecordTransaction", mock.Anything, mock.Anything)
 }
 
 // Helper function to create a string pointer

--- a/clearnode/api/channel_v1/testing.go
+++ b/clearnode/api/channel_v1/testing.go
@@ -45,8 +45,8 @@ func (m *MockStore) CheckOpenChannel(wallet, asset string) (string, bool, error)
 	return args.String(0), args.Bool(1), args.Error(2)
 }
 
-func (m *MockStore) StoreUserState(state core.State) error {
-	args := m.Called(state)
+func (m *MockStore) StoreUserState(state core.State, applicationID string) error {
+	args := m.Called(state, applicationID)
 	return args.Error(0)
 }
 
@@ -60,8 +60,8 @@ func (m *MockStore) ScheduleInitiateEscrowWithdrawal(stateID string, chainID uin
 	return args.Error(0)
 }
 
-func (m *MockStore) RecordTransaction(tx core.Transaction) error {
-	args := m.Called(tx)
+func (m *MockStore) RecordTransaction(tx core.Transaction, applicationID string) error {
+	args := m.Called(tx, applicationID)
 	return args.Error(0)
 }
 

--- a/clearnode/api/metric_store.go
+++ b/clearnode/api/metric_store.go
@@ -15,22 +15,22 @@ type metricStore struct {
 	callbacks []func()
 }
 
-func (s *metricStore) RecordTransaction(tx core.Transaction) error {
-	if err := s.DatabaseStore.RecordTransaction(tx); err != nil {
+func (s *metricStore) RecordTransaction(tx core.Transaction, applicationID string) error {
+	if err := s.DatabaseStore.RecordTransaction(tx, applicationID); err != nil {
 		return err
 	}
 	s.callbacks = append(s.callbacks, func() {
-		s.m.RecordTransaction(tx.Asset, tx.TxType, tx.Amount)
+		s.m.RecordTransaction(tx.Asset, tx.TxType, tx.Amount, applicationID)
 	})
 	return nil
 }
 
-func (s *metricStore) StoreUserState(state core.State) error {
-	if err := s.DatabaseStore.StoreUserState(state); err != nil {
+func (s *metricStore) StoreUserState(state core.State, applicationID string) error {
+	if err := s.DatabaseStore.StoreUserState(state, applicationID); err != nil {
 		return err
 	}
 	s.callbacks = append(s.callbacks, func() {
-		s.m.IncUserState(state.Asset, state.HomeLedger.BlockchainID, state.Transition.Type)
+		s.m.IncUserState(state.Asset, state.HomeLedger.BlockchainID, state.Transition.Type, applicationID)
 	})
 	return nil
 }

--- a/clearnode/config/migrations/postgres/20260420000000_add_application_id_to_writes.sql
+++ b/clearnode/config/migrations/postgres/20260420000000_add_application_id_to_writes.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+ALTER TABLE channel_states ADD COLUMN application_id VARCHAR(66);
+ALTER TABLE transactions ADD COLUMN application_id VARCHAR(66);
+
+CREATE INDEX idx_channel_states_app_id ON channel_states(application_id);
+CREATE INDEX idx_transactions_app_id ON transactions(application_id);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_transactions_app_id;
+DROP INDEX IF EXISTS idx_channel_states_app_id;
+ALTER TABLE transactions DROP COLUMN application_id;
+ALTER TABLE channel_states DROP COLUMN application_id;

--- a/clearnode/metrics/exporter.go
+++ b/clearnode/metrics/exporter.go
@@ -169,6 +169,13 @@ type runtimeMetricExporter struct {
 }
 
 // RuntimeMetricExporter exposes metrics related to runtime operations, such as API requests, channel state validations, and blockchain interactions.
+//
+// Cardinality note: user_states_total, transactions_total and
+// transactions_amount_total carry an application_id label. The value is
+// self-declared by clients and bounded only by the ingress regex
+// (pkg/app.ApplicationIDRegex, ~66 chars of [a-z0-9_-]). Operators running
+// untrusted clients should monitor series count on these metrics and, if
+// needed, add an allowlist or recording-rule aggregation before ingest.
 func NewRuntimeMetricExporter(reg prometheus.Registerer) (RuntimeMetricExporter, error) {
 	m := &runtimeMetricExporter{
 		// Shared

--- a/clearnode/metrics/exporter.go
+++ b/clearnode/metrics/exporter.go
@@ -374,37 +374,3 @@ const (
 func (res ActionResult) String() string {
 	return string(res)
 }
-
-// api/channel_v1
-// -* `user_states_total{asset, home_blockchain_id, transition}`
-// -* `transactions_total{asset, tx_type}`
-// -* `transactions_amount_total{asset, tx_type}`
-// - `channel_state_validations_total{sig_type, result}`
-
-// api/rpc_router.go
-// - `rpc_messages_total{msg_type, method}`
-// - `rpc_requests_total{method, status}`
-// - `rpc_request_duration_seconds{method, path, status}`
-// - `rpc_connections_total{region}`
-
-// api/app_session_v1
-// -* `app_state_updates{application}`
-// - `app_session_update_sig_validations_total{application, sig_type, result}`
-// -* `user_states_total{asset, home_blockchain_id, transition}`
-// -* `transactions_total{asset, tx_type}`
-// -* `transactions_amount_total{asset, tx_type}`
-// - `channel_state_sig_validations_total{sig_type, result}`
-
-// Blockchain Worker
-// -* `blockchain_actions_total{asset, blockchain_id, action_type, result}`
-
-// Event Listener
-// -* `blockchain_events_total{blockchain_id, process_result}`
-
-// By the end of this story a separate metric worker should expose the following metrics:
-
-// metric worker
-// - `channel_session_keys_total`
-// - `app_session_keys_total`
-// - `app_sessions_total{application,status}`
-// - `channels_total{asset,status}`

--- a/clearnode/metrics/exporter.go
+++ b/clearnode/metrics/exporter.go
@@ -176,17 +176,17 @@ func NewRuntimeMetricExporter(reg prometheus.Registerer) (RuntimeMetricExporter,
 			Namespace: MetricNamespace,
 			Name:      "user_states_total",
 			Help:      "Total number of user states",
-		}, []string{"asset", "home_blockchain_id", "transition"}),
+		}, []string{"asset", "home_blockchain_id", "transition", "application_id"}),
 		transactionsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: MetricNamespace,
 			Name:      "transactions_total",
 			Help:      "Total number of transactions",
-		}, []string{"asset", "tx_type"}),
+		}, []string{"asset", "tx_type", "application_id"}),
 		transactionsAmountTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: MetricNamespace,
 			Name:      "transactions_amount_total",
 			Help:      "Total amount of transactions processed",
-		}, []string{"asset", "tx_type"}),
+		}, []string{"asset", "tx_type", "application_id"}),
 		channelSessionKeysTotal: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: MetricNamespace,
 			Name:      "channel_session_keys_total",
@@ -278,14 +278,15 @@ func NewRuntimeMetricExporter(reg prometheus.Registerer) (RuntimeMetricExporter,
 }
 
 // Shared
-func (m *runtimeMetricExporter) IncUserState(asset string, homeBlockchainID uint64, transition core.TransitionType) {
+func (m *runtimeMetricExporter) IncUserState(asset string, homeBlockchainID uint64, transition core.TransitionType, applicationID string) {
 	homeBlockchainIDStr := strconv.FormatUint(homeBlockchainID, 10)
-	m.userStatesTotal.WithLabelValues(asset, homeBlockchainIDStr, transition.String()).Inc()
+	m.userStatesTotal.WithLabelValues(asset, homeBlockchainIDStr, transition.String(), getApplicationIDLabelValue(applicationID)).Inc()
 }
 
-func (m *runtimeMetricExporter) RecordTransaction(asset string, txType core.TransactionType, amount decimal.Decimal) {
-	m.transactionsTotal.WithLabelValues(asset, txType.String()).Inc()
-	m.transactionsAmountTotal.WithLabelValues(asset, txType.String()).Add(amount.InexactFloat64())
+func (m *runtimeMetricExporter) RecordTransaction(asset string, txType core.TransactionType, amount decimal.Decimal, applicationID string) {
+	appIDLabelValue := getApplicationIDLabelValue(applicationID)
+	m.transactionsTotal.WithLabelValues(asset, txType.String(), appIDLabelValue).Inc()
+	m.transactionsAmountTotal.WithLabelValues(asset, txType.String(), appIDLabelValue).Add(amount.InexactFloat64())
 }
 
 // api/rpc_router

--- a/clearnode/metrics/interface.go
+++ b/clearnode/metrics/interface.go
@@ -36,7 +36,7 @@ type RuntimeMetricExporter interface {
 	// api/rpc_router
 	IncRPCMessage(msgType rpc.MsgType, method string)
 	IncRPCRequest(method, path string, success bool)
-	ObserveRPCDuration(method, path string, success bool, durationSecs time.Duration)
+	ObserveRPCDuration(method, path string, success bool, duration time.Duration)
 	SetRPCConnections(region, origin string, count uint32)
 
 	// api/app_session_v1

--- a/clearnode/metrics/interface.go
+++ b/clearnode/metrics/interface.go
@@ -10,46 +10,61 @@ import (
 	"github.com/layer-3/nitrolite/pkg/rpc"
 )
 
+// defaultApplicationIDLabelValue is the value used for the application_id
+// metric label when a request arrives without an app_id query parameter, so
+// dashboards have a readable bucket for unattributed traffic.
+const defaultApplicationIDLabelValue = "_DEFAULT"
+
+// getApplicationIDLabelValue returns applicationID unchanged if non-empty,
+// otherwise defaultApplicationIDLabelValue.
+func getApplicationIDLabelValue(applicationID string) string {
+	if applicationID == "" {
+		return defaultApplicationIDLabelValue
+	}
+	return applicationID
+}
+
 // RuntimeMetricExporter defines the interface for recording runtime metrics across various components of the system.
 type RuntimeMetricExporter interface {
 	// Shared
-	IncUserState(asset string, homeBlockchainID uint64, transition core.TransitionType)  // +
-	RecordTransaction(asset string, txType core.TransactionType, amount decimal.Decimal) // +
-	IncChannelStateSigValidation(sigType core.ChannelSignerType, success bool)           // +
-	IncChannelSessionKeys()                                                              // +
-	IncAppSessionKeys()                                                                  // +
+	IncUserState(asset string, homeBlockchainID uint64, transition core.TransitionType, applicationID string)
+	RecordTransaction(asset string, txType core.TransactionType, amount decimal.Decimal, applicationID string)
+	IncChannelStateSigValidation(sigType core.ChannelSignerType, success bool)
+	IncChannelSessionKeys()
+	IncAppSessionKeys()
 
 	// api/rpc_router
-	IncRPCMessage(msgType rpc.MsgType, method string)                                 // +
-	IncRPCRequest(method, path string, success bool)                                  // +
-	ObserveRPCDuration(method, path string, success bool, durationSecs time.Duration) // +
-	SetRPCConnections(region, origin string, count uint32)                            // +
+	IncRPCMessage(msgType rpc.MsgType, method string)
+	IncRPCRequest(method, path string, success bool)
+	ObserveRPCDuration(method, path string, success bool, durationSecs time.Duration)
+	SetRPCConnections(region, origin string, count uint32)
 
 	// api/app_session_v1
-	IncAppStateUpdate(applicationID string)                                                                  // +
-	IncAppSessionUpdateSigValidation(applicationID string, sigType app.AppSessionSignerTypeV1, success bool) // +
+	IncAppStateUpdate(applicationID string)
+	IncAppSessionUpdateSigValidation(applicationID string, sigType app.AppSessionSignerTypeV1, success bool)
 
 	// Blockchain Worker
-	IncBlockchainAction(asset string, blockchainID uint64, actionType string, success bool) // +
+	IncBlockchainAction(asset string, blockchainID uint64, actionType string, success bool)
 
 	// Event Listener
-	IncBlockchainEvent(blockchainID uint64, handledSuccessfully bool) // +
+	IncBlockchainEvent(blockchainID uint64, handledSuccessfully bool)
 }
 
 // noopRuntimeMetricExporter is a no-op implementation for use in tests.
 type noopRuntimeMetricExporter struct{}
 
-func NewNoopRuntimeMetricExporter() RuntimeMetricExporter                                         { return noopRuntimeMetricExporter{} }
-func (noopRuntimeMetricExporter) IncUserState(string, uint64, core.TransitionType)                {}
-func (noopRuntimeMetricExporter) RecordTransaction(string, core.TransactionType, decimal.Decimal) {}
-func (noopRuntimeMetricExporter) IncChannelStateSigValidation(core.ChannelSignerType, bool)       {}
-func (noopRuntimeMetricExporter) IncChannelSessionKeys()                                          {}
-func (noopRuntimeMetricExporter) IncAppSessionKeys()                                              {}
-func (noopRuntimeMetricExporter) IncRPCMessage(rpc.MsgType, string)                               {}
-func (noopRuntimeMetricExporter) IncRPCRequest(string, string, bool)                              {}
-func (noopRuntimeMetricExporter) ObserveRPCDuration(string, string, bool, time.Duration)          {}
-func (noopRuntimeMetricExporter) SetRPCConnections(string, string, uint32)                        {}
-func (noopRuntimeMetricExporter) IncAppStateUpdate(string)                                        {}
+func NewNoopRuntimeMetricExporter() RuntimeMetricExporter                                  { return noopRuntimeMetricExporter{} }
+func (noopRuntimeMetricExporter) IncUserState(string, uint64, core.TransitionType, string) {}
+func (noopRuntimeMetricExporter) RecordTransaction(string, core.TransactionType, decimal.Decimal, string) {
+}
+func (noopRuntimeMetricExporter) IncChannelStateSigValidation(core.ChannelSignerType, bool) {}
+func (noopRuntimeMetricExporter) IncChannelSessionKeys()                                    {}
+func (noopRuntimeMetricExporter) IncAppSessionKeys()                                        {}
+func (noopRuntimeMetricExporter) IncRPCMessage(rpc.MsgType, string)                         {}
+func (noopRuntimeMetricExporter) IncRPCRequest(string, string, bool)                        {}
+func (noopRuntimeMetricExporter) ObserveRPCDuration(string, string, bool, time.Duration)    {}
+func (noopRuntimeMetricExporter) SetRPCConnections(string, string, uint32)                  {}
+func (noopRuntimeMetricExporter) IncAppStateUpdate(string)                                  {}
 func (noopRuntimeMetricExporter) IncAppSessionUpdateSigValidation(string, app.AppSessionSignerTypeV1, bool) {
 }
 func (noopRuntimeMetricExporter) IncBlockchainAction(string, uint64, string, bool) {

--- a/clearnode/store/database/blockchain_action_test.go
+++ b/clearnode/store/database/blockchain_action_test.go
@@ -34,7 +34,7 @@ func TestDBStore_ScheduleCheckpoint(t *testing.T) {
 				UserBalance: decimal.NewFromInt(1000),
 			},
 		}
-		require.NoError(t, store.StoreUserState(state))
+		require.NoError(t, store.StoreUserState(state, ""))
 
 		err := store.ScheduleCheckpoint(state.ID, 0)
 		require.NoError(t, err)
@@ -73,7 +73,7 @@ func TestDBStore_ScheduleInitiateEscrowWithdrawal(t *testing.T) {
 				UserBalance: decimal.NewFromInt(500),
 			},
 		}
-		require.NoError(t, store.StoreUserState(state))
+		require.NoError(t, store.StoreUserState(state, ""))
 
 		err := store.ScheduleInitiateEscrowWithdrawal(state.ID, 0)
 		require.NoError(t, err)
@@ -107,7 +107,7 @@ func TestDBStore_ScheduleFinalizeEscrowDeposit(t *testing.T) {
 				UserBalance: decimal.NewFromInt(100),
 			},
 		}
-		require.NoError(t, store.StoreUserState(state))
+		require.NoError(t, store.StoreUserState(state, ""))
 
 		err := store.ScheduleFinalizeEscrowDeposit(state.ID, 0)
 		require.NoError(t, err)
@@ -139,7 +139,7 @@ func TestDBStore_ScheduleFinalizeEscrowWithdrawal(t *testing.T) {
 				UserBalance: decimal.NewFromInt(200),
 			},
 		}
-		require.NoError(t, store.StoreUserState(state))
+		require.NoError(t, store.StoreUserState(state, ""))
 
 		err := store.ScheduleFinalizeEscrowWithdrawal(state.ID, 0)
 		require.NoError(t, err)
@@ -171,7 +171,7 @@ func TestDBStore_Fail(t *testing.T) {
 				UserBalance: decimal.NewFromInt(300),
 			},
 		}
-		require.NoError(t, store.StoreUserState(state))
+		require.NoError(t, store.StoreUserState(state, ""))
 		require.NoError(t, store.ScheduleCheckpoint(state.ID, 0))
 
 		var action BlockchainAction
@@ -211,7 +211,7 @@ func TestDBStore_FailNoRetry(t *testing.T) {
 				UserBalance: decimal.NewFromInt(400),
 			},
 		}
-		require.NoError(t, store.StoreUserState(state))
+		require.NoError(t, store.StoreUserState(state, ""))
 		require.NoError(t, store.ScheduleCheckpoint(state.ID, 0))
 
 		var action BlockchainAction
@@ -251,7 +251,7 @@ func TestDBStore_RecordAttempt(t *testing.T) {
 				UserBalance: decimal.NewFromInt(150),
 			},
 		}
-		require.NoError(t, store.StoreUserState(state))
+		require.NoError(t, store.StoreUserState(state, ""))
 		require.NoError(t, store.ScheduleCheckpoint(state.ID, 0))
 
 		var action BlockchainAction
@@ -291,7 +291,7 @@ func TestDBStore_Complete(t *testing.T) {
 				UserBalance: decimal.NewFromInt(600),
 			},
 		}
-		require.NoError(t, store.StoreUserState(state))
+		require.NoError(t, store.StoreUserState(state, ""))
 		require.NoError(t, store.ScheduleCheckpoint(state.ID, 0))
 
 		var action BlockchainAction
@@ -329,7 +329,7 @@ func TestDBStore_Complete(t *testing.T) {
 				UserBalance: decimal.NewFromInt(250),
 			},
 		}
-		require.NoError(t, store.StoreUserState(state))
+		require.NoError(t, store.StoreUserState(state, ""))
 		require.NoError(t, store.ScheduleCheckpoint(state.ID, 0))
 
 		var action BlockchainAction
@@ -390,9 +390,9 @@ func TestDBStore_GetActions(t *testing.T) {
 			HomeLedger: core.Ledger{UserBalance: decimal.NewFromInt(300)},
 		}
 
-		require.NoError(t, store.StoreUserState(state1))
-		require.NoError(t, store.StoreUserState(state2))
-		require.NoError(t, store.StoreUserState(state3))
+		require.NoError(t, store.StoreUserState(state1, ""))
+		require.NoError(t, store.StoreUserState(state2, ""))
+		require.NoError(t, store.StoreUserState(state3, ""))
 
 		require.NoError(t, store.ScheduleCheckpoint(state1.ID, 0))
 		require.NoError(t, store.ScheduleInitiateEscrowWithdrawal(state2.ID, 0))
@@ -425,7 +425,7 @@ func TestDBStore_GetActions(t *testing.T) {
 				Transition: core.Transition{},
 				HomeLedger: core.Ledger{UserBalance: decimal.NewFromInt(int64(100 * (i + 1)))},
 			}
-			require.NoError(t, store.StoreUserState(state))
+			require.NoError(t, store.StoreUserState(state, ""))
 			require.NoError(t, store.ScheduleCheckpoint(state.ID, 0))
 		}
 
@@ -471,9 +471,9 @@ func TestDBStore_GetActions(t *testing.T) {
 			HomeLedger: core.Ledger{UserBalance: decimal.NewFromInt(300)},
 		}
 
-		require.NoError(t, store.StoreUserState(state1))
-		require.NoError(t, store.StoreUserState(state2))
-		require.NoError(t, store.StoreUserState(state3))
+		require.NoError(t, store.StoreUserState(state1, ""))
+		require.NoError(t, store.StoreUserState(state2, ""))
+		require.NoError(t, store.StoreUserState(state3, ""))
 
 		require.NoError(t, store.ScheduleCheckpoint(state1.ID, 0))
 		require.NoError(t, store.ScheduleCheckpoint(state2.ID, 0))

--- a/clearnode/store/database/channel_test.go
+++ b/clearnode/store/database/channel_test.go
@@ -234,7 +234,7 @@ func TestDBStore_GetActiveHomeChannel(t *testing.T) {
 				NodeNetFlow: decimal.Zero,
 			},
 		}
-		require.NoError(t, store.StoreUserState(state))
+		require.NoError(t, store.StoreUserState(state, ""))
 
 		result, err := store.GetActiveHomeChannel("0xuser123", "USDC")
 		require.NoError(t, err)
@@ -295,7 +295,7 @@ func TestDBStore_GetActiveHomeChannel(t *testing.T) {
 				NodeNetFlow: decimal.Zero,
 			},
 		}
-		require.NoError(t, store.StoreUserState(state))
+		require.NoError(t, store.StoreUserState(state, ""))
 
 		result, err := store.GetActiveHomeChannel("0xuser123", "USDC")
 		require.NoError(t, err)
@@ -341,7 +341,7 @@ func TestDBStore_GetActiveHomeChannel(t *testing.T) {
 				NodeNetFlow: decimal.Zero,
 			},
 		}
-		require.NoError(t, store.StoreUserState(state))
+		require.NoError(t, store.StoreUserState(state, ""))
 
 		result, err := store.GetActiveHomeChannel("0xuser123", "USDC")
 		require.NoError(t, err)
@@ -369,7 +369,7 @@ func TestDBStore_GetActiveHomeChannel(t *testing.T) {
 				NodeNetFlow: decimal.Zero,
 			},
 		}
-		require.NoError(t, store.StoreUserState(state))
+		require.NoError(t, store.StoreUserState(state, ""))
 
 		result, err := store.GetActiveHomeChannel("0xuser123", "USDC")
 		require.NoError(t, err)
@@ -418,7 +418,7 @@ func TestDBStore_CheckOpenChannel(t *testing.T) {
 				NodeNetFlow: decimal.Zero,
 			},
 		}
-		require.NoError(t, store.StoreUserState(state))
+		require.NoError(t, store.StoreUserState(state, ""))
 
 		approvedSigValidators, hasOpenChannel, err := store.CheckOpenChannel("0xuser123", "USDC")
 		require.NoError(t, err)
@@ -477,7 +477,7 @@ func TestDBStore_CheckOpenChannel(t *testing.T) {
 				NodeNetFlow: decimal.Zero,
 			},
 		}
-		require.NoError(t, store.StoreUserState(state))
+		require.NoError(t, store.StoreUserState(state, ""))
 
 		approvedSigValidators, hasOpenChannel, err := store.CheckOpenChannel("0xuser123", "USDC")
 		require.NoError(t, err)
@@ -524,7 +524,7 @@ func TestDBStore_CheckOpenChannel(t *testing.T) {
 				NodeNetFlow: decimal.Zero,
 			},
 		}
-		require.NoError(t, store.StoreUserState(state))
+		require.NoError(t, store.StoreUserState(state, ""))
 
 		// Check for different asset
 		approvedSigValidators, hasOpenChannel, err := store.CheckOpenChannel("0xuser123", "ETH")

--- a/clearnode/store/database/database.go
+++ b/clearnode/store/database/database.go
@@ -214,7 +214,7 @@ func migratePostgres(cnf DatabaseConfig, embedMigrations embed.FS) error {
 }
 
 func migrateSqlite(db *gorm.DB) error {
-	if err := db.AutoMigrate(&AppV1{}, &AppLedgerEntryV1{}, &Channel{}, &AppSessionV1{}, &ContractEvent{}, &BlockchainAction{}, &AppSessionKeyStateV1{}, &AppSessionKeyApplicationV1{}, &AppSessionKeyAppSessionIDV1{}, &UserBalance{}, &UserStakedV1{}, &ActionLogEntryV1{}, &LifespanMetric{}); err != nil {
+	if err := db.AutoMigrate(&AppV1{}, &AppLedgerEntryV1{}, &Channel{}, &AppSessionV1{}, &ContractEvent{}, &State{}, &Transaction{}, &BlockchainAction{}, &AppSessionKeyStateV1{}, &AppSessionKeyApplicationV1{}, &AppSessionKeyAppSessionIDV1{}, &UserBalance{}, &UserStakedV1{}, &ActionLogEntryV1{}, &LifespanMetric{}); err != nil {
 		return err
 	}
 	return nil

--- a/clearnode/store/database/db_store_test.go
+++ b/clearnode/store/database/db_store_test.go
@@ -39,7 +39,7 @@ func TestDBStore_GetUserBalances(t *testing.T) {
 		_, err := store.LockUserState("0xuser123", "USDC")
 		require.NoError(t, err)
 
-		require.NoError(t, store.StoreUserState(state))
+		require.NoError(t, store.StoreUserState(state, ""))
 
 		balances, err := store.GetUserBalances("0xuser123")
 		require.NoError(t, err)
@@ -97,8 +97,8 @@ func TestDBStore_GetUserBalances(t *testing.T) {
 		_, err = store.LockUserState("0xuser123", "ETH")
 		require.NoError(t, err)
 
-		require.NoError(t, store.StoreUserState(state1))
-		require.NoError(t, store.StoreUserState(state2))
+		require.NoError(t, store.StoreUserState(state1, ""))
+		require.NoError(t, store.StoreUserState(state2, ""))
 
 		balances, err := store.GetUserBalances("0xuser123")
 		require.NoError(t, err)
@@ -167,8 +167,8 @@ func TestDBStore_GetUserBalances(t *testing.T) {
 		_, err := store.LockUserState("0xuser123", "USDC")
 		require.NoError(t, err)
 
-		require.NoError(t, store.StoreUserState(state1))
-		require.NoError(t, store.StoreUserState(state2))
+		require.NoError(t, store.StoreUserState(state1, ""))
+		require.NoError(t, store.StoreUserState(state2, ""))
 
 		balances, err := store.GetUserBalances("0xuser123")
 		require.NoError(t, err)
@@ -223,8 +223,8 @@ func TestDBStore_GetUserBalances(t *testing.T) {
 		_, err := store.LockUserState("0xuser123", "USDC")
 		require.NoError(t, err)
 
-		require.NoError(t, store.StoreUserState(state1))
-		require.NoError(t, store.StoreUserState(state2))
+		require.NoError(t, store.StoreUserState(state1, ""))
+		require.NoError(t, store.StoreUserState(state2, ""))
 
 		balances, err := store.GetUserBalances("0xuser123")
 		require.NoError(t, err)
@@ -306,7 +306,7 @@ func TestDBStore_EnsureNoOngoingStateTransitions(t *testing.T) {
 		_, err := store.LockUserState("0xuser123", "USDC")
 		require.NoError(t, err)
 
-		require.NoError(t, store.StoreUserState(state))
+		require.NoError(t, store.StoreUserState(state, ""))
 
 		err = store.EnsureNoOngoingStateTransitions("0xuser123", "USDC")
 		require.NoError(t, err)
@@ -362,7 +362,7 @@ func TestDBStore_EnsureNoOngoingStateTransitions(t *testing.T) {
 		_, err := store.LockUserState("0xuser123", "USDC")
 		require.NoError(t, err)
 
-		require.NoError(t, store.StoreUserState(state))
+		require.NoError(t, store.StoreUserState(state, ""))
 
 		err = store.EnsureNoOngoingStateTransitions("0xuser123", "USDC")
 		assert.Error(t, err)
@@ -442,7 +442,7 @@ func TestDBStore_EnsureNoOngoingStateTransitions(t *testing.T) {
 		_, err := store.LockUserState("0xuser123", "USDC")
 		require.NoError(t, err)
 
-		require.NoError(t, store.StoreUserState(state))
+		require.NoError(t, store.StoreUserState(state, ""))
 
 		err = store.EnsureNoOngoingStateTransitions("0xuser123", "USDC")
 		require.NoError(t, err)
@@ -521,7 +521,7 @@ func TestDBStore_EnsureNoOngoingStateTransitions(t *testing.T) {
 		_, err := store.LockUserState("0xuser123", "USDC")
 		require.NoError(t, err)
 
-		require.NoError(t, store.StoreUserState(state))
+		require.NoError(t, store.StoreUserState(state, ""))
 
 		err = store.EnsureNoOngoingStateTransitions("0xuser123", "USDC")
 		assert.Error(t, err)
@@ -586,7 +586,7 @@ func TestDBStore_EnsureNoOngoingStateTransitions(t *testing.T) {
 		_, err := store.LockUserState("0xuser123", "USDC")
 		require.NoError(t, err)
 
-		require.NoError(t, store.StoreUserState(state))
+		require.NoError(t, store.StoreUserState(state, ""))
 
 		err = store.EnsureNoOngoingStateTransitions("0xuser123", "USDC")
 		require.NoError(t, err)
@@ -639,7 +639,7 @@ func TestDBStore_EnsureNoOngoingStateTransitions(t *testing.T) {
 		_, err := store.LockUserState("0xuser123", "USDC")
 		require.NoError(t, err)
 
-		require.NoError(t, store.StoreUserState(state))
+		require.NoError(t, store.StoreUserState(state, ""))
 
 		// Should not error because there's no signed state
 		err = store.EnsureNoOngoingStateTransitions("0xuser123", "USDC")

--- a/clearnode/store/database/interface.go
+++ b/clearnode/store/database/interface.go
@@ -32,7 +32,10 @@ type DatabaseStore interface {
 	GetUserTransactions(wallet string, asset *string, txType *core.TransactionType, fromTime *uint64, toTime *uint64, paginate *core.PaginationParams) ([]core.Transaction, core.PaginationMetadata, error)
 
 	// RecordTransaction creates a transaction record linking state transitions.
-	RecordTransaction(tx core.Transaction) error
+	// applicationID is the self-declared origin tag of the client that caused
+	// the transaction (see rpc.ApplicationIDQueryParam); empty string means no
+	// app_id was supplied and the column is persisted as NULL.
+	RecordTransaction(tx core.Transaction, applicationID string) error
 
 	// --- Channel Operations ---
 
@@ -69,7 +72,10 @@ type DatabaseStore interface {
 	GetLastUserState(wallet, asset string, signed bool) (*core.State, error)
 
 	// StoreUserState persists a new user state to the database.
-	StoreUserState(state core.State) error
+	// applicationID is the self-declared origin tag of the client that caused
+	// the transition (see rpc.ApplicationIDQueryParam); empty string means no
+	// app_id was supplied and the column is persisted as NULL.
+	StoreUserState(state core.State, applicationID string) error
 
 	// EnsureNoOngoingStateTransitions validates that no conflicting blockchain operations are pending.
 	EnsureNoOngoingStateTransitions(wallet, asset string) error

--- a/clearnode/store/database/state.go
+++ b/clearnode/store/database/state.go
@@ -71,6 +71,10 @@ type State struct {
 	UserSig *string `gorm:"column:user_sig;type:text"`
 	NodeSig *string `gorm:"column:node_sig;type:text"`
 
+	// ApplicationID is the self-declared origin tag of the client that caused
+	// this state transition (see rpc.ApplicationIDQueryParam). Advisory only.
+	ApplicationID *string `gorm:"column:application_id;size:66;index:idx_channel_states_app_id"`
+
 	// Read-only fields populated from JOINs with channels table
 	HomeBlockchainID   *uint64 `gorm:"->;column:home_blockchain_id"`
 	HomeTokenAddress   *string `gorm:"->;column:home_token_address"`
@@ -130,10 +134,15 @@ func (s *DBStore) GetLastUserState(wallet, asset string, signed bool) (*core.Sta
 }
 
 // StoreUserState persists a new user state to the database.
-func (s *DBStore) StoreUserState(state core.State) error {
+// applicationID is the client-declared origin tag; empty string → NULL column.
+func (s *DBStore) StoreUserState(state core.State, applicationID string) error {
 	dbState, err := coreStateToDB(&state)
 	if err != nil {
 		return fmt.Errorf("failed to encode transitions while creating a db state: %w", err)
+	}
+
+	if applicationID != "" {
+		dbState.ApplicationID = &applicationID
 	}
 
 	if err := s.db.Create(dbState).Error; err != nil {

--- a/clearnode/store/database/state_test.go
+++ b/clearnode/store/database/state_test.go
@@ -14,6 +14,62 @@ func TestState_TableName(t *testing.T) {
 	assert.Equal(t, "channel_states", state.TableName())
 }
 
+func TestDBStore_StoreUserState_ApplicationID(t *testing.T) {
+	newState := func(id string) core.State {
+		homeChannelID := "0xhomechannel123"
+		return core.State{
+			ID:            id,
+			Asset:         "USDC",
+			UserWallet:    "0xuserapp",
+			Epoch:         1,
+			Version:       1,
+			HomeChannelID: &homeChannelID,
+			Transition: core.Transition{
+				Type:      core.TransitionTypeHomeDeposit,
+				AccountID: homeChannelID,
+				Amount:    decimal.NewFromInt(1),
+			},
+			HomeLedger: core.Ledger{
+				UserBalance: decimal.NewFromInt(1),
+				UserNetFlow: decimal.NewFromInt(1),
+				NodeBalance: decimal.Zero,
+				NodeNetFlow: decimal.Zero,
+			},
+		}
+	}
+
+	t.Run("ApplicationID is persisted when provided", func(t *testing.T) {
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+
+		store := NewDBStore(db)
+		_, err := store.LockUserState("0xuserapp", "USDC")
+		require.NoError(t, err)
+
+		require.NoError(t, store.StoreUserState(newState("state-app"), "my-app"))
+
+		var dbState State
+		require.NoError(t, db.Where("id = ?", "state-app").First(&dbState).Error)
+		require.NotNil(t, dbState.ApplicationID)
+		assert.Equal(t, "my-app", *dbState.ApplicationID)
+	})
+
+	t.Run("ApplicationID is NULL when empty", func(t *testing.T) {
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+
+		store := NewDBStore(db)
+		_, err := store.LockUserState("0xuserapp", "USDC")
+		require.NoError(t, err)
+
+		require.NoError(t, store.StoreUserState(newState("state-noapp"), ""))
+
+		var dbState State
+		require.NoError(t, db.Where("id = ?", "state-noapp").First(&dbState).Error)
+		assert.Nil(t, dbState.ApplicationID)
+	})
+}
+
 func TestDBStore_StoreUserState(t *testing.T) {
 	t.Run("Success - Store new state", func(t *testing.T) {
 		db, cleanup := SetupTestDB(t)
@@ -47,7 +103,7 @@ func TestDBStore_StoreUserState(t *testing.T) {
 			NodeSig: &nodeSig,
 		}
 
-		err := store.StoreUserState(state)
+		err := store.StoreUserState(state, "")
 		require.NoError(t, err)
 
 		// Verify state was stored
@@ -107,7 +163,7 @@ func TestDBStore_StoreUserState(t *testing.T) {
 			NodeSig: &nodeSig,
 		}
 
-		err := store.StoreUserState(state)
+		err := store.StoreUserState(state, "")
 		require.NoError(t, err)
 
 		// Verify state was stored
@@ -144,11 +200,11 @@ func TestDBStore_StoreUserState(t *testing.T) {
 			},
 		}
 
-		err := store.StoreUserState(state)
+		err := store.StoreUserState(state, "")
 		require.NoError(t, err)
 
 		// Try to store again with same ID
-		err = store.StoreUserState(state)
+		err = store.StoreUserState(state, "")
 		assert.Error(t, err)
 	})
 }
@@ -207,8 +263,8 @@ func TestDBStore_GetLastUserState(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, store.StoreUserState(state1))
-		require.NoError(t, store.StoreUserState(state2))
+		require.NoError(t, store.StoreUserState(state1, ""))
+		require.NoError(t, store.StoreUserState(state2, ""))
 
 		// Get last state
 		result, err := store.GetLastUserState("0xuser123", "USDC", false)
@@ -278,8 +334,8 @@ func TestDBStore_GetLastUserState(t *testing.T) {
 			NodeSig: &nodeSig,
 		}
 
-		require.NoError(t, store.StoreUserState(state1))
-		require.NoError(t, store.StoreUserState(state2))
+		require.NoError(t, store.StoreUserState(state1, ""))
+		require.NoError(t, store.StoreUserState(state2, ""))
 
 		// Get last signed state should return state2
 		result, err := store.GetLastUserState("0xuser123", "USDC", true)
@@ -355,8 +411,8 @@ func TestDBStore_GetLastUserState(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, store.StoreUserState(state1))
-		require.NoError(t, store.StoreUserState(state2))
+		require.NoError(t, store.StoreUserState(state1, ""))
+		require.NoError(t, store.StoreUserState(state2, ""))
 
 		// Get last state - should prioritize higher epoch
 		result, err := store.GetLastUserState("0xuser123", "USDC", false)
@@ -407,7 +463,7 @@ func TestDBStore_GetLastStateByChannelID(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, store.StoreUserState(state))
+		require.NoError(t, store.StoreUserState(state, ""))
 
 		result, err := store.GetLastStateByChannelID(homeChannelID, false)
 		require.NoError(t, err)
@@ -474,7 +530,7 @@ func TestDBStore_GetLastStateByChannelID(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, store.StoreUserState(state))
+		require.NoError(t, store.StoreUserState(state, ""))
 
 		result, err := store.GetLastStateByChannelID(escrowChannelID, false)
 		require.NoError(t, err)
@@ -545,8 +601,8 @@ func TestDBStore_GetLastStateByChannelID(t *testing.T) {
 			NodeSig: &nodeSig,
 		}
 
-		require.NoError(t, store.StoreUserState(state1))
-		require.NoError(t, store.StoreUserState(state2))
+		require.NoError(t, store.StoreUserState(state1, ""))
+		require.NoError(t, store.StoreUserState(state2, ""))
 
 		result, err := store.GetLastStateByChannelID(homeChannelID, true)
 		require.NoError(t, err)
@@ -623,8 +679,8 @@ func TestDBStore_GetStateByChannelIDAndVersion(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, store.StoreUserState(state1))
-		require.NoError(t, store.StoreUserState(state2))
+		require.NoError(t, store.StoreUserState(state1, ""))
+		require.NoError(t, store.StoreUserState(state2, ""))
 
 		// Get version 1
 		result, err := store.GetStateByChannelIDAndVersion(homeChannelID, 1)
@@ -701,7 +757,7 @@ func TestDBStore_GetStateByChannelIDAndVersion(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, store.StoreUserState(state))
+		require.NoError(t, store.StoreUserState(state, ""))
 
 		result, err := store.GetStateByChannelIDAndVersion(escrowChannelID, 5)
 		require.NoError(t, err)
@@ -750,7 +806,7 @@ func TestDBStore_GetStateByChannelIDAndVersion(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, store.StoreUserState(state))
+		require.NoError(t, store.StoreUserState(state, ""))
 
 		result, err := store.GetStateByChannelIDAndVersion(homeChannelID, 999)
 		require.NoError(t, err)

--- a/clearnode/store/database/test/postgres_integration_test.go
+++ b/clearnode/store/database/test/postgres_integration_test.go
@@ -113,7 +113,7 @@ func TestPostgres_StateOperations(t *testing.T) {
 			},
 		}
 
-		err := store.StoreUserState(state)
+		err := store.StoreUserState(state, "")
 		require.NoError(t, err)
 
 		retrieved, err := store.GetLastUserState(wallet, asset, false)
@@ -169,9 +169,9 @@ func TestPostgres_StateOperations(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, store.StoreUserState(state1))
-		require.NoError(t, store.StoreUserState(state2))
-		require.NoError(t, store.StoreUserState(state3))
+		require.NoError(t, store.StoreUserState(state1, ""))
+		require.NoError(t, store.StoreUserState(state2, ""))
+		require.NoError(t, store.StoreUserState(state3, ""))
 
 		retrieved, err := store.GetLastUserState(wallet2, asset, false)
 		require.NoError(t, err)
@@ -201,7 +201,7 @@ func TestPostgres_TransactionOperations(t *testing.T) {
 			CreatedAt:   time.Now(),
 		}
 
-		err := store.RecordTransaction(tx1)
+		err := store.RecordTransaction(tx1, "")
 		require.NoError(t, err)
 
 		transactions, metadata, err := store.GetUserTransactions(wallet, nil, nil, nil, nil, &core.PaginationParams{})
@@ -236,8 +236,8 @@ func TestPostgres_TransactionOperations(t *testing.T) {
 			CreatedAt:   time.Now(),
 		}
 
-		require.NoError(t, store.RecordTransaction(tx1))
-		require.NoError(t, store.RecordTransaction(tx2))
+		require.NoError(t, store.RecordTransaction(tx1, ""))
+		require.NoError(t, store.RecordTransaction(tx2, ""))
 
 		assetFilter := "USDC"
 		transactions, _, err := store.GetUserTransactions(wallet2, &assetFilter, nil, nil, nil, &core.PaginationParams{})
@@ -446,8 +446,8 @@ func TestPostgres_UserBalances(t *testing.T) {
 		_, err = store.LockUserState(wallet, "ETH")
 		require.NoError(t, err)
 
-		require.NoError(t, store.StoreUserState(state1))
-		require.NoError(t, store.StoreUserState(state2))
+		require.NoError(t, store.StoreUserState(state1, ""))
+		require.NoError(t, store.StoreUserState(state2, ""))
 
 		balances, err := store.GetUserBalances(wallet)
 		require.NoError(t, err)
@@ -496,7 +496,7 @@ func TestPostgres_DecimalPrecision(t *testing.T) {
 			},
 		}
 
-		err := store.StoreUserState(state)
+		err := store.StoreUserState(state, "")
 		require.NoError(t, err)
 
 		retrieved, err := store.GetLastUserState(wallet, "USDC", false)
@@ -524,7 +524,7 @@ func TestPostgres_DecimalPrecision(t *testing.T) {
 			},
 		}
 
-		err := store.StoreUserState(state)
+		err := store.StoreUserState(state, "")
 		require.NoError(t, err)
 
 		retrieved, err := store.GetLastUserState(wallet, "ETH", false)

--- a/clearnode/store/database/testing.go
+++ b/clearnode/store/database/testing.go
@@ -99,7 +99,7 @@ func setupTestPostgres(ctx context.Context, t testing.TB) (*gorm.DB, testcontain
 		t.Fatalf("Failed to open PostgreSQL database: %v", err)
 	}
 
-	err = database.AutoMigrate(&AppV1{}, &AppLedgerEntryV1{}, &Channel{}, &AppSessionV1{}, &ContractEvent{}, &Transaction{}, &BlockchainAction{}, &AppSessionKeyStateV1{}, &AppSessionKeyApplicationV1{}, &AppSessionKeyAppSessionIDV1{}, &ChannelSessionKeyStateV1{}, &ChannelSessionKeyAssetV1{}, &UserBalance{}, &UserStakedV1{}, &ActionLogEntryV1{}, &LifespanMetric{})
+	err = database.AutoMigrate(&AppV1{}, &AppLedgerEntryV1{}, &Channel{}, &AppSessionV1{}, &ContractEvent{}, &State{}, &Transaction{}, &BlockchainAction{}, &AppSessionKeyStateV1{}, &AppSessionKeyApplicationV1{}, &AppSessionKeyAppSessionIDV1{}, &ChannelSessionKeyStateV1{}, &ChannelSessionKeyAssetV1{}, &UserBalance{}, &UserStakedV1{}, &ActionLogEntryV1{}, &LifespanMetric{})
 	if err != nil {
 		t.Fatalf("Failed to run migrations: %v", err)
 	}

--- a/clearnode/store/database/transaction.go
+++ b/clearnode/store/database/transaction.go
@@ -29,6 +29,10 @@ type Transaction struct {
 	ReceiverNewStateID *string              `gorm:"column:receiver_new_state_id;size:64"`
 	Amount             decimal.Decimal      `gorm:"column:amount;type:decimal(38,18);not null"`
 	CreatedAt          time.Time
+
+	// ApplicationID is the self-declared origin tag of the client that caused
+	// this transaction (see rpc.ApplicationIDQueryParam). Advisory only.
+	ApplicationID *string `gorm:"column:application_id;size:66;index:idx_transactions_app_id"`
 }
 
 func (Transaction) TableName() string {
@@ -36,7 +40,8 @@ func (Transaction) TableName() string {
 }
 
 // RecordTransaction creates a transaction record linking state transitions.
-func (s *DBStore) RecordTransaction(tx core.Transaction) error {
+// applicationID is the client-declared origin tag; empty string → NULL column.
+func (s *DBStore) RecordTransaction(tx core.Transaction, applicationID string) error {
 	dbTx := Transaction{
 		ID:          strings.ToLower(tx.ID),
 		Type:        tx.TxType,
@@ -53,6 +58,9 @@ func (s *DBStore) RecordTransaction(tx core.Transaction) error {
 	if tx.ReceiverNewStateID != nil {
 		lowered := strings.ToLower(*tx.ReceiverNewStateID)
 		dbTx.ReceiverNewStateID = &lowered
+	}
+	if applicationID != "" {
+		dbTx.ApplicationID = &applicationID
 	}
 
 	if err := s.db.Create(&dbTx).Error; err != nil {

--- a/clearnode/store/database/transaction_test.go
+++ b/clearnode/store/database/transaction_test.go
@@ -35,7 +35,7 @@ func TestDBStore_RecordTransaction(t *testing.T) {
 			CreatedAt:          time.Now(),
 		}
 
-		err := store.RecordTransaction(tx)
+		err := store.RecordTransaction(tx, "")
 		require.NoError(t, err)
 
 		// Verify transaction was recorded
@@ -75,7 +75,7 @@ func TestDBStore_RecordTransaction(t *testing.T) {
 			CreatedAt:          time.Now(),
 		}
 
-		err := store.RecordTransaction(tx)
+		err := store.RecordTransaction(tx, "")
 		require.NoError(t, err)
 
 		// Verify transaction was recorded
@@ -107,11 +107,11 @@ func TestDBStore_RecordTransaction(t *testing.T) {
 			CreatedAt:   time.Now(),
 		}
 
-		err := store.RecordTransaction(tx)
+		err := store.RecordTransaction(tx, "")
 		require.NoError(t, err)
 
 		// Try to record again with same ID
-		err = store.RecordTransaction(tx)
+		err = store.RecordTransaction(tx, "")
 		assert.Error(t, err)
 	})
 }
@@ -154,9 +154,9 @@ func TestDBStore_GetUserTransactions(t *testing.T) {
 			CreatedAt:   time.Now(),
 		}
 
-		require.NoError(t, store.RecordTransaction(tx1))
-		require.NoError(t, store.RecordTransaction(tx2))
-		require.NoError(t, store.RecordTransaction(tx3))
+		require.NoError(t, store.RecordTransaction(tx1, ""))
+		require.NoError(t, store.RecordTransaction(tx2, ""))
+		require.NoError(t, store.RecordTransaction(tx3, ""))
 
 		// Get all transactions for user123
 		pagination := &core.PaginationParams{}
@@ -198,8 +198,8 @@ func TestDBStore_GetUserTransactions(t *testing.T) {
 			CreatedAt:   time.Now(),
 		}
 
-		require.NoError(t, store.RecordTransaction(tx1))
-		require.NoError(t, store.RecordTransaction(tx2))
+		require.NoError(t, store.RecordTransaction(tx1, ""))
+		require.NoError(t, store.RecordTransaction(tx2, ""))
 
 		// Filter by USDC
 		asset := "USDC"
@@ -240,8 +240,8 @@ func TestDBStore_GetUserTransactions(t *testing.T) {
 			CreatedAt:   time.Now(),
 		}
 
-		require.NoError(t, store.RecordTransaction(tx1))
-		require.NoError(t, store.RecordTransaction(tx2))
+		require.NoError(t, store.RecordTransaction(tx1, ""))
+		require.NoError(t, store.RecordTransaction(tx2, ""))
 
 		// Filter by deposit type
 		txType := core.TransactionTypeHomeDeposit
@@ -294,9 +294,9 @@ func TestDBStore_GetUserTransactions(t *testing.T) {
 			CreatedAt:   baseTime.Add(-1 * time.Second),
 		}
 
-		require.NoError(t, store.RecordTransaction(tx1))
-		require.NoError(t, store.RecordTransaction(tx2))
-		require.NoError(t, store.RecordTransaction(tx3))
+		require.NoError(t, store.RecordTransaction(tx1, ""))
+		require.NoError(t, store.RecordTransaction(tx2, ""))
+		require.NoError(t, store.RecordTransaction(tx3, ""))
 
 		// Filter from 2 hours ago to now
 		fromTime := uint64(baseTime.Add(-2 * time.Hour).Unix())
@@ -327,7 +327,7 @@ func TestDBStore_GetUserTransactions(t *testing.T) {
 				Amount:      decimal.NewFromInt(int64(i * 100)),
 				CreatedAt:   time.Now().Add(time.Duration(i) * time.Minute),
 			}
-			require.NoError(t, store.RecordTransaction(tx))
+			require.NoError(t, store.RecordTransaction(tx, ""))
 		}
 
 		// Get first page (2 items)
@@ -405,10 +405,10 @@ func TestDBStore_GetUserTransactions(t *testing.T) {
 			CreatedAt:   baseTime,
 		}
 
-		require.NoError(t, store.RecordTransaction(tx1))
-		require.NoError(t, store.RecordTransaction(tx2))
-		require.NoError(t, store.RecordTransaction(tx3))
-		require.NoError(t, store.RecordTransaction(tx4))
+		require.NoError(t, store.RecordTransaction(tx1, ""))
+		require.NoError(t, store.RecordTransaction(tx2, ""))
+		require.NoError(t, store.RecordTransaction(tx3, ""))
+		require.NoError(t, store.RecordTransaction(tx4, ""))
 
 		// Filter: USDC + Deposit + from 1 hour ago
 		asset := "USDC"
@@ -455,7 +455,7 @@ func TestDBStore_GetUserTransactions(t *testing.T) {
 			CreatedAt:   time.Now(),
 		}
 
-		require.NoError(t, store.RecordTransaction(tx))
+		require.NoError(t, store.RecordTransaction(tx, ""))
 
 		pagination := &core.PaginationParams{}
 		transactions, metadata, err := store.GetUserTransactions("0xuser123", nil, nil, nil, nil, pagination)
@@ -465,5 +465,52 @@ func TestDBStore_GetUserTransactions(t *testing.T) {
 		assert.Equal(t, uint32(1), metadata.TotalCount)
 		assert.Equal(t, "tx1", transactions[0].ID)
 		assert.Equal(t, "0xuser123", transactions[0].ToAccount)
+	})
+
+	t.Run("ApplicationID is persisted when provided", func(t *testing.T) {
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+
+		store := NewDBStore(db)
+
+		tx := core.Transaction{
+			ID:          "txapp1",
+			Asset:       "USDC",
+			TxType:      core.TransactionTypeHomeDeposit,
+			FromAccount: "0xuserapp",
+			ToAccount:   "0xchannelapp",
+			Amount:      decimal.NewFromInt(500),
+			CreatedAt:   time.Now(),
+		}
+
+		require.NoError(t, store.RecordTransaction(tx, "my-app"))
+
+		var dbTx Transaction
+		require.NoError(t, db.Where("id = ?", "txapp1").First(&dbTx).Error)
+		require.NotNil(t, dbTx.ApplicationID)
+		assert.Equal(t, "my-app", *dbTx.ApplicationID)
+	})
+
+	t.Run("ApplicationID is NULL when empty", func(t *testing.T) {
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+
+		store := NewDBStore(db)
+
+		tx := core.Transaction{
+			ID:          "txnoapp",
+			Asset:       "USDC",
+			TxType:      core.TransactionTypeHomeDeposit,
+			FromAccount: "0xusernoapp",
+			ToAccount:   "0xchannelnoapp",
+			Amount:      decimal.NewFromInt(500),
+			CreatedAt:   time.Now(),
+		}
+
+		require.NoError(t, store.RecordTransaction(tx, ""))
+
+		var dbTx Transaction
+		require.NoError(t, db.Where("id = ?", "txnoapp").First(&dbTx).Error)
+		assert.Nil(t, dbTx.ApplicationID)
 	})
 }

--- a/pkg/app/app_v1.go
+++ b/pkg/app/app_v1.go
@@ -13,6 +13,18 @@ import (
 
 var AppIDV1Regex = regexp.MustCompile(`^[a-z0-9][-a-z0-9]{0,65}$`)
 
+// ApplicationIDRegex bounds the advisory application identifier to lowercase
+// letters, digits, dashes and underscores, 1..66 chars — matching the DB
+// column width (VARCHAR(66), see
+// clearnode/config/migrations/postgres/20260420000000_add_application_id_to_writes.sql).
+var ApplicationIDRegex = regexp.MustCompile(`^[a-z0-9_-]{1,66}$`)
+
+// IsValidApplicationID reports whether id is a well-formed advisory
+// application identifier (see ApplicationIDRegex).
+func IsValidApplicationID(id string) bool {
+	return ApplicationIDRegex.MatchString(id)
+}
+
 // AppV1 represents an application registry entry.
 type AppV1 struct {
 	ID                          string

--- a/pkg/app/app_v1_test.go
+++ b/pkg/app/app_v1_test.go
@@ -1,0 +1,41 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsValidApplicationID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		id   string
+		want bool
+	}{
+		{"simple", "my-app", true},
+		{"underscore", "my_app", true},
+		{"digits", "app-123", true},
+		{"dash only", "-", true},
+		{"underscore only", "_", true},
+		{"single char", "a", true},
+		{"exactly 66 chars", strings.Repeat("a", 66), true},
+
+		{"empty", "", false},
+		{"67 chars", strings.Repeat("a", 67), false},
+		{"uppercase", "MyApp", false},
+		{"space", "my app", false},
+		{"dot", "my.app", false},
+		{"slash", "my/app", false},
+		{"newline", "my\napp", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, IsValidApplicationID(tc.id))
+		})
+	}
+}

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -5,6 +5,30 @@ import (
 	"sync"
 )
 
+// ApplicationIDQueryParam is the URL query parameter clients use to declare
+// their application identity during the WebSocket upgrade (e.g.
+// ws://host/?app_id=my-app). The same key is used to store the value in
+// per-connection SafeStorage.
+const ApplicationIDQueryParam = "app_id"
+
+// GetApplicationID returns the application identifier associated with the current
+// connection (supplied by the client as the ApplicationIDQueryParam query parameter
+// during the WebSocket upgrade). Returns an empty string if no app_id was provided.
+//
+// The value is an advisory origin tag — it is self-declared by the client and
+// must not be used for authentication or access control.
+func GetApplicationID(c *Context) string {
+	if c == nil || c.Storage == nil {
+		return ""
+	}
+	v, ok := c.Storage.Get(ApplicationIDQueryParam)
+	if !ok {
+		return ""
+	}
+	s, _ := v.(string)
+	return s
+}
+
 // Handler defines the function signature for RPC request processors.
 // Handlers receive a Context containing the request and all necessary
 // information to process it. They can call c.Next() to delegate to

--- a/pkg/rpc/context_internal_test.go
+++ b/pkg/rpc/context_internal_test.go
@@ -137,6 +137,35 @@ func TestContext_Fail(t *testing.T) {
 	})
 }
 
+func TestGetApplicationID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns empty for nil context", func(t *testing.T) {
+		assert.Equal(t, "", GetApplicationID(nil))
+	})
+
+	t.Run("returns empty for nil storage", func(t *testing.T) {
+		assert.Equal(t, "", GetApplicationID(&Context{}))
+	})
+
+	t.Run("returns empty when unset", func(t *testing.T) {
+		ctx := &Context{Storage: NewSafeStorage()}
+		assert.Equal(t, "", GetApplicationID(ctx))
+	})
+
+	t.Run("returns value when set", func(t *testing.T) {
+		ctx := &Context{Storage: NewSafeStorage()}
+		ctx.Storage.Set(ApplicationIDQueryParam, "my-app")
+		assert.Equal(t, "my-app", GetApplicationID(ctx))
+	})
+
+	t.Run("returns empty when value is not a string", func(t *testing.T) {
+		ctx := &Context{Storage: NewSafeStorage()}
+		ctx.Storage.Set(ApplicationIDQueryParam, 123)
+		assert.Equal(t, "", GetApplicationID(ctx))
+	})
+}
+
 func TestSafeStorage(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/rpc/node.go
+++ b/pkg/rpc/node.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
+	"github.com/layer-3/nitrolite/pkg/app"
 	"github.com/layer-3/nitrolite/pkg/log"
 )
 
@@ -202,6 +203,14 @@ func NewWebsocketNode(config WebsocketNodeConfig) (*WebsocketNode, error) {
 // The method ensures proper cleanup when connections close, including
 // removing the connection from the hub and invoking disconnect callbacks.
 func (wn *WebsocketNode) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	applicationID := r.URL.Query().Get(ApplicationIDQueryParam)
+	if applicationID != "" && !app.IsValidApplicationID(applicationID) {
+		wn.cfg.Logger.Warn("rejecting connection with invalid application_id",
+			"remoteAddr", r.RemoteAddr, "applicationID", applicationID)
+		http.Error(w, fmt.Sprintf("invalid %s: must match %s", ApplicationIDQueryParam, app.ApplicationIDRegex.String()), http.StatusBadRequest)
+		return
+	}
+
 	wsConnection, err := wn.upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		wn.cfg.Logger.Error("failed to upgrade connection to WebSocket", "error", err)
@@ -210,7 +219,6 @@ func (wn *WebsocketNode) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer wsConnection.Close()
 
 	connectionID := uuid.NewString()
-	applicationID := r.URL.Query().Get(ApplicationIDQueryParam)
 
 	connConfig := WebsocketConnectionConfig{
 		ConnectionID:      connectionID,

--- a/pkg/rpc/node.go
+++ b/pkg/rpc/node.go
@@ -210,6 +210,7 @@ func (wn *WebsocketNode) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer wsConnection.Close()
 
 	connectionID := uuid.NewString()
+	applicationID := r.URL.Query().Get(ApplicationIDQueryParam)
 
 	connConfig := WebsocketConnectionConfig{
 		ConnectionID:      connectionID,
@@ -247,7 +248,7 @@ func (wn *WebsocketNode) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	go connection.Serve(parentCtx, childHandleClosure)
-	go wn.processRequests(connection, parentCtx, childHandleClosure)
+	go wn.processRequests(connection, applicationID, parentCtx, childHandleClosure)
 
 	wg.Wait()
 }
@@ -264,9 +265,12 @@ func (wn *WebsocketNode) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // The method runs until the connection closes or the context is cancelled.
 // Each connection has its own SafeStorage instance for maintaining state
 // across requests.
-func (wn *WebsocketNode) processRequests(conn Connection, parentCtx context.Context, handleClosure func(error)) {
+func (wn *WebsocketNode) processRequests(conn Connection, applicationID string, parentCtx context.Context, handleClosure func(error)) {
 	defer handleClosure(nil) // Stop other goroutines when done
 	safeStorage := NewSafeStorage()
+	if applicationID != "" {
+		safeStorage.Set(ApplicationIDQueryParam, applicationID)
+	}
 
 	for {
 		var messageBytes []byte

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -103,6 +103,11 @@ func NewClient(wsURL string, stateSigner core.ChannelSigner, rawSigner sign.Sign
 	dialer := rpc.NewWebsocketDialer(dialerConfig)
 	rpcClient := rpc.NewClient(dialer)
 
+	dialURL, err := appendApplicationIDQueryParam(wsURL, config.ApplicationID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid websocket URL: %w", err)
+	}
+
 	// Create client instance
 	client := &Client{
 		rpcClient:                rpcClient,
@@ -128,7 +133,7 @@ func NewClient(wsURL string, stateSigner core.ChannelSigner, rawSigner sign.Sign
 	}
 
 	// Establish connection
-	err := rpcClient.Start(context.Background(), wsURL, handleError)
+	err = rpcClient.Start(context.Background(), dialURL, handleError)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to clearnode: %w", err)
 	}

--- a/sdk/go/config.go
+++ b/sdk/go/config.go
@@ -2,8 +2,11 @@ package sdk
 
 import (
 	"log"
+	"net/url"
 	"os"
 	"time"
+
+	"github.com/layer-3/nitrolite/pkg/rpc"
 )
 
 // Config holds the configuration options for the Clearnode client.
@@ -24,6 +27,11 @@ type Config struct {
 	// BlockchainRPCs maps blockchain IDs to their RPC endpoints
 	// Used by SDKClient for on-chain operations
 	BlockchainRPCs map[uint64]string
+
+	// ApplicationID is an advisory origin tag the client sends to the clearnode as
+	// the "app_id" WebSocket query parameter. The clearnode stamps this value on
+	// records produced by requests from this client. Empty means no tag.
+	ApplicationID string
 }
 
 // Option is a functional option for configuring the Client.
@@ -34,6 +42,23 @@ var DefaultConfig = Config{
 	HandshakeTimeout: 5 * time.Second,
 	PingTimeout:      15 * time.Second,
 	ErrorHandler:     defaultErrorHandler,
+}
+
+// appendApplicationIDQueryParam returns wsURL with the app_id query parameter set
+// to applicationID. If applicationID is empty, wsURL is returned unchanged. Any
+// existing app_id value is overwritten. Returns an error if wsURL cannot be parsed.
+func appendApplicationIDQueryParam(wsURL, applicationID string) (string, error) {
+	if applicationID == "" {
+		return wsURL, nil
+	}
+	parsed, err := url.Parse(wsURL)
+	if err != nil {
+		return "", err
+	}
+	q := parsed.Query()
+	q.Set(rpc.ApplicationIDQueryParam, applicationID)
+	parsed.RawQuery = q.Encode()
+	return parsed.String(), nil
 }
 
 // defaultErrorHandler logs errors to stderr.
@@ -54,6 +79,15 @@ func WithHandshakeTimeout(d time.Duration) Option {
 func WithPingTimeout(d time.Duration) Option {
 	return func(c *Config) {
 		c.PingTimeout = d
+	}
+}
+
+// WithApplicationID sets the application ID sent to the clearnode as the
+// "app_id" WebSocket query parameter. The clearnode treats this as an advisory
+// origin tag on records produced by requests from this connection.
+func WithApplicationID(appID string) Option {
+	return func(c *Config) {
+		c.ApplicationID = appID
 	}
 }
 

--- a/sdk/go/config_test.go
+++ b/sdk/go/config_test.go
@@ -47,3 +47,37 @@ func TestDefaultErrorHandler(t *testing.T) {
 	defaultErrorHandler(nil)
 	// defaultErrorHandler(errors.New("test error")) // verification would require capturing stderr
 }
+
+func TestWithApplicationID(t *testing.T) {
+	c := &Config{}
+	WithApplicationID("my-app")(c)
+	assert.Equal(t, "my-app", c.ApplicationID)
+}
+
+func TestAppendApplicationIDQueryParam(t *testing.T) {
+	cases := []struct {
+		name    string
+		url     string
+		appID   string
+		want    string
+		wantErr bool
+	}{
+		{name: "empty app_id returns url unchanged", url: "ws://host/path", appID: "", want: "ws://host/path"},
+		{name: "adds app_id when no query", url: "ws://host/path", appID: "my-app", want: "ws://host/path?app_id=my-app"},
+		{name: "adds app_id alongside existing query", url: "ws://host/path?foo=bar", appID: "my-app", want: "ws://host/path?app_id=my-app&foo=bar"},
+		{name: "overwrites existing app_id", url: "ws://host/path?app_id=old", appID: "new", want: "ws://host/path?app_id=new"},
+		{name: "url-escapes the value", url: "ws://host/", appID: "a b&c", want: "ws://host/?app_id=a+b%26c"},
+		{name: "invalid url returns error", url: "://", appID: "x", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := appendApplicationIDQueryParam(tc.url, tc.appID)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/sdk/ts/src/client.ts
+++ b/sdk/ts/src/client.ts
@@ -14,7 +14,7 @@ import { StateV1, ChannelDefinitionV1, ChannelSessionKeyStateV1, AppV1, AppInfoV
 import { RPCClient } from './rpc/client.js';
 import { WebsocketDialer } from './rpc/dialer.js';
 import { ClientAssetStore } from './asset_store.js';
-import { Config, DefaultConfig, Option } from './config.js';
+import { appendApplicationIDQueryParam, Config, DefaultConfig, Option } from './config.js';
 import {
   generateNonce,
   transformNodeConfig,
@@ -199,8 +199,9 @@ export class Client {
       client.exitResolve?.();
     };
 
-    // Establish connection
-    await rpcClient.start(wsURL, handleError);
+    // Establish connection (append app_id query param if configured)
+    const dialURL = appendApplicationIDQueryParam(wsURL, config.applicationID);
+    await rpcClient.start(dialURL, handleError);
 
     return client;
   }

--- a/sdk/ts/src/config.ts
+++ b/sdk/ts/src/config.ts
@@ -19,6 +19,13 @@ export interface Config {
   blockchainRPCs?: Map<bigint, string>;
 
   pingInterval?: number;
+
+  /**
+   * Advisory origin tag sent to the clearnode as the "app_id" WebSocket query
+   * parameter. The clearnode stamps this value on records produced by requests
+   * from this client. Empty / undefined means no tag is sent.
+   */
+  applicationID?: string;
 }
 
 /**
@@ -61,6 +68,38 @@ export function withErrorHandler(handler: (error: Error) => void): Option {
   return (config: Config) => {
     config.errorHandler = handler;
   };
+}
+
+/**
+ * The URL query parameter name used to declare the client's application
+ * identity during the WebSocket upgrade. Kept in sync with
+ * pkg/rpc.ApplicationIDQueryParam on the server.
+ */
+export const APPLICATION_ID_QUERY_PARAM = 'app_id';
+
+/**
+ * withApplicationID sets the application ID sent to the clearnode as the
+ * `app_id` WebSocket query parameter. Advisory origin tag only.
+ */
+export function withApplicationID(appID: string): Option {
+  return (config: Config) => {
+    config.applicationID = appID;
+  };
+}
+
+/**
+ * appendApplicationIDQueryParam returns `wsURL` with the `app_id` query
+ * parameter set to `applicationID`. If `applicationID` is empty the URL is
+ * returned unchanged. Any existing `app_id` value is overwritten. Throws if
+ * `wsURL` cannot be parsed.
+ */
+export function appendApplicationIDQueryParam(wsURL: string, applicationID?: string): string {
+  if (!applicationID) {
+    return wsURL;
+  }
+  const parsed = new URL(wsURL);
+  parsed.searchParams.set(APPLICATION_ID_QUERY_PARAM, applicationID);
+  return parsed.toString();
 }
 
 /**

--- a/sdk/ts/src/config.ts
+++ b/sdk/ts/src/config.ts
@@ -90,14 +90,20 @@ export function withApplicationID(appID: string): Option {
 /**
  * appendApplicationIDQueryParam returns `wsURL` with the `app_id` query
  * parameter set to `applicationID`. If `applicationID` is empty the URL is
- * returned unchanged. Any existing `app_id` value is overwritten. Throws if
- * `wsURL` cannot be parsed.
+ * returned unchanged. Any existing `app_id` value is overwritten. Throws a
+ * descriptive error if `wsURL` cannot be parsed.
  */
 export function appendApplicationIDQueryParam(wsURL: string, applicationID?: string): string {
   if (!applicationID) {
     return wsURL;
   }
-  const parsed = new URL(wsURL);
+  let parsed: URL;
+  try {
+    parsed = new URL(wsURL);
+  } catch (err) {
+    const cause = err instanceof Error ? err.message : String(err);
+    throw new Error(`cannot append ${APPLICATION_ID_QUERY_PARAM}: invalid url ${JSON.stringify(wsURL)} (${cause})`);
+  }
   parsed.searchParams.set(APPLICATION_ID_QUERY_PARAM, applicationID);
   return parsed.toString();
 }

--- a/sdk/ts/src/index.ts
+++ b/sdk/ts/src/index.ts
@@ -23,7 +23,8 @@ export {
   type Option,
   withHandshakeTimeout,
   withErrorHandler,
-  withBlockchainRPC
+  withBlockchainRPC,
+  withApplicationID
 } from './config.js';
 
 // Export asset store

--- a/sdk/ts/src/index.ts
+++ b/sdk/ts/src/index.ts
@@ -24,7 +24,9 @@ export {
   withHandshakeTimeout,
   withErrorHandler,
   withBlockchainRPC,
-  withApplicationID
+  withApplicationID,
+  APPLICATION_ID_QUERY_PARAM,
+  appendApplicationIDQueryParam
 } from './config.js';
 
 // Export asset store

--- a/sdk/ts/test/unit/config.test.ts
+++ b/sdk/ts/test/unit/config.test.ts
@@ -41,7 +41,9 @@ describe('appendApplicationIDQueryParam', () => {
     expect(new URL(out).searchParams.get(APPLICATION_ID_QUERY_PARAM)).toBe('a b&c');
   });
 
-  it('throws on an invalid URL', () => {
-    expect(() => appendApplicationIDQueryParam('://', 'x')).toThrow();
+  it('throws a descriptive error on an invalid URL', () => {
+    expect(() => appendApplicationIDQueryParam('://', 'x')).toThrow(
+      /cannot append app_id: invalid url/,
+    );
   });
 });

--- a/sdk/ts/test/unit/config.test.ts
+++ b/sdk/ts/test/unit/config.test.ts
@@ -1,0 +1,47 @@
+import {
+  APPLICATION_ID_QUERY_PARAM,
+  appendApplicationIDQueryParam,
+  type Config,
+  withApplicationID,
+} from '../../src/config';
+
+describe('withApplicationID', () => {
+  it('sets applicationID on the config', () => {
+    const c: Config = { url: 'ws://host/' };
+    withApplicationID('my-app')(c);
+    expect(c.applicationID).toBe('my-app');
+  });
+});
+
+describe('appendApplicationIDQueryParam', () => {
+  it('returns the URL unchanged when applicationID is empty', () => {
+    expect(appendApplicationIDQueryParam('ws://host/path')).toBe('ws://host/path');
+    expect(appendApplicationIDQueryParam('ws://host/path', '')).toBe('ws://host/path');
+  });
+
+  it('adds app_id when no query string exists', () => {
+    const out = appendApplicationIDQueryParam('ws://host/path', 'my-app');
+    expect(out).toBe('ws://host/path?app_id=my-app');
+  });
+
+  it('adds app_id alongside an existing query string', () => {
+    const out = appendApplicationIDQueryParam('ws://host/path?foo=bar', 'my-app');
+    const parsed = new URL(out);
+    expect(parsed.searchParams.get('foo')).toBe('bar');
+    expect(parsed.searchParams.get(APPLICATION_ID_QUERY_PARAM)).toBe('my-app');
+  });
+
+  it('overwrites an existing app_id value', () => {
+    const out = appendApplicationIDQueryParam('ws://host/path?app_id=old', 'new');
+    expect(new URL(out).searchParams.get(APPLICATION_ID_QUERY_PARAM)).toBe('new');
+  });
+
+  it('url-encodes values with reserved characters', () => {
+    const out = appendApplicationIDQueryParam('ws://host/', 'a b&c');
+    expect(new URL(out).searchParams.get(APPLICATION_ID_QUERY_PARAM)).toBe('a b&c');
+  });
+
+  it('throws on an invalid URL', () => {
+    expect(() => appendApplicationIDQueryParam('://', 'x')).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- Treat `?app_id=` on the WebSocket upgrade as an advisory origin tag: clearnode reads it in `ServeHTTP`, stores it in per-connection `SafeStorage`, and stamps it onto `channel_states.application_id` and `transactions.application_id` (nullable `VARCHAR(66)`) for writes originating from client requests.
- App-session handlers use the **session's own `ApplicationID`** rather than the connection tag. `rebalance_app_sessions` now rejects batches that mix sessions from different applications.
- Metrics `user_states_total`, `transactions_total`, `transactions_amount_total` carry an `application_id` label; unset clients bucket under `_DEFAULT`.
- Go SDK (`WithApplicationID`) and TypeScript SDK (`withApplicationID`) append `?app_id=` to the dial URL.

## Notes

- The `application_id` column is advisory — it is self-declared by the client and **must not be used for access control**.
- Existing rows and clients that connect without `?app_id=` continue to work; their writes store `NULL`.
- Migration: `clearnode/config/migrations/postgres/20260420000000_add_application_id_to_writes.sql`.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` — 23/23 packages green, including new `TestGetApplicationID`, `TestDBStore_StoreUserState_ApplicationID`, `TestDBStore_RecordTransaction/ApplicationID_*`, `TestRebalanceAppSessions_Error_DifferentApplications`, `TestWithApplicationID`, `TestAppendApplicationIDQueryParam`
- [x] TS SDK typecheck introduces no new errors (pre-existing `state_advancer.ts` import-extension errors are unchanged)
- [x] Manual smoke: connect with and without `?app_id=`; verify column value on resulting rows
- [x] Verify Prometheus scrape shows `application_id` label on the three affected metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clients can supply an application ID via the WebSocket query parameter; SDKs include helpers to set and append it. Server validates the ID and attaches it to session/request flows.

* **Database Changes**
  * Added application_id columns and indexes to state and transaction storage; empty values are persisted as NULL.

* **Behavior Change**
  * Operations that aggregate sessions now enforce a single application ID across involved sessions.

* **Metrics**
  * Application ID added as a Prometheus label for user-state and transaction metrics.

* **Tests**
  * Updated and added tests covering validation, propagation, persistence, and multi-session enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->