### PR TITLE
M2-L01: docs(protocol): clarify session-key authorization scope and metadata extensibility

### DIFF
--- a/docs/protocol/cryptography.md
+++ b/docs/protocol/cryptography.md
@@ -95,11 +95,24 @@ The authorization is constructed as follows:
 
 1. The participant signs a message containing:
    - the session key address
-   - authorization metadata hash (`keccak256` over scope, expiration and possible other data)
+   - authorization metadata hash (`keccak256` over the canonically encoded authorization metadata structure)
 2. The authorization signature is produced using the participant's primary key
 3. The session key MAY then produce signatures on behalf of the participant within the authorized scope
 
 Session key signatures MUST include the authorization proof alongside the session key signature. The authorization proof is canonically encoded as a tuple containing the session key authorization and the raw signature bytes.
+
+### Authorization Metadata
+
+The authorization metadata structure defines the scope of a session key. It MUST contain at least the following fields, which constitute the minimum scope every implementation MUST enforce:
+
+| Field        | Purpose                                                                                                                                                                                                                                       |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `version`    | Replay and revocation guard for the participant's session-key delegations. Issuing a session-key state with a higher version supersedes prior versions, so the previous delegation MUST be treated as revoked once a newer one is registered. |
+| `expires_at` | Bounds the lifetime of the delegation; signatures produced after expiry MUST be rejected.                                                                                                                                                     |
+
+Implementations MAY extend the metadata structure with additional restrictions (for example: authorized assets, allowed transitions, channels, recipients, or per-asset spending limits). Restrictions that an implementation does not encode and enforce are not applied: a session key whose authorization does not narrow a given dimension can sign any otherwise-valid state along that dimension, up to the participant's full balance, until the authorization expires. Participants SHOULD scope the metadata fields available to them accordingly and treat session-key compromise as equivalent to control of the participant's authority within the scope they issued, for the duration of the validity window.
+
+Only the `keccak256` hash of the canonically encoded metadata is bound into the authorization signature; the full structure is supplied alongside the signature at validation time. This indirection lets implementations extend the metadata structure with additional fields purely at the off-chain layer, without changes to the on-chain validator and without invalidating session keys issued under earlier metadata layouts: the on-chain layer only verifies the metadata hash, while the off-chain layer is responsible for decoding the full metadata and enforcing every field it understands.
 
 ## Replay Protection
 

--- a/docs/protocol/terminology.md
+++ b/docs/protocol/terminology.md
@@ -74,7 +74,7 @@ An entity capable of producing signatures. Each signer is associated with a spec
 
 ### Session Key
 
-A delegated signing key authorized by a participant's primary key to sign specific types of state updates on their behalf. Session key authorization MUST be associated with the same address as the channel's user or node participant.
+A delegated signing key authorized by a participant's primary key to sign state updates on their behalf within an authorization scope. Session key authorization MUST be associated with the same address as the channel's user or node participant. The authorization scope is defined by an extensible metadata structure (see [Cryptography — Session Key Authorization](cryptography.md#session-key-authorization)). Participants SHOULD treat session-key compromise as equivalent to control of the participant's authority within the scope they issued, for the duration of the validity window.
 
 ### Signature Validation Mode
 


### PR DESCRIPTION
## Summary

Audit finding **M2-L01** (Low) flagged that channel session keys are authorized today only by asset and expiration, with no per-action, channel, recipient, or spending-limit enforcement. We are acknowledging the finding without changing runtime behaviour for now, and tightening the protocol documentation so the actual scope is explicit and the metadata extension model is unambiguous.

### Changes

- `docs/protocol/cryptography.md`
  - Replaces the loose `"scope, expiration and possible other data"` phrasing with a reference to the canonically encoded authorization metadata structure.
  - Adds an **Authorization Metadata** subsection that:
    - Lists `version` and `expires_at` as the protocol-mandated minimum.
    - Explains that `version` is a replay / revocation guard — issuing a higher-version session-key state supersedes (revokes) prior ones — not a metadata-layout version.
    - States that implementations MAY extend the metadata with additional restrictions (authorized assets, allowed transitions, channels, recipients, spending limits, …), and that any dimension an implementation does not encode and enforce is not narrowed: a session key can sign any otherwise-valid state along that dimension up to the participant's full balance until expiry.
    - Documents the rationale for binding only the `keccak256` of the metadata into the authorization signature: implementations can extend the structure off-chain without on-chain validator changes and without invalidating session keys issued under earlier layouts.
- `docs/protocol/terminology.md`
  - Removes the misleading "specific types of state updates" wording from the **Session Key** entry, links it to the cryptography section, and notes that a participant delegating a session key SHOULD assume it may exercise any authority not narrowed by the scope it issued.

`assets` is intentionally not promoted to the protocol minimum — it is an existing implementation-level extension and remains documented as such by omission from the minimum scope and inclusion in the example list of optional restrictions.

## Test plan

- [x] Docs-only change; no code paths affected.
- [x] Visual review of the rendered Markdown for the two modified files.