### PR TITLE
YNU-869: Guard TS SDK drift and CI validation

### DIFF
--- a/.github/workflows/main-pr.yml
+++ b/.github/workflows/main-pr.yml
@@ -29,6 +29,7 @@ jobs:
     with:
       project-path: 'sdk/ts-compat'
       project-name: 'TS SDK Compat'
+      bootstrap-project-path: 'sdk/ts'
 
   build-and-publish-clearnode:
     name: Build and Publish (Clearnode)

--- a/.github/workflows/main-pr.yml
+++ b/.github/workflows/main-pr.yml
@@ -16,12 +16,19 @@ jobs:
     name: Test (Foundry)
     uses: ./.github/workflows/test-forge.yml
 
-  # test-sdk:
-  #   name: Test (SDK)
-  #   uses: ./.github/workflows/test-sdk.yml
-  #   with:
-  #     project-path: 'sdk'
-  #     project-name: 'SDK'
+  test-sdk-ts:
+    name: Test (TS SDK)
+    uses: ./.github/workflows/test-sdk.yml
+    with:
+      project-path: 'sdk/ts'
+      project-name: 'TS SDK'
+
+  test-sdk-compat:
+    name: Test (TS SDK Compat)
+    uses: ./.github/workflows/test-sdk.yml
+    with:
+      project-path: 'sdk/ts-compat'
+      project-name: 'TS SDK Compat'
 
   build-and-publish-clearnode:
     name: Build and Publish (Clearnode)
@@ -56,4 +63,3 @@ jobs:
           cache-from: type=gha
           build-args: |
             VERSION=${{ steps.sha.outputs.short_sha }}
-

--- a/.github/workflows/main-push.yml
+++ b/.github/workflows/main-push.yml
@@ -16,15 +16,22 @@ jobs:
     name: Test (Foundry)
     uses: ./.github/workflows/test-forge.yml
 
-  # test-sdk:
-  #   name: Test (SDK)
-  #   uses: ./.github/workflows/test-sdk.yml
-  #   with:
-  #     project-path: 'sdk'
-  #     project-name: 'SDK'
+  test-sdk-ts:
+    name: Test (TS SDK)
+    uses: ./.github/workflows/test-sdk.yml
+    with:
+      project-path: 'sdk/ts'
+      project-name: 'TS SDK'
+
+  test-sdk-compat:
+    name: Test (TS SDK Compat)
+    uses: ./.github/workflows/test-sdk.yml
+    with:
+      project-path: 'sdk/ts-compat'
+      project-name: 'TS SDK Compat'
 
   # build-and-publish-sdk:
-  #   needs: test-sdk
+  #   needs: [test-sdk-ts, test-sdk-compat]
   #   name: Build and Publish (SDK)
   #   uses: ./.github/workflows/publish-sdk.yml
   #   secrets:
@@ -93,7 +100,7 @@ jobs:
   # notify-slack:
   #   name: Notify Slack
   #   runs-on: ubuntu-latest
-  #   needs: [deploy-prod, deploy-sandbox, deploy-uat, test-forge, test-sdk]
+  #   needs: [deploy-prod, deploy-sandbox, deploy-uat, test-forge, test-sdk-ts, test-sdk-compat]
   #   if: always()
 
   #   steps:
@@ -116,4 +123,3 @@ jobs:
   #           ⚠️ RC build or deployment was cancelled!
   #           ${{github.event.head_commit.message}}
   #         SLACK_FOOTER: 'Nitrolite CI/CD Pipeline'
-

--- a/.github/workflows/main-push.yml
+++ b/.github/workflows/main-push.yml
@@ -29,6 +29,7 @@ jobs:
     with:
       project-path: 'sdk/ts-compat'
       project-name: 'TS SDK Compat'
+      bootstrap-project-path: 'sdk/ts'
 
   # build-and-publish-sdk:
   #   needs: [test-sdk-ts, test-sdk-compat]

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -11,6 +11,11 @@ on:
         description: 'Human-readable name for the project'
         required: true
         type: string
+      bootstrap-project-path:
+        description: 'Optional SDK project that must be built before validating the target project'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   test:
@@ -27,6 +32,16 @@ jobs:
           node-version-file: '${{ inputs.project-path }}/package.json'
           cache: 'npm'
           cache-dependency-path: '${{ inputs.project-path }}/package-lock.json'
+
+      - name: Install bootstrap dependencies
+        if: ${{ inputs.bootstrap-project-path != '' }}
+        run: npm ci
+        working-directory: ${{ inputs.bootstrap-project-path }}
+
+      - name: Build bootstrap project
+        if: ${{ inputs.bootstrap-project-path != '' }}
+        run: npm run build:ci
+        working-directory: ${{ inputs.bootstrap-project-path }}
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -31,7 +31,9 @@ jobs:
         with:
           node-version-file: '${{ inputs.project-path }}/package.json'
           cache: 'npm'
-          cache-dependency-path: '${{ inputs.project-path }}/package-lock.json'
+          cache-dependency-path: |
+            ${{ inputs.project-path }}/package-lock.json
+            ${{ inputs.bootstrap-project-path != '' && format('{0}/package-lock.json', inputs.bootstrap-project-path) || '' }}
 
       - name: Install bootstrap dependencies
         if: ${{ inputs.bootstrap-project-path != '' }}
@@ -45,10 +47,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-        working-directory: ${{ inputs.project-path }}
-
-      - name: Typecheck
-        run: npm run typecheck
         working-directory: ${{ inputs.project-path }}
 
       - name: Test

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -36,7 +36,7 @@ jobs:
         run: npm run typecheck
         working-directory: ${{ inputs.project-path }}
 
-      - name: Run tests
+      - name: Test
         run: npm test
         working-directory: ${{ inputs.project-path }}
 
@@ -45,5 +45,5 @@ jobs:
         working-directory: ${{ inputs.project-path }}
 
       - name: Build
-        run: npm run build
+        run: npm run build:ci
         working-directory: ${{ inputs.project-path }}

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -5,18 +5,16 @@ on:
     inputs:
       project-path:
         description: 'Path to the SDK project directory'
-        required: false
+        required: true
         type: string
-        default: 'sdk'
       project-name:
         description: 'Human-readable name for the project'
-        required: false
+        required: true
         type: string
-        default: 'SDK'
 
 jobs:
   test:
-    name: Test ${{ inputs.project-name }}
+    name: Validate ${{ inputs.project-name }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -34,6 +32,18 @@ jobs:
         run: npm ci
         working-directory: ${{ inputs.project-path }}
 
+      - name: Typecheck
+        run: npm run typecheck
+        working-directory: ${{ inputs.project-path }}
+
       - name: Run tests
         run: npm test
+        working-directory: ${{ inputs.project-path }}
+
+      - name: Lint
+        run: npm run lint
+        working-directory: ${{ inputs.project-path }}
+
+      - name: Build
+        run: npm run build
         working-directory: ${{ inputs.project-path }}

--- a/.github/workflows/v1-push.yml
+++ b/.github/workflows/v1-push.yml
@@ -29,6 +29,7 @@ jobs:
   #   with:
   #     project-path: 'sdk/ts-compat'
   #     project-name: 'TS SDK Compat'
+  #     bootstrap-project-path: 'sdk/ts'
 
   # build-and-publish-sdk:
   #   needs: [test-sdk-ts, test-sdk-compat]

--- a/.github/workflows/v1-push.yml
+++ b/.github/workflows/v1-push.yml
@@ -16,15 +16,22 @@ jobs:
     name: Test (Foundry)
     uses: ./.github/workflows/test-forge.yml
 
-  # test-sdk:
-  #   name: Test (SDK)
+  # test-sdk-ts:
+  #   name: Test (TS SDK)
   #   uses: ./.github/workflows/test-sdk.yml
   #   with:
-  #     project-path: 'sdk'
-  #     project-name: 'SDK'
+  #     project-path: 'sdk/ts'
+  #     project-name: 'TS SDK'
+
+  # test-sdk-compat:
+  #   name: Test (TS SDK Compat)
+  #   uses: ./.github/workflows/test-sdk.yml
+  #   with:
+  #     project-path: 'sdk/ts-compat'
+  #     project-name: 'TS SDK Compat'
 
   # build-and-publish-sdk:
-  #   needs: test-sdk
+  #   needs: [test-sdk-ts, test-sdk-compat]
   #   name: Build and Publish (SDK)
   #   uses: ./.github/workflows/publish-sdk.yml
   #   secrets:
@@ -137,7 +144,7 @@ jobs:
   # notify-slack:
   #   name: Notify Slack
   #   runs-on: ubuntu-latest
-  #   needs: [deploy-prod, deploy-sandbox, deploy-uat, test-forge, test-sdk]
+  #   needs: [deploy-prod, deploy-sandbox, deploy-uat, test-forge, test-sdk-ts, test-sdk-compat]
   #   if: always()
 
   #   steps:

--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -589,43 +589,6 @@ api:
               errors:
                 - message: channel_not_found
                   description: The specified channel was not found
-            - name: get_states
-              description: Retrieve state history for a user with optional filtering
-              request:
-                - field_name: wallet
-                  type: string
-                  description: The user's wallet address
-                - field_name: asset
-                  type: string
-                  description: Filter by asset symbol
-                - field_name: epoch
-                  type: string
-                  description: Filter by user epoch index
-                  optional: true
-                - field_name: channel_id
-                  type: string
-                  description: Filter by Home/Escrow Channel ID
-                  optional: true
-                - field_name: only_signed
-                  type: boolean
-                  description: Return only signed states
-                - field_name: pagination
-                  type: pagination_params
-                  description: Pagination parameters (offset, limit, sort)
-                  optional: true
-              response:
-                - field_name: states
-                  type: array
-                  items:
-                    type: state
-                  description: List of states
-                - field_name: metadata
-                  type: pagination_metadata
-                  description: Pagination information
-                  optional: true
-              errors:
-                - message: invalid_parameters
-                  description: The request parameters are invalid
             - name: request_creation
               description: Request the creation of a channel from Node
               request:

--- a/pkg/rpc/README.md
+++ b/pkg/rpc/README.md
@@ -350,12 +350,6 @@ state, err := client.ChannelsV1GetLatestState(ctx, rpc.ChannelsV1GetLatestStateR
     Asset:  "usdc",
 })
 
-// Get states with filters
-states, err := client.ChannelsV1GetStates(ctx, rpc.ChannelsV1GetStatesRequest{
-    Wallet: walletAddress,
-    Asset:  &asset,
-})
-
 // Request channel creation
 creation, err := client.ChannelsV1RequestCreation(ctx, rpc.ChannelsV1RequestCreationRequest{
     Wallet: walletAddress,
@@ -383,11 +377,6 @@ sessions, err := client.AppSessionsV1GetAppSessions(ctx, rpc.AppSessionsV1GetApp
 // Create app session
 session, err := client.AppSessionsV1CreateAppSession(ctx, rpc.AppSessionsV1CreateAppSessionRequest{
     Definition: definition,
-})
-
-// Close app session
-closeResp, err := client.AppSessionsV1CloseAppSession(ctx, rpc.AppSessionsV1CloseAppSessionRequest{
-    AppSessionID: sessionID,
 })
 
 // Submit deposit state

--- a/pkg/rpc/api.go
+++ b/pkg/rpc/api.go
@@ -77,30 +77,6 @@ type ChannelsV1GetLatestStateResponse struct {
 	State StateV1 `json:"state"`
 }
 
-// ChannelsV1GetStatesRequest retrieves state history for a user with optional filtering.
-type ChannelsV1GetStatesRequest struct {
-	// Wallet is the user's wallet address
-	Wallet string `json:"wallet"`
-	// Asset filters by asset symbol
-	Asset string `json:"asset"`
-	// Epoch filters by user epoch index
-	Epoch *string `json:"epoch,omitempty"`
-	// ChannelID filters by Home/Escrow Channel ID
-	ChannelID *string `json:"channel_id,omitempty"`
-	// OnlySigned returns only signed states
-	OnlySigned bool `json:"only_signed"`
-	// Pagination contains pagination parameters (offset, limit, sort)
-	Pagination *PaginationParamsV1 `json:"pagination,omitempty"`
-}
-
-// ChannelsV1GetStatesResponse returns the list of states.
-type ChannelsV1GetStatesResponse struct {
-	// States is the list of states
-	States []StateV1 `json:"states"`
-	// Metadata contains pagination information
-	Metadata PaginationMetadataV1 `json:"metadata"`
-}
-
 // ChannelsV1RequestCreationRequest requests the creation of a channel from Node.
 type ChannelsV1RequestCreationRequest struct {
 	// State is the state to be submitted

--- a/pkg/rpc/client.go
+++ b/pkg/rpc/client.go
@@ -96,15 +96,6 @@ func (c *Client) ChannelsV1GetLatestState(ctx context.Context, req ChannelsV1Get
 	return resp, nil
 }
 
-// ChannelsV1GetStates retrieves state history for a user with optional filtering.
-func (c *Client) ChannelsV1GetStates(ctx context.Context, req ChannelsV1GetStatesRequest) (ChannelsV1GetStatesResponse, error) {
-	var resp ChannelsV1GetStatesResponse
-	if err := c.call(ctx, ChannelsV1GetStatesMethod, req, &resp); err != nil {
-		return resp, err
-	}
-	return resp, nil
-}
-
 // ChannelsV1RequestCreation requests the creation of a channel from Node.
 func (c *Client) ChannelsV1RequestCreation(ctx context.Context, req ChannelsV1RequestCreationRequest) (ChannelsV1RequestCreationResponse, error) {
 	var resp ChannelsV1RequestCreationResponse

--- a/pkg/rpc/client_test.go
+++ b/pkg/rpc/client_test.go
@@ -245,35 +245,6 @@ func TestClientV1_ChannelsV1GetLatestState(t *testing.T) {
 	assert.Equal(t, testAssetV1, resp.State.Asset)
 }
 
-func TestClientV1_ChannelsV1GetStates(t *testing.T) {
-	t.Parallel()
-
-	client, dialer := setupClient()
-
-	states := rpc.ChannelsV1GetStatesResponse{
-		States: []rpc.StateV1{
-			{ID: "state1", Version: "1", Asset: testAssetV1},
-			{ID: "state2", Version: "2", Asset: testAssetV1},
-		},
-		Metadata: rpc.PaginationMetadataV1{
-			Page:       1,
-			PerPage:    10,
-			TotalCount: 2,
-			PageCount:  1,
-		},
-	}
-
-	registerSimpleHandlerV1(dialer, "channels.v1.get_states", states)
-
-	resp, err := client.ChannelsV1GetStates(testCtxV1, rpc.ChannelsV1GetStatesRequest{
-		Wallet:     testWalletV1,
-		Asset:      testAssetV1,
-		OnlySigned: false,
-	})
-	require.NoError(t, err)
-	assert.Len(t, resp.States, 2)
-}
-
 func TestClientV1_ChannelsV1RequestCreation(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/rpc/methods.go
+++ b/pkg/rpc/methods.go
@@ -12,7 +12,6 @@ const (
 	ChannelsV1GetEscrowChannelMethod      Method = "channels.v1.get_escrow_channel"
 	ChannelsV1GetChannelsMethod           Method = "channels.v1.get_channels"
 	ChannelsV1GetLatestStateMethod        Method = "channels.v1.get_latest_state"
-	ChannelsV1GetStatesMethod             Method = "channels.v1.get_states"
 	ChannelsV1RequestCreationMethod       Method = "channels.v1.request_creation"
 	ChannelsV1SubmitStateMethod           Method = "channels.v1.submit_state"
 	ChannelsV1SubmitSessionKeyStateMethod Method = "channels.v1.submit_session_key_state"

--- a/sdk/ts-compat/package.json
+++ b/sdk/ts-compat/package.json
@@ -12,6 +12,7 @@
     ],
     "scripts": {
         "build": "tsc",
+        "build:ci": "tsc",
         "build:prod": "tsc -p tsconfig.prod.json",
         "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js --config jest.config.cjs",
         "lint": "eslint src test",

--- a/sdk/ts-compat/src/client.ts
+++ b/sdk/ts-compat/src/client.ts
@@ -551,29 +551,38 @@ export class NitroliteClient {
     }
 
     async getAppSessionsList(wallet?: Address, status?: string): Promise<AppSession[]> {
-        const mapSessions = (sessions: any[]) => sessions.map((s) => ({
-            app_session_id: s.appSessionId,
-            nonce: Number(s.nonce ?? 0),
-            participants: s.participants.map((p: any) => p.walletAddress),
-            protocol: '',
-            quorum: s.quorum,
-            status: s.isClosed ? 'closed' : 'open',
-            version: Number(s.version ?? 0),
-            weights: s.participants.map((p: any) => p.signatureWeight),
-            allocations: s.allocations?.map((a: any) => {
-                const info = this.assetsBySymbol.get(a.asset?.toLowerCase?.() ?? '');
-                const dec = info?.decimals ?? 6;
-                const rawAmount = a.amount
-                    ? a.amount.mul(new Decimal(10).pow(dec)).toFixed(0)
-                    : '0';
-                return {
-                    participant: a.participant as Address,
-                    asset: a.asset,
-                    amount: rawAmount,
-                };
-            }) ?? [],
-            sessionData: s.sessionData ?? '',
-        }));
+        const mapSessions = (sessions: any[]) => sessions.map((s) => {
+            const definition = s.appDefinition ?? {
+                participants: s.participants ?? [],
+                quorum: s.quorum,
+                nonce: s.nonce,
+            };
+            const participants = definition.participants ?? [];
+
+            return {
+                app_session_id: s.appSessionId,
+                nonce: Number(definition.nonce ?? 0),
+                participants: participants.map((p: any) => p.walletAddress),
+                protocol: '',
+                quorum: definition.quorum ?? 0,
+                status: s.isClosed ? 'closed' : 'open',
+                version: Number(s.version ?? 0),
+                weights: participants.map((p: any) => p.signatureWeight),
+                allocations: s.allocations?.map((a: any) => {
+                    const info = this.assetsBySymbol.get(a.asset?.toLowerCase?.() ?? '');
+                    const dec = info?.decimals ?? 6;
+                    const rawAmount = a.amount
+                        ? a.amount.mul(new Decimal(10).pow(dec)).toFixed(0)
+                        : '0';
+                    return {
+                        participant: a.participant as Address,
+                        asset: a.asset,
+                        amount: rawAmount,
+                    };
+                }) ?? [],
+                sessionData: s.sessionData ?? '',
+            };
+        });
 
         const participant = (wallet ?? this.userAddress).toLowerCase() as Address;
         const normalizedStatus = status?.toLowerCase();

--- a/sdk/ts-compat/test/unit/client.test.ts
+++ b/sdk/ts-compat/test/unit/client.test.ts
@@ -1,0 +1,122 @@
+import { Decimal } from 'decimal.js';
+import { jest } from '@jest/globals';
+
+import { NitroliteClient } from '../../src/client.js';
+
+const wallet = '0x1111111111111111111111111111111111111111';
+const friend = '0x2222222222222222222222222222222222222222';
+
+function makeClient(sessions: any[]) {
+    const client = Object.create(NitroliteClient.prototype) as any;
+    client.userAddress = wallet;
+    client.innerClient = {
+        getAppSessions: jest.fn().mockResolvedValue({ sessions }),
+    };
+    client.assetsBySymbol = new Map([
+        ['yusd', { decimals: 6 }],
+        ['yellow', { decimals: 18 }],
+    ]);
+    client._lastAppSessionsListError = null;
+    client._lastAppSessionsListErrorLogged = null;
+
+    return client;
+}
+
+describe('NitroliteClient getAppSessionsList compat mapping', () => {
+    let infoSpy: jest.SpyInstance;
+    let warnSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+        warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        infoSpy.mockRestore();
+        warnSpy.mockRestore();
+    });
+
+    it('maps the current v1 appDefinition session shape', async () => {
+        const client = makeClient([
+            {
+                appSessionId: '0xsession',
+                appDefinition: {
+                    participants: [
+                        { walletAddress: wallet, signatureWeight: 1 },
+                        { walletAddress: friend, signatureWeight: 2 },
+                    ],
+                    quorum: 3,
+                    nonce: 42n,
+                },
+                isClosed: false,
+                version: 7n,
+                allocations: [
+                    { participant: wallet, asset: 'YUSD', amount: new Decimal('1.25') },
+                    { participant: friend, asset: 'YELLOW', amount: new Decimal('2') },
+                ],
+                sessionData: '{"intent":"purchase"}',
+            },
+        ]);
+
+        const sessions = await client.getAppSessionsList();
+
+        expect(client.innerClient.getAppSessions).toHaveBeenCalledWith({
+            wallet: wallet.toLowerCase(),
+        });
+        expect(sessions).toEqual([
+            {
+                app_session_id: '0xsession',
+                nonce: 42,
+                participants: [wallet, friend],
+                protocol: '',
+                quorum: 3,
+                status: 'open',
+                version: 7,
+                weights: [1, 2],
+                allocations: [
+                    { participant: wallet, asset: 'YUSD', amount: '1250000' },
+                    { participant: friend, asset: 'YELLOW', amount: '2000000000000000000' },
+                ],
+                sessionData: '{"intent":"purchase"}',
+            },
+        ]);
+    });
+
+    it('keeps the legacy flat session shape fallback', async () => {
+        const client = makeClient([
+            {
+                appSessionId: '0xlegacy',
+                participants: [
+                    { walletAddress: wallet, signatureWeight: 50 },
+                    { walletAddress: friend, signatureWeight: 50 },
+                ],
+                quorum: 100,
+                nonce: 99n,
+                isClosed: true,
+                version: 4n,
+                allocations: [],
+                sessionData: '{"legacy":true}',
+            },
+        ]);
+
+        const sessions = await client.getAppSessionsList(wallet, 'any');
+
+        expect(client.innerClient.getAppSessions).toHaveBeenCalledWith({
+            wallet: wallet.toLowerCase(),
+        });
+        expect(sessions).toEqual([
+            {
+                app_session_id: '0xlegacy',
+                nonce: 99,
+                participants: [wallet, friend],
+                protocol: '',
+                quorum: 100,
+                status: 'closed',
+                version: 4,
+                weights: [50, 50],
+                allocations: [],
+                sessionData: '{"legacy":true}',
+            },
+        ]);
+    });
+});

--- a/sdk/ts/package.json
+++ b/sdk/ts/package.json
@@ -11,6 +11,7 @@
     ],
     "scripts": {
         "build": "npm run test && tsc",
+        "build:ci": "tsc",
         "codegen-abi": "npx tsx scripts/codegen-abi.ts",
         "build:prod": "npm run test && tsc -p tsconfig.prod.json",
         "build:full": "npm run build",

--- a/sdk/ts/src/rpc/api.ts
+++ b/sdk/ts/src/rpc/api.ts
@@ -89,28 +89,6 @@ export interface ChannelsV1GetLatestStateResponse {
   state: StateV1;
 }
 
-export interface ChannelsV1GetStatesRequest {
-  /** User's wallet address */
-  wallet: Address;
-  /** Asset symbol */
-  asset: string;
-  /** User epoch index filter */
-  epoch?: bigint; // uint64
-  /** Home/Escrow Channel ID filter */
-  channel_id?: string;
-  /** Return only signed states */
-  only_signed: boolean;
-  /** Pagination parameters */
-  pagination?: PaginationParamsV1;
-}
-
-export interface ChannelsV1GetStatesResponse {
-  /** List of states */
-  states: StateV1[];
-  /** Pagination information */
-  metadata: PaginationMetadataV1;
-}
-
 export interface ChannelsV1RequestCreationRequest {
   /** State to be submitted */
   state: StateV1;

--- a/sdk/ts/src/rpc/client.ts
+++ b/sdk/ts/src/rpc/client.ts
@@ -88,13 +88,6 @@ export class RPCClient {
     return this.call(Methods.ChannelsV1GetLatestStateMethod, req, signal);
   }
 
-  async channelsV1GetStates(
-    req: API.ChannelsV1GetStatesRequest,
-    signal?: AbortSignal
-  ): Promise<API.ChannelsV1GetStatesResponse> {
-    return this.call(Methods.ChannelsV1GetStatesMethod, req, signal);
-  }
-
   async channelsV1RequestCreation(
     req: API.ChannelsV1RequestCreationRequest,
     signal?: AbortSignal

--- a/sdk/ts/src/rpc/methods.ts
+++ b/sdk/ts/src/rpc/methods.ts
@@ -18,7 +18,6 @@ export const ChannelsV1GetHomeChannelMethod: Method = 'channels.v1.get_home_chan
 export const ChannelsV1GetEscrowChannelMethod: Method = 'channels.v1.get_escrow_channel';
 export const ChannelsV1GetChannelsMethod: Method = 'channels.v1.get_channels';
 export const ChannelsV1GetLatestStateMethod: Method = 'channels.v1.get_latest_state';
-export const ChannelsV1GetStatesMethod: Method = 'channels.v1.get_states';
 export const ChannelsV1RequestCreationMethod: Method = 'channels.v1.request_creation';
 export const ChannelsV1SubmitStateMethod: Method = 'channels.v1.submit_state';
 

--- a/sdk/ts/test/unit/rpc-drift.test.ts
+++ b/sdk/ts/test/unit/rpc-drift.test.ts
@@ -34,7 +34,16 @@ function extractRouterHandlers(source: string): Set<string> {
         )
     );
 
-    return new Set(methodNames.map((name) => namedLiterals.get(name)).filter(Boolean) as string[]);
+    const unresolvedMethodNames = methodNames.filter((name) => !namedLiterals.has(name));
+    if (unresolvedMethodNames.length > 0) {
+        throw new Error(
+            `rpc_router.go references unresolved rpc method constants: ${unresolvedMethodNames.join(
+                ', '
+            )}`
+        );
+    }
+
+    return new Set(methodNames.map((name) => namedLiterals.get(name) as string));
 }
 
 function sorted(values: Set<string>): string[] {

--- a/sdk/ts/test/unit/rpc-drift.test.ts
+++ b/sdk/ts/test/unit/rpc-drift.test.ts
@@ -71,7 +71,7 @@ describe('TS RPC drift guards', () => {
         expect({ missing, extra }).toEqual({ missing: [], extra: [] });
     });
 
-    it('keeps every TS raw RPC method registered by the live router', () => {
+    it('keeps the TS raw RPC method surface aligned with live router registrations', () => {
         const routerMethods = extractRouterHandlers(
             fs.readFileSync(path.join(repoRoot, 'clearnode/api/rpc_router.go'), 'utf8')
         );

--- a/sdk/ts/test/unit/rpc-drift.test.ts
+++ b/sdk/ts/test/unit/rpc-drift.test.ts
@@ -5,6 +5,9 @@ import { fileURLToPath } from 'node:url';
 const testDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(testDir, '../../../..');
 
+// This guard intentionally parses rpc_router.go with regex. If router registration
+// is refactored away from direct Handle(rpc.XxxMethod.String(), ...) calls, update
+// extractRouterHandlers rather than treating the resulting failure as protocol drift.
 function extractGoMethodLiterals(source: string): Set<string> {
     const matches = source.matchAll(/^\s*[A-Za-z0-9]+Method\s+Method\s*=\s*"([^"]+)"$/gm);
     return new Set(Array.from(matches, ([, method]) => method));

--- a/sdk/ts/test/unit/rpc-drift.test.ts
+++ b/sdk/ts/test/unit/rpc-drift.test.ts
@@ -1,0 +1,74 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(testDir, '../../../..');
+
+function extractGoMethodLiterals(source: string): Set<string> {
+    const matches = source.matchAll(/^\s*[A-Za-z0-9]+Method\s+Method\s*=\s*"([^"]+)"$/gm);
+    return new Set(Array.from(matches, ([, method]) => method));
+}
+
+function extractTsMethodLiterals(source: string): Set<string> {
+    const matches = source.matchAll(
+        /^\s*export const [A-Za-z0-9]+Method:\s*Method\s*=\s*'([^']+)';$/gm
+    );
+    return new Set(Array.from(matches, ([, method]) => method));
+}
+
+function extractRouterHandlers(source: string): Set<string> {
+    const matches = source.matchAll(/Handle\(rpc\.[A-Za-z0-9]+Method\.String\(\),/g);
+    const methodNames = Array.from(matches, ([match]) =>
+        match.match(/rpc\.([A-Za-z0-9]+Method)\.String/)?.[1]
+    ).filter((methodName): methodName is string => Boolean(methodName));
+
+    const methodsSource = fs.readFileSync(path.join(repoRoot, 'pkg/rpc/methods.go'), 'utf8');
+    const namedLiterals = new Map<string, string>(
+        Array.from(
+            methodsSource.matchAll(/^\s*([A-Za-z0-9]+Method)\s+Method\s*=\s*"([^"]+)"$/gm),
+            ([, name, literal]) => [name, literal]
+        )
+    );
+
+    return new Set(methodNames.map((name) => namedLiterals.get(name)).filter(Boolean) as string[]);
+}
+
+function sorted(values: Set<string>): string[] {
+    return Array.from(values).sort();
+}
+
+function diff(left: Set<string>, right: Set<string>): { missing: string[]; extra: string[] } {
+    return {
+        missing: sorted(new Set(Array.from(right).filter((value) => !left.has(value)))),
+        extra: sorted(new Set(Array.from(left).filter((value) => !right.has(value)))),
+    };
+}
+
+describe('TS RPC drift guards', () => {
+    it('keeps the TS raw RPC method surface aligned with pkg/rpc', () => {
+        const goMethods = extractGoMethodLiterals(
+            fs.readFileSync(path.join(repoRoot, 'pkg/rpc/methods.go'), 'utf8')
+        );
+        const tsMethods = extractTsMethodLiterals(
+            fs.readFileSync(path.join(repoRoot, 'sdk/ts/src/rpc/methods.ts'), 'utf8')
+        );
+
+        const { missing, extra } = diff(tsMethods, goMethods);
+
+        expect({ missing, extra }).toEqual({ missing: [], extra: [] });
+    });
+
+    it('keeps every TS raw RPC method registered by the live router', () => {
+        const routerMethods = extractRouterHandlers(
+            fs.readFileSync(path.join(repoRoot, 'clearnode/api/rpc_router.go'), 'utf8')
+        );
+        const tsMethods = extractTsMethodLiterals(
+            fs.readFileSync(path.join(repoRoot, 'sdk/ts/src/rpc/methods.ts'), 'utf8')
+        );
+
+        const { missing, extra } = diff(tsMethods, routerMethods);
+
+        expect({ missing, extra }).toEqual({ missing: [], extra: [] });
+    });
+});


### PR DESCRIPTION
this is part of the ts sdk refinement work.

it does three things:
- removes the unsupported `channels.v1.get_states` surface from shared rpc, ts raw rpc, and the protocol docs
- adds a static drift test in `sdk/ts` to keep the ts raw rpc surface aligned with `pkg/rpc` and the live clearnode router
- re-enables sdk validation on `main` prs and pushes for both `sdk/ts` and `sdk/ts-compat`, using the real package paths and the full `typecheck` / `test` / `lint` / `build` gate


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the channels.get_states RPC method and its client interfaces (API, SDK clients, and related docs/examples).

* **Tests**
  * Added automated test to ensure RPC method lists stay aligned across implementations.
  * Expanded CI validations to include typecheck, lint, and CI builds for SDKs.

* **Chores**
  * CI updated to run separate jobs for TS SDK and TS-compat variants; added CI-only build scripts.

* **SDK**
  * TS-compat client now prefers embedded appDefinition payloads when mapping app session data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Additional compat fix discovered during stress Clearnode testing:

While wiring `cosign-demo` to `wss://clearnode-stress.yellow.org/v1/ws`, `getAppSessionsList()` exposed a compat drift: current v1 SDK sessions return participant/quorum/nonce data under `appDefinition`, but compat was still reading the old flat `participants` shape. This PR now maps `appDefinition.participants` first and keeps a flat-shape fallback for older callers.