### PR TITLE
M2-M01: fix(clearnode): alert on home channel challenge instead of auto-checkpoint

### DIFF
--- a/clearnode/event_handlers/service.go
+++ b/clearnode/event_handlers/service.go
@@ -115,9 +115,11 @@ func (s *EventHandlerService) HandleHomeChannelCheckpointed(ctx context.Context,
 }
 
 // HandleHomeChannelChallenged processes the HomeChannelChallenged event emitted when a potentially
-// stale state is submitted on-chain. It updates the channel status to Challenged, sets the challenge
-// expiration time, and automatically schedules a checkpoint of the latest signed state if available
-// to resolve the challenge.
+// stale state is submitted on-chain. Automatic challenge response is intentionally disabled: the
+// latest signed state may carry an intent (e.g. CLOSE, escrow initiate/finalize, migration) that
+// cannot be resolved via ScheduleCheckpoint, and silently queueing an impossible transaction
+// risks letting the challenge expire on a stale state. Instead, this handler emits a warning so
+// operators are alerted and can submit the appropriate on-chain action manually before expiry.
 func (s *EventHandlerService) HandleHomeChannelChallenged(ctx context.Context, tx core.ChannelHubEventHandlerStore, event *core.HomeChannelChallengedEvent) error {
 	logger := log.FromContext(ctx)
 	chanID := event.ChannelID
@@ -134,40 +136,14 @@ func (s *EventHandlerService) HandleHomeChannelChallenged(ctx context.Context, t
 		return nil
 	}
 
-	if event.StateVersion < channel.StateVersion {
-		logger.Error("challenged state version is less than current channel state version", "channelId", chanID, "currentStateVersion", channel.StateVersion, "challengedStateVersion", event.StateVersion)
-		return nil
-	}
-
-	channel.StateVersion = event.StateVersion
-	channel.Status = core.ChannelStatusChallenged
-
-	expirationTime := time.Unix(int64(event.ChallengeExpiry), 0)
-	channel.ChallengeExpiresAt = &expirationTime
-
-	if err := tx.UpdateChannel(*channel); err != nil {
-		return err
-	}
-
-	lastSignedState, err := tx.GetLastStateByChannelID(chanID, true)
-	if err != nil {
-		return err
-	}
-	if lastSignedState == nil {
-		logger.Warn("no state found for channel during HomeChannelChallenged event", "channelId", chanID)
-	} else if lastSignedState.Version <= event.StateVersion {
-		logger.Warn("last signed state version is not greater than challenged state version", "channelId", chanID, "lastSignedStateVersion", lastSignedState.Version, "challengedStateVersion", event.StateVersion)
-	} else {
-		if err := tx.ScheduleCheckpoint(lastSignedState.ID, lastSignedState.HomeLedger.BlockchainID); err != nil {
-			return err
-		}
-	}
-
-	if err := tx.RefreshUserEnforcedBalance(channel.UserWallet, channel.Asset); err != nil {
-		return err
-	}
-
-	logger.Info("handled HomeChannelChallenged event", "channelId", event.ChannelID, "stateVersion", event.StateVersion, "userWallet", channel.UserWallet)
+	logger.Warn("home channel challenged",
+		"channelId", chanID,
+		"userWallet", channel.UserWallet,
+		"blockchainID", channel.BlockchainID,
+		"asset", channel.Asset,
+		"challengedStateVersion", event.StateVersion,
+		"challengeExpiry", time.Unix(int64(event.ChallengeExpiry), 0),
+	)
 	return nil
 }
 

--- a/clearnode/event_handlers/service_test.go
+++ b/clearnode/event_handlers/service_test.go
@@ -100,14 +100,16 @@ func TestHandleHomeChannelCheckpointed_Success(t *testing.T) {
 	mockStore.AssertExpectations(t)
 }
 
-func TestHandleHomeChannelChallenged_Success(t *testing.T) {
-	// Setup
+func TestHandleHomeChannelChallenged_LogsOnly(t *testing.T) {
+	// Automatic challenge response was removed because non-checkpointable intents (CLOSE,
+	// escrow initiate/finalize, migration) cannot be resolved via ScheduleCheckpoint. The
+	// handler must only fetch the channel for context and emit a warning — no state mutation,
+	// no scheduled action, no enforced-balance refresh.
 	mockStore := new(MockStore)
 	ctx := log.SetContextLogger(context.Background(), log.NewNoopLogger())
 
 	service := &EventHandlerService{}
 
-	// Test data
 	channelID := "0xHomeChannel123"
 	userWallet := "0x1234567890123456789012345678901234567890"
 	challengeExpiry := uint64(time.Now().Add(time.Hour).Unix())
@@ -121,36 +123,70 @@ func TestHandleHomeChannelChallenged_Success(t *testing.T) {
 		StateVersion: 3,
 	}
 
-	state := &core.State{
-		ID:      "state123",
-		Version: 6,
-		HomeLedger: core.Ledger{
-			BlockchainID: 0,
-		},
-	}
-
 	event := &core.HomeChannelChallengedEvent{
 		ChannelID:       channelID,
 		StateVersion:    4,
 		ChallengeExpiry: challengeExpiry,
 	}
 
-	// Mock expectations
 	mockStore.On("GetChannelByID", channelID).Return(channel, nil)
-	mockStore.On("UpdateChannel", mock.MatchedBy(func(ch core.Channel) bool {
-		return ch.ChannelID == channelID &&
-			ch.Status == core.ChannelStatusChallenged &&
-			ch.StateVersion == 4 &&
-			ch.ChallengeExpiresAt != nil
-	})).Return(nil)
-	mockStore.On("GetLastStateByChannelID", channelID, true).Return(state, nil)
-	mockStore.On("ScheduleCheckpoint", "state123", uint64(0)).Return(nil)
-	mockStore.On("RefreshUserEnforcedBalance", userWallet, "usdc").Return(nil)
 
-	// Execute
 	err := service.HandleHomeChannelChallenged(ctx, mockStore, event)
 
-	// Assert
+	require.NoError(t, err)
+	mockStore.AssertExpectations(t)
+	mockStore.AssertNotCalled(t, "UpdateChannel", mock.Anything)
+	mockStore.AssertNotCalled(t, "GetLastStateByChannelID", mock.Anything, mock.Anything)
+	mockStore.AssertNotCalled(t, "ScheduleCheckpoint", mock.Anything, mock.Anything)
+	mockStore.AssertNotCalled(t, "RefreshUserEnforcedBalance", mock.Anything, mock.Anything)
+}
+
+func TestHandleHomeChannelChallenged_ChannelNotFound(t *testing.T) {
+	mockStore := new(MockStore)
+	ctx := log.SetContextLogger(context.Background(), log.NewNoopLogger())
+
+	service := &EventHandlerService{}
+
+	channelID := "0xMissingChannel"
+
+	event := &core.HomeChannelChallengedEvent{
+		ChannelID:       channelID,
+		StateVersion:    1,
+		ChallengeExpiry: uint64(time.Now().Add(time.Hour).Unix()),
+	}
+
+	mockStore.On("GetChannelByID", channelID).Return(nil, nil)
+
+	err := service.HandleHomeChannelChallenged(ctx, mockStore, event)
+
+	require.NoError(t, err)
+	mockStore.AssertExpectations(t)
+}
+
+func TestHandleHomeChannelChallenged_TypeMismatch(t *testing.T) {
+	mockStore := new(MockStore)
+	ctx := log.SetContextLogger(context.Background(), log.NewNoopLogger())
+
+	service := &EventHandlerService{}
+
+	channelID := "0xEscrowAsHome"
+
+	channel := &core.Channel{
+		ChannelID: channelID,
+		Type:      core.ChannelTypeEscrow,
+		Status:    core.ChannelStatusOpen,
+	}
+
+	event := &core.HomeChannelChallengedEvent{
+		ChannelID:       channelID,
+		StateVersion:    1,
+		ChallengeExpiry: uint64(time.Now().Add(time.Hour).Unix()),
+	}
+
+	mockStore.On("GetChannelByID", channelID).Return(channel, nil)
+
+	err := service.HandleHomeChannelChallenged(ctx, mockStore, event)
+
 	require.NoError(t, err)
 	mockStore.AssertExpectations(t)
 }


### PR DESCRIPTION
## Summary

- Audit finding **M2-M01**: `HandleHomeChannelChallenged` always scheduled a `ScheduleCheckpoint` for the latest signed state when its version exceeded the challenged version, but the Checkpoint worker only handles `OPERATE`, `DEPOSIT`, and `WITHDRAW` intents. Latest signed states with `CLOSE`, escrow initiate/finalize, or migration intents were retried as checkpoints and failed silently, leaving channels exposed to stale settlement at challenge expiry.
- Per the audit recommendation, automatic challenge response is postponed. The handler now emits a `Warn` log with channel id, user wallet, blockchain id, asset, challenged state version, and challenge expiry. Operators handle the alert manually before expiry.
- Updated unit tests: replaced the success path with `TestHandleHomeChannelChallenged_LogsOnly` (asserts no `UpdateChannel` / `GetLastStateByChannelID` / `ScheduleCheckpoint` / `RefreshUserEnforcedBalance` calls), plus new `_ChannelNotFound` and `_TypeMismatch` cases.
- No external documentation referenced the prior auto-checkpoint behaviour; the handler doc comment is updated in place to record the rationale.

`HandleEscrowDepositChallenged` and `HandleEscrowWithdrawalChallenged` are untouched — their scheduled actions (`ScheduleFinalizeEscrowDeposit` / `ScheduleFinalizeEscrowWithdrawal`) are dedicated paths and out of scope for this finding.

## Test plan

- [x] `go test ./clearnode/event_handlers/...`
- [x] `go vet ./clearnode/event_handlers/...`
- [x] `go build ./clearnode/...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified channel challenge handling to eliminate automatic state mutations and resolution scheduling. The system now logs challenge events without performing automated updates or follow-up actions.

* **Tests**
  * Updated test coverage to verify log-only behavior for channel challenges and added edge-case validation for missing or mismatched channel scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->