### PR TITLE
M2-H01: fix(contracts/ChannelHub): add finalize escrow home chain intent check

### DIFF
--- a/contracts/src/ChannelHub.sol
+++ b/contracts/src/ChannelHub.sol
@@ -696,7 +696,7 @@ contract ChannelHub is ReentrancyGuard {
 
         if (_isChannelHomeChain(channelId)) {
             require(msg.sender == NODE, IncorrectMsgSender());
-            _processHomeChainEscrowInitiate(channelId, candidate);
+            _processHomeChainEscrow(channelId, candidate);
             emit EscrowDepositInitiatedOnHome(escrowId, channelId, candidate);
         } else {
             // NON-HOME CHAIN: Create escrow record - recover addresses from signatures
@@ -734,17 +734,20 @@ contract ChannelHub is ReentrancyGuard {
     }
 
     function finalizeEscrowDeposit(bytes32 channelId, bytes32 escrowId, State calldata candidate) external {
-        EscrowDepositMeta storage meta = _escrowDeposits[escrowId];
-
         if (_isEscrowDepositHomeChain(channelId, escrowId)) {
             // HOME CHAIN: Get user from channel definition
-            ChannelMeta storage channelMeta = _channels[channelId];
-            _processHomeChainEscrowFinalize(channelId, candidate, channelMeta.definition.user);
+            require(candidate.intent == StateIntent.FINALIZE_ESCROW_DEPOSIT, IncorrectStateIntent());
+
+            ChannelDefinition storage metaDef = _channels[channelId].definition;
+            _validateSignatures(channelId, candidate, metaDef.user, metaDef.approvedSignatureValidators);
+
+            _processHomeChainEscrow(channelId, candidate);
             emit EscrowDepositFinalizedOnHome(escrowId, channelId, candidate);
             return;
         }
 
         // NON-HOME CHAIN: Use escrow metadata
+        EscrowDepositMeta storage meta = _escrowDeposits[escrowId];
         require(meta.channelId == channelId, IncorrectChannelId()); // Validate consistency
         address user = meta.user;
         EscrowStatus status = meta.status;
@@ -794,7 +797,7 @@ contract ChannelHub is ReentrancyGuard {
 
         if (_isChannelHomeChain(channelId)) {
             // HOME CHAIN: Process through channel state, no escrow metadata
-            _processHomeChainEscrowInitiate(channelId, candidate);
+            _processHomeChainEscrow(channelId, candidate);
             emit EscrowWithdrawalInitiatedOnHome(escrowId, channelId, candidate);
         } else {
             // NON-HOME CHAIN
@@ -832,17 +835,20 @@ contract ChannelHub is ReentrancyGuard {
     }
 
     function finalizeEscrowWithdrawal(bytes32 channelId, bytes32 escrowId, State calldata candidate) external {
-        EscrowWithdrawalMeta storage meta = _escrowWithdrawals[escrowId];
-
         if (_isEscrowWithdrawalHomeChain(channelId, escrowId)) {
             // HOME CHAIN: Get user from channel definition
-            ChannelMeta storage channelMeta = _channels[channelId];
-            _processHomeChainEscrowFinalize(channelId, candidate, channelMeta.definition.user);
+            require(candidate.intent == StateIntent.FINALIZE_ESCROW_WITHDRAWAL, IncorrectStateIntent());
+
+            ChannelDefinition storage metaDef = _channels[channelId].definition;
+            _validateSignatures(channelId, candidate, metaDef.user, metaDef.approvedSignatureValidators);
+
+            _processHomeChainEscrow(channelId, candidate);
             emit EscrowWithdrawalFinalizedOnHome(escrowId, channelId, candidate);
             return;
         }
 
         // NON-HOME CHAIN: Use escrow metadata
+        EscrowWithdrawalMeta storage meta = _escrowWithdrawals[escrowId];
         require(meta.channelId == channelId, IncorrectChannelId()); // Validate consistency
         address user = meta.user;
         EscrowStatus status = meta.status;
@@ -1046,8 +1052,8 @@ contract ChannelHub is ReentrancyGuard {
         require(ValidationResult.unwrap(result) != ValidationResult.unwrap(VALIDATION_FAILURE), IncorrectSignature());
     }
 
-    /// @dev Process HOME CHAIN path for escrow initiate operations
-    function _processHomeChainEscrowInitiate(bytes32 channelId, State calldata candidate) internal {
+    /// @dev Process HOME CHAIN path for escrow operations
+    function _processHomeChainEscrow(bytes32 channelId, State calldata candidate) internal {
         ChannelDefinition memory metaDef = _channels[channelId].definition;
 
         ChannelEngine.TransitionContext memory ctx =
@@ -1055,18 +1061,6 @@ contract ChannelHub is ReentrancyGuard {
         ChannelEngine.TransitionEffects memory effects = ChannelEngine.validateTransition(ctx, candidate);
 
         _applyEffects(channelId, metaDef, candidate, effects);
-    }
-
-    /// @dev Process HOME CHAIN path for escrow finalize operations
-    function _processHomeChainEscrowFinalize(bytes32 channelId, State calldata candidate, address user) internal {
-        ChannelDefinition memory channelDef = _channels[channelId].definition;
-        _validateSignatures(channelId, candidate, user, channelDef.approvedSignatureValidators);
-
-        ChannelEngine.TransitionContext memory ctx =
-            _buildChannelContext(channelId, _nodeBalances[candidate.homeLedger.token]);
-        ChannelEngine.TransitionEffects memory effects = ChannelEngine.validateTransition(ctx, candidate);
-
-        _applyEffects(channelId, channelDef, candidate, effects);
     }
 
     function _buildChannelContext(bytes32 channelId, uint256 nodeAvailableFunds)

--- a/contracts/test/ChannelEngine/ChannelEngine_validateTransition.t.sol
+++ b/contracts/test/ChannelEngine/ChannelEngine_validateTransition.t.sol
@@ -7,6 +7,7 @@ import {ChannelEngine} from "../../src/ChannelEngine.sol";
 import {ChannelStatus, State, StateIntent, Ledger} from "../../src/interfaces/Types.sol";
 import {TestUtils} from "../TestUtils.sol";
 
+// forge-lint: disable-next-item(unsafe-typecast)
 contract ChannelEngineTest_ValidateTransition is Test {
     // ======== Helpers ========
 

--- a/contracts/test/ChannelHub_challenge/ChannelHub_challengeSessionKeyValidator.t.sol
+++ b/contracts/test/ChannelHub_challenge/ChannelHub_challengeSessionKeyValidator.t.sol
@@ -6,7 +6,6 @@ import {ChannelHubTest_Challenge_Base} from "./ChannelHub_Challenge_Base.t.sol";
 import {Utils} from "../../src/Utils.sol";
 import {TestUtils, SESSION_KEY_VALIDATOR_ID} from "../TestUtils.sol";
 import {ChannelDefinition, State, StateIntent, Ledger, ParticipantIndex} from "../../src/interfaces/Types.sol";
-import {ChannelHub} from "../../src/ChannelHub.sol";
 import {SessionKeyValidator, SessionKeyAuthorization} from "../../src/sigValidators/SessionKeyValidator.sol";
 
 /*

--- a/contracts/test/ChannelHub_emitsNodeBalanceUpdated.t.sol
+++ b/contracts/test/ChannelHub_emitsNodeBalanceUpdated.t.sol
@@ -72,10 +72,6 @@ contract ChannelHubTest_emitsNodeBalanceUpdated is ChannelHubTest_Base {
     uint64 constant FOREIGN_CHAIN_ID = 42;
     address constant FOREIGN_TOKEN = address(42);
 
-    Ledger EMPTY_LEDGER = Ledger({
-        chainId: 0, token: address(0), decimals: 0, userAllocation: 0, userNetFlow: 0, nodeAllocation: 0, nodeNetFlow: 0
-    });
-
     // ======== Setup ========
 
     function setUp() public override {
@@ -134,7 +130,7 @@ contract ChannelHubTest_emitsNodeBalanceUpdated is ChannelHubTest_Base {
                 nodeAllocation: 0,
                 nodeNetFlow: 0
             }),
-            nonHomeLedger: EMPTY_LEDGER,
+            nonHomeLedger: TestUtils.emptyLedger(),
             userSig: "",
             nodeSig: ""
         });
@@ -159,7 +155,7 @@ contract ChannelHubTest_emitsNodeBalanceUpdated is ChannelHubTest_Base {
                 nodeAllocation: 0,
                 nodeNetFlow: int256(DEPOSIT_AMOUNT)
             }),
-            nonHomeLedger: EMPTY_LEDGER,
+            nonHomeLedger: TestUtils.emptyLedger(),
             userSig: "",
             nodeSig: ""
         });
@@ -272,7 +268,7 @@ contract ChannelHubTest_emitsNodeBalanceUpdated is ChannelHubTest_Base {
                 nodeAllocation: DEPOSIT_AMOUNT,
                 nodeNetFlow: int256(DEPOSIT_AMOUNT)
             }),
-            nonHomeLedger: EMPTY_LEDGER,
+            nonHomeLedger: TestUtils.emptyLedger(),
             userSig: "",
             nodeSig: ""
         });
@@ -300,7 +296,7 @@ contract ChannelHubTest_emitsNodeBalanceUpdated is ChannelHubTest_Base {
                 nodeAllocation: 0,
                 nodeNetFlow: int256(DEPOSIT_AMOUNT)
             }),
-            nonHomeLedger: EMPTY_LEDGER,
+            nonHomeLedger: TestUtils.emptyLedger(),
             userSig: "",
             nodeSig: ""
         });
@@ -351,7 +347,7 @@ contract ChannelHubTest_emitsNodeBalanceUpdated is ChannelHubTest_Base {
                 nodeAllocation: 0,
                 nodeNetFlow: 500
             }),
-            nonHomeLedger: EMPTY_LEDGER,
+            nonHomeLedger: TestUtils.emptyLedger(),
             userSig: "",
             nodeSig: ""
         });
@@ -400,7 +396,7 @@ contract ChannelHubTest_emitsNodeBalanceUpdated is ChannelHubTest_Base {
                 nodeAllocation: 0,
                 nodeNetFlow: 0
             }),
-            nonHomeLedger: EMPTY_LEDGER,
+            nonHomeLedger: TestUtils.emptyLedger(),
             userSig: "",
             nodeSig: ""
         });

--- a/contracts/test/ChannelHub_units/ChannelHub_challenge.t.sol
+++ b/contracts/test/ChannelHub_units/ChannelHub_challenge.t.sol
@@ -14,6 +14,7 @@ import {
     ParticipantIndex
 } from "../../src/interfaces/Types.sol";
 
+// forge-lint: disable-next-item(unsafe-typecast)
 contract ChannelHubTest_challenge is ChannelHubTest_Base {
     ChannelDefinition internal def;
     bytes32 internal channelId;
@@ -73,6 +74,34 @@ contract ChannelHubTest_challenge is ChannelHubTest_Base {
         );
         escrowState = mutualSignStateBothWithEcdsaValidator(escrowState, channelId, ALICE_PK);
     }
+
+    // ========== StateIntent ==========
+
+    function test_revert_closeIntent() public {
+        State memory state;
+        state.version = 1;
+        state.intent = StateIntent.CLOSE;
+
+        bytes memory challengerSig = signChallengeEip191WithEcdsaValidator(channelId, state, ALICE_PK);
+
+        vm.expectRevert(ChannelHub.IncorrectStateIntent.selector);
+        vm.prank(alice);
+        cHub.challengeChannel(channelId, state, challengerSig, ParticipantIndex.USER);
+    }
+
+    function test_revert_finalizeMigrationIntent() public {
+        State memory state;
+        state.version = 1;
+        state.intent = StateIntent.FINALIZE_MIGRATION;
+
+        bytes memory challengerSig = signChallengeEip191WithEcdsaValidator(channelId, state, ALICE_PK);
+
+        vm.expectRevert(ChannelHub.IncorrectStateIntent.selector);
+        vm.prank(alice);
+        cHub.challengeChannel(channelId, state, challengerSig, ParticipantIndex.USER);
+    }
+
+    // ========== INITIATE_ESCROW_DEPOSIT caller restriction ==========
 
     function test_revert_initiateEscrowDeposit_homeChain_callerNotNode() public {
         bytes memory challengerSig = signChallengeEip191WithEcdsaValidator(channelId, escrowState, ALICE_PK);

--- a/contracts/test/ChannelHub_units/ChannelHub_checkpointChannel.t.sol
+++ b/contracts/test/ChannelHub_units/ChannelHub_checkpointChannel.t.sol
@@ -3,9 +3,20 @@ pragma solidity 0.8.30;
 
 import {ChannelHubTest_Base} from "../ChannelHub_Base.t.sol";
 
-import {State} from "../../src/interfaces/Types.sol";
+import {ChannelHub} from "../../src/ChannelHub.sol";
+import {State, StateIntent} from "../../src/interfaces/Types.sol";
 
 contract ChannelHubTest_checkpointChannel is ChannelHubTest_Base {
+    // ========== StateIntent ==========
+
+    function test_revert_ifWrongIntent() public {
+        State memory state;
+        state.intent = StateIntent.DEPOSIT;
+
+        vm.expectRevert(ChannelHub.IncorrectStateIntent.selector);
+        cHub.checkpointChannel(bytes32(0), state);
+    }
+
     // ========== Payable ==========
 
     // The EVM rejects ETH at the dispatcher level before any Solidity code runs,

--- a/contracts/test/ChannelHub_units/ChannelHub_closeChannel.t.sol
+++ b/contracts/test/ChannelHub_units/ChannelHub_closeChannel.t.sol
@@ -3,9 +3,20 @@ pragma solidity 0.8.30;
 
 import {ChannelHubTest_Base} from "../ChannelHub_Base.t.sol";
 
-import {State} from "../../src/interfaces/Types.sol";
+import {ChannelHub} from "../../src/ChannelHub.sol";
+import {State, StateIntent} from "../../src/interfaces/Types.sol";
 
 contract ChannelHubTest_closeChannel is ChannelHubTest_Base {
+    // ========== StateIntent ==========
+
+    function test_revert_ifWrongIntent() public {
+        State memory state;
+        state.intent = StateIntent.DEPOSIT;
+
+        vm.expectRevert(ChannelHub.IncorrectStateIntent.selector);
+        cHub.closeChannel(bytes32(0), state);
+    }
+
     // ========== Payable ==========
 
     // The EVM rejects ETH at the dispatcher level before any Solidity code runs,

--- a/contracts/test/ChannelHub_units/ChannelHub_createChannel.t.sol
+++ b/contracts/test/ChannelHub_units/ChannelHub_createChannel.t.sol
@@ -8,6 +8,7 @@ import {Utils} from "../../src/Utils.sol";
 import {ChannelDefinition, ChannelStatus, State, StateIntent, Ledger} from "../../src/interfaces/Types.sol";
 import {TestUtils} from "../TestUtils.sol";
 
+// forge-lint: disable-next-item(unsafe-typecast)
 contract ChannelHubTest_createChannel is ChannelHubTest_Base {
     ChannelDefinition internal def;
     bytes32 internal channelId;
@@ -153,6 +154,16 @@ contract ChannelHubTest_createChannel is ChannelHubTest_Base {
 
         vm.prank(alice);
         vm.expectRevert(ChannelHub.IncorrectChannelStatus.selector);
+        cHub.createChannel(def, state);
+    }
+
+    // ========== StateIntent ==========
+
+    function test_revert_ifDisallowedIntent() public {
+        State memory state;
+        state.intent = StateIntent.CLOSE;
+
+        vm.expectRevert(ChannelHub.IncorrectStateIntent.selector);
         cHub.createChannel(def, state);
     }
 

--- a/contracts/test/ChannelHub_units/ChannelHub_depositToChannel.t.sol
+++ b/contracts/test/ChannelHub_units/ChannelHub_depositToChannel.t.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.30;
+
+import {ChannelHubTest_Base} from "../ChannelHub_Base.t.sol";
+
+import {ChannelHub} from "../../src/ChannelHub.sol";
+import {State, StateIntent} from "../../src/interfaces/Types.sol";
+
+contract ChannelHubTest_depositToChannel is ChannelHubTest_Base {
+    // ========== StateIntent ==========
+
+    function test_revert_ifWrongIntent() public {
+        State memory state;
+        state.intent = StateIntent.WITHDRAW;
+
+        vm.expectRevert(ChannelHub.IncorrectStateIntent.selector);
+        cHub.depositToChannel(bytes32(0), state);
+    }
+}

--- a/contracts/test/ChannelHub_units/ChannelHub_finalizeEscrowDeposit.t.sol
+++ b/contracts/test/ChannelHub_units/ChannelHub_finalizeEscrowDeposit.t.sol
@@ -4,15 +4,15 @@ pragma solidity 0.8.30;
 import {ChannelHubTest_Base} from "../ChannelHub_Base.t.sol";
 import {TestUtils} from "../TestUtils.sol";
 import {Utils} from "../../src/Utils.sol";
+
 import {ChannelHub} from "../../src/ChannelHub.sol";
-import {State, ChannelDefinition, StateIntent, Ledger, ChannelStatus} from "../../src/interfaces/Types.sol";
+import {State, ChannelDefinition, StateIntent, Ledger} from "../../src/interfaces/Types.sol";
 
 // forge-lint: disable-next-item(unsafe-typecast)
-contract ChannelHubTest_initiateEscrowDeposit is ChannelHubTest_Base {
+contract ChannelHubTest_finalizeEscrowDeposit is ChannelHubTest_Base {
     ChannelDefinition internal def;
     bytes32 internal channelId;
     State internal initState;
-    State internal escrowState;
 
     uint256 constant ESCROW_AMOUNT = 500;
     uint64 constant NON_HOME_CHAIN_ID = 42;
@@ -52,52 +52,23 @@ contract ChannelHubTest_initiateEscrowDeposit is ChannelHubTest_Base {
 
         vm.prank(alice);
         cHub.createChannel(def, initState);
-
-        // Build INITIATE_ESCROW_DEPOSIT: node locks ESCROW_AMOUNT on home chain,
-        // user will lock ESCROW_AMOUNT on non-home chain.
-        escrowState = TestUtils.nextState(
-            initState,
-            StateIntent.INITIATE_ESCROW_DEPOSIT,
-            [uint256(DEPOSIT_AMOUNT), uint256(ESCROW_AMOUNT)],
-            [int256(DEPOSIT_AMOUNT), int256(ESCROW_AMOUNT)],
-            NON_HOME_CHAIN_ID,
-            NON_HOME_TOKEN,
-            [uint256(ESCROW_AMOUNT), uint256(0)],
-            [int256(ESCROW_AMOUNT), int256(0)]
-        );
-        escrowState = mutualSignStateBothWithEcdsaValidator(escrowState, channelId, ALICE_PK);
     }
 
     // ========== StateIntent ==========
 
-    function test_revert_ifWrongIntent() public {
+    function test_revert_homeChain_ifWrongIntent() public {
         State memory state;
         state.intent = StateIntent.DEPOSIT;
 
         vm.expectRevert(ChannelHub.IncorrectStateIntent.selector);
-        cHub.initiateEscrowDeposit(def, state);
+        cHub.finalizeEscrowDeposit(channelId, bytes32(0), state);
     }
 
-    // ========== INITIATE_ESCROW_DEPOSIT caller restriction ==========
+    function test_revert_nonHomeChain_ifWrongIntent() public {
+        State memory state;
+        state.intent = StateIntent.DEPOSIT;
 
-    function test_revert_homeChain_callerNotNode() public {
-        vm.expectRevert(ChannelHub.IncorrectMsgSender.selector);
-        vm.prank(alice);
-        cHub.initiateEscrowDeposit(def, escrowState);
-    }
-
-    function test_homeChain_nodeCanSubmit() public {
-        uint256 nodeBalanceBefore = cHub.getNodeBalance(address(token));
-
-        vm.prank(node);
-        cHub.initiateEscrowDeposit(def, escrowState);
-
-        // Channel state advanced and node funds locked
-        verifyChannelData(channelId, ChannelStatus.OPERATING, 1, 0, "State should advance after node submits");
-        assertEq(
-            cHub.getNodeBalance(address(token)),
-            nodeBalanceBefore - ESCROW_AMOUNT,
-            "Node balance should decrease by escrow amount"
-        );
+        vm.expectRevert(ChannelHub.IncorrectStateIntent.selector);
+        cHub.finalizeEscrowDeposit(bytes32(0), bytes32(0), state);
     }
 }

--- a/contracts/test/ChannelHub_units/ChannelHub_finalizeEscrowWithdrawal.t.sol
+++ b/contracts/test/ChannelHub_units/ChannelHub_finalizeEscrowWithdrawal.t.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.30;
+
+import {ChannelHubTest_Base} from "../ChannelHub_Base.t.sol";
+import {TestUtils} from "../TestUtils.sol";
+import {Utils} from "../../src/Utils.sol";
+
+import {ChannelHub} from "../../src/ChannelHub.sol";
+import {State, ChannelDefinition, StateIntent, Ledger} from "../../src/interfaces/Types.sol";
+
+// forge-lint: disable-next-item(unsafe-typecast)
+contract ChannelHubTest_finalizeEscrowWithdrawal is ChannelHubTest_Base {
+    ChannelDefinition internal def;
+    bytes32 internal channelId;
+    State internal initState;
+
+    function setUp() public override {
+        super.setUp();
+
+        def = ChannelDefinition({
+            challengeDuration: CHALLENGE_DURATION,
+            user: alice,
+            node: node,
+            nonce: NONCE,
+            approvedSignatureValidators: 0,
+            metadata: bytes32(0)
+        });
+        channelId = Utils.getChannelId(def, CHANNEL_HUB_VERSION);
+
+        initState = State({
+            version: 0,
+            intent: StateIntent.DEPOSIT,
+            metadata: bytes32(0),
+            homeLedger: Ledger({
+                chainId: uint64(block.chainid),
+                token: address(token),
+                decimals: 18,
+                userAllocation: DEPOSIT_AMOUNT,
+                userNetFlow: int256(DEPOSIT_AMOUNT),
+                nodeAllocation: 0,
+                nodeNetFlow: 0
+            }),
+            nonHomeLedger: TestUtils.emptyLedger(),
+            userSig: "",
+            nodeSig: ""
+        });
+        initState = mutualSignStateBothWithEcdsaValidator(initState, channelId, ALICE_PK);
+
+        vm.prank(alice);
+        cHub.createChannel(def, initState);
+    }
+
+    // ========== StateIntent ==========
+
+    function test_revert_homeChain_ifWrongIntent() public {
+        State memory state;
+        state.intent = StateIntent.DEPOSIT;
+
+        vm.expectRevert(ChannelHub.IncorrectStateIntent.selector);
+        cHub.finalizeEscrowWithdrawal(channelId, bytes32(0), state);
+    }
+
+    function test_revert_nonHomeChain_ifWrongIntent() public {
+        State memory state;
+        state.intent = StateIntent.DEPOSIT;
+
+        vm.expectRevert(ChannelHub.IncorrectStateIntent.selector);
+        cHub.finalizeEscrowWithdrawal(bytes32(0), bytes32(0), state);
+    }
+}

--- a/contracts/test/ChannelHub_units/ChannelHub_finalizeMigration.t.sol
+++ b/contracts/test/ChannelHub_units/ChannelHub_finalizeMigration.t.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.30;
+
+import {ChannelHubTest_Base} from "../ChannelHub_Base.t.sol";
+
+import {ChannelHub} from "../../src/ChannelHub.sol";
+import {State, StateIntent} from "../../src/interfaces/Types.sol";
+
+contract ChannelHubTest_finalizeMigration is ChannelHubTest_Base {
+    // ========== StateIntent ==========
+
+    function test_revert_ifWrongIntent() public {
+        State memory state;
+        state.intent = StateIntent.DEPOSIT;
+
+        vm.expectRevert(ChannelHub.IncorrectStateIntent.selector);
+        cHub.finalizeMigration(bytes32(0), state);
+    }
+}

--- a/contracts/test/ChannelHub_units/ChannelHub_initiateEscrowWithdrawal.t.sol
+++ b/contracts/test/ChannelHub_units/ChannelHub_initiateEscrowWithdrawal.t.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.30;
+
+import {ChannelHubTest_Base} from "../ChannelHub_Base.t.sol";
+
+import {ChannelHub} from "../../src/ChannelHub.sol";
+import {ChannelDefinition, State, StateIntent} from "../../src/interfaces/Types.sol";
+
+contract ChannelHubTest_initiateEscrowWithdrawal is ChannelHubTest_Base {
+    // ========== StateIntent ==========
+
+    function test_revert_ifWrongIntent() public {
+        ChannelDefinition memory def;
+        State memory state;
+        state.intent = StateIntent.DEPOSIT;
+
+        vm.expectRevert(ChannelHub.IncorrectStateIntent.selector);
+        cHub.initiateEscrowWithdrawal(def, state);
+    }
+}

--- a/contracts/test/ChannelHub_units/ChannelHub_initiateMigration.t.sol
+++ b/contracts/test/ChannelHub_units/ChannelHub_initiateMigration.t.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.30;
+
+import {ChannelHubTest_Base} from "../ChannelHub_Base.t.sol";
+
+import {ChannelHub} from "../../src/ChannelHub.sol";
+import {ChannelDefinition, State, StateIntent} from "../../src/interfaces/Types.sol";
+
+contract ChannelHubTest_initiateMigration is ChannelHubTest_Base {
+    // ========== StateIntent ==========
+
+    function test_revert_ifWrongIntent() public {
+        ChannelDefinition memory def;
+        State memory state;
+        state.intent = StateIntent.DEPOSIT;
+
+        vm.expectRevert(ChannelHub.IncorrectStateIntent.selector);
+        cHub.initiateMigration(def, state);
+    }
+}

--- a/contracts/test/ChannelHub_units/ChannelHub_withdrawFromChannel.t.sol
+++ b/contracts/test/ChannelHub_units/ChannelHub_withdrawFromChannel.t.sol
@@ -3,9 +3,20 @@ pragma solidity 0.8.30;
 
 import {ChannelHubTest_Base} from "../ChannelHub_Base.t.sol";
 
-import {State} from "../../src/interfaces/Types.sol";
+import {ChannelHub} from "../../src/ChannelHub.sol";
+import {State, StateIntent} from "../../src/interfaces/Types.sol";
 
 contract ChannelHubTest_withdrawFromChannel is ChannelHubTest_Base {
+    // ========== StateIntent ==========
+
+    function test_revert_ifWrongIntent() public {
+        State memory state;
+        state.intent = StateIntent.DEPOSIT;
+
+        vm.expectRevert(ChannelHub.IncorrectStateIntent.selector);
+        cHub.withdrawFromChannel(bytes32(0), state);
+    }
+
     // ========== Payable ==========
 
     // The EVM rejects ETH at the dispatcher level before any Solidity code runs,

--- a/contracts/test/TestChannelHub.sol
+++ b/contracts/test/TestChannelHub.sol
@@ -9,6 +9,7 @@ import {EscrowStatus} from "../src/interfaces/Types.sol";
  * @title TestChannelHub
  * @notice Test harness contract that exposes internal ChannelHub functions for testing
  */
+// forge-lint: disable-next-item(mixed-case-function)
 contract TestChannelHub is ChannelHub {
     constructor(ISignatureValidator _defaultSigValidator, address _node) ChannelHub(_defaultSigValidator, _node) {}
 

--- a/contracts/test/WadMath.t.sol
+++ b/contracts/test/WadMath.t.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.30;
 import {Test} from "forge-std/Test.sol";
 import {WadMath} from "../src/WadMath.sol";
 
+// forge-lint: disable-next-item(mixed-case-function)
 contract TestWadMath {
     using WadMath for uint256;
     using WadMath for int256;


### PR DESCRIPTION
## **Description**

`finalizeEscrowDeposit` and `finalizeEscrowWithdrawal` route home-chain calls before checking the candidate state intent. When escrow metadata is absent and the channel is home on the current chain, the functions call `_processHomeChainEscrowFinalize`, which validates signatures and forwards the candidate to `ChannelEngine.validateTransition`.

```
        if (_isEscrowDepositHomeChain(channelId, escrowId)) {
            // HOME CHAIN: Get user from channel definition
            ChannelMeta storage channelMeta = _channels[channelId];
            _processHomeChainEscrowFinalize(channelId, candidate, channelMeta.definition.user);
            emit EscrowDepositFinalizedOnHome(escrowId, channelId, candidate);
            return;
        }
```

The intent check is only reached on the non-home path. The home path therefore accepts any valid next signed channel transition supported by ChannelEngine. This breaks the intended escrow deposit flow. The user receives a co-signed `INITIATE_ESCROW_DEPOSIT` state so they can submit it on the non-home chain and lock their funds in escrow. The home-chain submission of that same state is intentionally restricted to the node.

```
        if (_isChannelHomeChain(channelId)) {
            require(msg.sender == NODE, IncorrectMsgSender());
            _processHomeChainEscrowInitiate(channelId, candidate);
            emit EscrowDepositInitiatedOnHome(escrowId, channelId, candidate);
        }
```

However, the user can submit that signed initiation state through `finalizeEscrowDeposit` on the home chain. Since home-chain escrow metadata is empty,  `_isEscrowDepositHomeChain` returns true and the candidate is processed as a generic channel transition. As a result, the home channel advances to the `INITIATE_ESCROW_DEPOSIT` state and the node’s matching liquidity is moved from the node vault into the channel’s locked funds, even if the non-home escrow was never created and the user never locked the corresponding funds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation of state intent across escrow initiation and finalization operations, ensuring correct operation types are supplied.
  * Strengthened signature validation for home-chain escrow finalizations using channel definition validators.

* **Tests**
  * Added comprehensive unit test coverage validating incorrect state intent rejection across all core ChannelHub operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->