### PR TITLE
feat(clearnode): adopt resource profiles for per-env clearnode sizing

### DIFF
--- a/clearnode/chart/config/profiles.yaml
+++ b/clearnode/chart/config/profiles.yaml
@@ -1,0 +1,78 @@
+# Resource sizing profiles for the clearnode release.
+#
+# Select one inline at the top of each env's clearnode.yaml.gotmpl:
+#
+#     {{- $profile := "medium" -}}
+#     {{- $p := index .Values.profiles $profile -}}
+#
+# Then reference `$p.replicaCount`, `$p.resources`, `$p.database.*` where the
+# chart previously had hardcoded values.
+#
+# ──────────────────────────────────────────────────────────────────────────────
+# Tuning notes — use this when authoring a new profile
+# ──────────────────────────────────────────────────────────────────────────────
+#
+#   replicaCount         Clearnode keeps signer state in-process. Running more
+#                        than one replica today is a no-op at best and a
+#                        correctness risk at worst — keep at 1 unless the
+#                        runtime has been refactored for distribution.
+#
+#   resources            requests == limits (guaranteed QoS class in GKE,
+#                        predictable scheduling, no throttling on burst).
+#                        ephemeral-storage is the same across tiers — it covers
+#                        logs + tmpfs, not workload data.
+#
+#   database.maxOpenConns    Upper bound on the Go DB pool's concurrent
+#                            connections to pgbouncer. Grows with CPU: more
+#                            CPU → more goroutines → more in-flight queries.
+#                            Stays comfortably below pgbouncer's
+#                            max_client_conn (2000 by default in our stack),
+#                            so pgbouncer multiplexing absorbs the headroom.
+#
+#   database.maxIdleConns    Sized at ~20–25% of maxOpenConns so the pool
+#                            reclaims fast on idle periods but doesn't thrash
+#                            on bursty traffic. Must be <= maxOpenConns.
+#
+# Profiles intentionally exclude:
+#   - autoscaling: override per env when needed (requires clearnode to be
+#     stateless first; see replicaCount note).
+#   - podDisruptionBudget: with replicaCount=1 a PDB blocks voluntary drains.
+#   - DB conn lifetimes (CONN_MAX_LIFETIME_SEC, CONN_MAX_IDLE_TIME_SEC):
+#     policy, not resource-dependent.
+#   - any networking / ingress / service account bits: env identity, not sizing.
+#
+# ──────────────────────────────────────────────────────────────────────────────
+# Profiles
+# ──────────────────────────────────────────────────────────────────────────────
+
+profiles:
+  # Smoke/stress — minimal footprint, single replica, no HA.
+  tiny:
+    replicaCount: 1
+    resources:
+      # CPU sized to 1.5× the derived bound (maxOpenConns × 0.01 CPU/conn).
+      requests: { cpu: 400m,  memory: 200Mi, ephemeral-storage: 256Mi }
+      limits:   { cpu: 400m,  memory: 200Mi, ephemeral-storage: 256Mi }
+    database:
+      maxOpenConns: 25
+      maxIdleConns: 6
+
+  # Baseline for active dev work — room to spare without over-provisioning.
+  light:
+    replicaCount: 1
+    resources:
+      requests: { cpu: 750m,  memory: 1Gi,   ephemeral-storage: 256Mi }
+      limits:   { cpu: 750m,  memory: 1Gi,   ephemeral-storage: 256Mi }
+    database:
+      maxOpenConns: 50
+      maxIdleConns: 12
+
+  # Release-candidate / sandbox — sized for representative load.
+  medium:
+    replicaCount: 1
+    resources:
+      requests: { cpu: 1500m, memory: 2Gi,   ephemeral-storage: 256Mi }
+      limits:   { cpu: 1500m, memory: 2Gi,   ephemeral-storage: 256Mi }
+    database:
+      maxOpenConns: 100
+      maxIdleConns: 25

--- a/clearnode/chart/config/sandbox-v1/clearnode.yaml.gotmpl
+++ b/clearnode/chart/config/sandbox-v1/clearnode.yaml.gotmpl
@@ -1,3 +1,5 @@
+{{- $profile := "medium" -}}
+{{- $p := index .Values.profiles $profile -}}
 config:
   args: ["clearnode"]
   logLevel: info
@@ -9,9 +11,9 @@ config:
     user: clearnode_sandbox_v1_admin
   gcpSaSecret: gcp-kms-signer-sa
   envSecret: clearnode-secret-env
-  extraEnvs: 
-    CLEARNODE_DATABASE_MAX_OPEN_CONNS: "10"
-    CLEARNODE_DATABASE_MAX_IDLE_CONNS: "2"
+  extraEnvs:
+    CLEARNODE_DATABASE_MAX_OPEN_CONNS: "{{ $p.database.maxOpenConns }}"
+    CLEARNODE_DATABASE_MAX_IDLE_CONNS: "{{ $p.database.maxIdleConns }}"
     CLEARNODE_DATABASE_CONN_MAX_LIFETIME_SEC: "3600"
     CLEARNODE_DATABASE_CONN_MAX_IDLE_TIME_SEC: "600"
     CLEARNODE_SIGNER_TYPE: "gcp-kms"
@@ -38,15 +40,9 @@ metrics:
   port: 4242
   endpoint: "/metrics"
 
+replicaCount: {{ $p.replicaCount }}
 resources:
-  limits:
-    cpu: 2000m
-    memory: 2Gi
-    ephemeral-storage: 256Mi
-  requests:
-    cpu: 2000m
-    memory: 2Gi
-    ephemeral-storage: 256Mi
+  {{- toYaml $p.resources | nindent 2 }}
 
 autoscaling:
   enabled: false

--- a/clearnode/chart/config/stress-v1/clearnode.yaml.gotmpl
+++ b/clearnode/chart/config/stress-v1/clearnode.yaml.gotmpl
@@ -1,3 +1,5 @@
+{{- $profile := "tiny" -}}
+{{- $p := index .Values.profiles $profile -}}
 config:
   args: ["clearnode"]
   logLevel: info
@@ -8,9 +10,9 @@ config:
     name: clearnode_stress_v1
     user: clearnode_stress_v1_admin
   envSecret: clearnode-secret-env
-  extraEnvs: 
-    CLEARNODE_DATABASE_MAX_OPEN_CONNS: "10"
-    CLEARNODE_DATABASE_MAX_IDLE_CONNS: "2"
+  extraEnvs:
+    CLEARNODE_DATABASE_MAX_OPEN_CONNS: "{{ $p.database.maxOpenConns }}"
+    CLEARNODE_DATABASE_MAX_IDLE_CONNS: "{{ $p.database.maxIdleConns }}"
     CLEARNODE_DATABASE_CONN_MAX_LIFETIME_SEC: "3600"
     CLEARNODE_DATABASE_CONN_MAX_IDLE_TIME_SEC: "600"
     CLEARNODE_SIGNER_TYPE: "gcp-kms"
@@ -42,15 +44,9 @@ metrics:
   port: 4242
   endpoint: "/metrics"
 
+replicaCount: {{ $p.replicaCount }}
 resources:
-  limits:
-    cpu: 200m
-    memory: 200Mi
-    ephemeral-storage: 256Mi
-  requests:
-    cpu: 200m
-    memory: 200Mi
-    ephemeral-storage: 256Mi
+  {{- toYaml $p.resources | nindent 2 }}
 
 autoscaling:
   enabled: false

--- a/clearnode/chart/config/v1-rc/clearnode.yaml.gotmpl
+++ b/clearnode/chart/config/v1-rc/clearnode.yaml.gotmpl
@@ -1,3 +1,5 @@
+{{- $profile := "medium" -}}
+{{- $p := index .Values.profiles $profile -}}
 config:
   args: ["clearnode"]
   logLevel: info
@@ -9,9 +11,9 @@ config:
     user: clearnode_v1_rc_admin
   gcpSaSecret: gcp-kms-signer-sa
   envSecret: clearnode-secret-env
-  extraEnvs: 
-    CLEARNODE_DATABASE_MAX_OPEN_CONNS: "10"
-    CLEARNODE_DATABASE_MAX_IDLE_CONNS: "2"
+  extraEnvs:
+    CLEARNODE_DATABASE_MAX_OPEN_CONNS: "{{ $p.database.maxOpenConns }}"
+    CLEARNODE_DATABASE_MAX_IDLE_CONNS: "{{ $p.database.maxIdleConns }}"
     CLEARNODE_DATABASE_CONN_MAX_LIFETIME_SEC: "3600"
     CLEARNODE_DATABASE_CONN_MAX_IDLE_TIME_SEC: "600"
     CLEARNODE_SIGNER_TYPE: "gcp-kms"
@@ -38,15 +40,9 @@ metrics:
   port: 4242
   endpoint: "/metrics"
 
+replicaCount: {{ $p.replicaCount }}
 resources:
-  limits:
-    cpu: 2000m
-    memory: 2Gi
-    ephemeral-storage: 256Mi
-  requests:
-    cpu: 2000m
-    memory: 2Gi
-    ephemeral-storage: 256Mi
+  {{- toYaml $p.resources | nindent 2 }}
 
 autoscaling:
   enabled: false

--- a/clearnode/helmfile.yaml.gotmpl
+++ b/clearnode/helmfile.yaml.gotmpl
@@ -1,7 +1,13 @@
 environments:
-  sandbox-v1: {}
-  stress-v1: {}
-  v1-rc: {}
+  sandbox-v1:
+    values:
+      - chart/config/profiles.yaml
+  stress-v1:
+    values:
+      - chart/config/profiles.yaml
+  v1-rc:
+    values:
+      - chart/config/profiles.yaml
 
 ---
 
@@ -14,7 +20,7 @@ releases:
       - chart/config/secrets.yaml
       - chart/config/{{ .Environment.Name }}/secrets.yaml
     values:
-      - chart/config/{{ .Environment.Name }}/clearnode.yaml
+      - chart/config/{{ .Environment.Name }}/clearnode.yaml.gotmpl
     set:
       - name: image.tag
         value: '{{ requiredEnv "IMAGE_TAG" }}'


### PR DESCRIPTION
- Introduce chart/config/profiles.yaml with tiny, light, medium profiles covering replicaCount, resources, and database connection pool (maxOpenConns/maxIdleConns). Header comment documents the tuning relationships — CPU sized to 1.5× derived bound from maxOpenConns, memory independent of pool size.
- Promote each env's clearnode.yaml to .gotmpl; the top selects a profile and the rest of the file references $p.replicaCount, $p.resources, and the two CLEARNODE_DATABASE_MAX_*_CONNS env vars.
- Env → profile: sandbox-v1 → medium, stress-v1 → tiny, v1-rc → medium.
- helmfile.yaml.gotmpl loads chart/config/profiles.yaml into each environment's values so .Values.profiles is visible when rendering each env's clearnode.yaml.gotmpl.

Pairs with layer-3/ops bumping pgbouncer/postgres conn sizing to match the new clearnode pool sizes (25/50/100 for tiny/light/medium).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced configurable deployment profiles (tiny, light, medium) enabling flexible resource sizing and database connection pool settings across environments.

* **Chores**
  * Updated deployment configurations to use selectable profiles instead of hardcoded resource specifications, improving environment-specific customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->