### PR TITLE
M2-I02: fix(clearnode/api): normalize participant addresses consistently across endpoints

### DIFF
--- a/clearnode/api/app_session_v1/create_app_session.go
+++ b/clearnode/api/app_session_v1/create_app_session.go
@@ -70,11 +70,19 @@ func (h *Handler) CreateAppSession(c *rpc.Context) {
 		return
 	}
 
-	// Validate quorum against total weights and check for duplicate participants
+	// Validate quorum against total weights and check for duplicate participants.
+	// Normalize each participant's wallet so the deduplication, packing, app session ID
+	// derivation, and stored participant list all see the canonical (lowercase, 0x-prefixed)
+	// representation regardless of how the caller cased the address or whether they
+	// included the 0x prefix.
 	var totalWeights uint8
 	participantWeights := make(map[string]uint8)
-	for _, participant := range reqPayload.Definition.Participants {
-		participantWallet := strings.ToLower(participant.WalletAddress)
+	for i, participant := range reqPayload.Definition.Participants {
+		participantWallet, err := core.NormalizeHexAddress(participant.WalletAddress)
+		if err != nil {
+			c.Fail(rpc.Errorf("invalid participant wallet_address %q: %v", participant.WalletAddress, err), "")
+			return
+		}
 
 		// Check for duplicate participant addresses
 		if _, exists := participantWeights[participantWallet]; exists {
@@ -83,6 +91,7 @@ func (h *Handler) CreateAppSession(c *rpc.Context) {
 		}
 		totalWeights += participant.SignatureWeight
 		participantWeights[participantWallet] = participant.SignatureWeight
+		appDef.Participants[i].WalletAddress = participantWallet
 	}
 
 	if reqPayload.Definition.Quorum > totalWeights {

--- a/clearnode/api/app_session_v1/create_app_session_test.go
+++ b/clearnode/api/app_session_v1/create_app_session_test.go
@@ -1167,3 +1167,65 @@ func TestCreateAppSession_AppRegistryDisabled(t *testing.T) {
 	mockStore.AssertNotCalled(t, "GetApp", mock.Anything)
 	mockStore.AssertExpectations(t)
 }
+
+// TestCreateAppSession_DuplicateParticipantAcrossCases verifies that two participant
+// addresses that differ only in letter case are detected as duplicates. Without address
+// normalization the duplicate-check map would key on the raw representation and accept
+// the same wallet twice.
+func TestCreateAppSession_DuplicateParticipantAcrossCases(t *testing.T) {
+	mockStore := new(MockStore)
+
+	storeTxProvider := func(fn StoreTxHandler) error {
+		return fn(mockStore)
+	}
+
+	mockSigner := NewMockChannelSigner()
+	mockAssetStore := new(MockAssetStore)
+	mockStatePacker := new(MockStatePacker)
+
+	handler := NewHandler(
+		storeTxProvider,
+		mockAssetStore,
+		&MockActionGateway{},
+		mockSigner,
+		core.NewStateAdvancerV1(mockAssetStore),
+		mockStatePacker,
+		"0xnode",
+		true,
+		metrics.NewNoopRuntimeMetricExporter(),
+		32, 1024, 256, 16,
+	)
+
+	lower := "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	upper := "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+
+	reqPayload := rpc.AppSessionsV1CreateAppSessionRequest{
+		Definition: rpc.AppDefinitionV1{
+			Application: "test-app",
+			Participants: []rpc.AppParticipantV1{
+				{WalletAddress: lower, SignatureWeight: 1},
+				{WalletAddress: upper, SignatureWeight: 1},
+			},
+			Quorum: 1,
+			Nonce:  "12345",
+		},
+		QuorumSigs: []string{"0xdeadbeef"},
+	}
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, string(rpc.AppSessionsV1CreateAppSessionMethod), payload),
+	}
+
+	handler.CreateAppSession(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.NotNil(t, respErr)
+	assert.Contains(t, respErr.Error(), "duplicate participant address")
+	mockStore.AssertNotCalled(t, "GetApp", mock.Anything)
+	mockStore.AssertNotCalled(t, "CreateAppSession", mock.Anything)
+}

--- a/clearnode/api/app_session_v1/get_app_sessions.go
+++ b/clearnode/api/app_session_v1/get_app_sessions.go
@@ -23,6 +23,15 @@ func (h *Handler) GetAppSessions(c *rpc.Context) {
 		return
 	}
 
+	if req.Participant != nil {
+		normalizedParticipant, err := core.NormalizeHexAddress(*req.Participant)
+		if err != nil {
+			c.Fail(rpc.Errorf("invalid participant: %v", err), "")
+			return
+		}
+		req.Participant = &normalizedParticipant
+	}
+
 	var paginationParams core.PaginationParams
 	if req.Pagination != nil {
 		paginationParams.Offset = req.Pagination.Offset

--- a/clearnode/api/app_session_v1/get_app_sessions_test.go
+++ b/clearnode/api/app_session_v1/get_app_sessions_test.go
@@ -410,3 +410,34 @@ func TestGetAppSessions_StoreError(t *testing.T) {
 	// Verify all mock expectations
 	mockStore.AssertExpectations(t)
 }
+
+// TestGetAppSessions_NormalizesParticipant verifies the participant filter is normalized
+// before being passed to the store.
+func TestGetAppSessions_NormalizesParticipant(t *testing.T) {
+	mockStore := new(MockStore)
+
+	handler := &Handler{
+		useStoreInTx: func(fn StoreTxHandler) error { return fn(mockStore) },
+		metrics:      metrics.NewNoopRuntimeMetricExporter(),
+	}
+
+	canonicalParticipant := "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+	mixedCaseParticipant := "0xABCDEFabcdefABCDEFabcdefABCDEFabcdefABCD"
+
+	mockStore.On("GetAppSessions", (*string)(nil), &canonicalParticipant, app.AppSessionStatusVoid, &core.PaginationParams{}).
+		Return([]app.AppSessionV1{}, core.PaginationMetadata{}, nil)
+
+	reqPayload := rpc.AppSessionsV1GetAppSessionsRequest{Participant: &mixedCaseParticipant}
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.Message{Method: "app_sessions.v1.get_app_sessions", Payload: payload},
+	}
+
+	handler.GetAppSessions(ctx)
+
+	require.Nil(t, ctx.Response.Error())
+	mockStore.AssertExpectations(t)
+}

--- a/clearnode/api/app_session_v1/submit_deposit_state.go
+++ b/clearnode/api/app_session_v1/submit_deposit_state.go
@@ -36,6 +36,13 @@ func (h *Handler) SubmitDepositState(c *rpc.Context) {
 		c.Fail(err, "failed to parse app state update")
 		return
 	}
+
+	reqPayload.UserState.UserWallet, err = core.NormalizeHexAddress(reqPayload.UserState.UserWallet)
+	if err != nil {
+		c.Fail(rpc.Errorf("invalid user_wallet: %v", err), "")
+		return
+	}
+
 	userState, err := unmapStateV1(reqPayload.UserState)
 	if err != nil {
 		c.Fail(err, "failed to parse user state")

--- a/clearnode/api/app_session_v1/submit_deposit_state_test.go
+++ b/clearnode/api/app_session_v1/submit_deposit_state_test.go
@@ -20,6 +20,47 @@ import (
 	"github.com/layer-3/nitrolite/pkg/rpc"
 )
 
+func TestSubmitDepositState_InvalidUserWallet_Rejected(t *testing.T) {
+	mockStore := new(MockStore)
+
+	handler := &Handler{
+		useStoreInTx:   func(h StoreTxHandler) error { return h(mockStore) },
+		metrics:        metrics.NewNoopRuntimeMetricExporter(),
+		maxSessionData: 1024,
+	}
+
+	reqPayload := rpc.AppSessionsV1SubmitDepositStateRequest{
+		AppStateUpdate: rpc.AppStateUpdateV1{
+			AppSessionID: "0xappsession",
+			Version:      "2",
+			Intent:       app.AppStateUpdateIntentDeposit,
+		},
+		UserState: rpc.StateV1{
+			UserWallet: "ZZ-not-an-address",
+			Asset:      "USDC",
+			Epoch:      "1",
+			Version:    "1",
+			Transition: rpc.TransitionV1{Amount: "0"},
+		},
+		QuorumSigs: []string{"0xdeadbeef"},
+	}
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.Message{Method: "app_sessions.v1.submit_deposit_state", Payload: payload},
+	}
+
+	handler.SubmitDepositState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.NotNil(t, respErr)
+	assert.Contains(t, respErr.Error(), "invalid user_wallet")
+	mockStore.AssertNotCalled(t, "LockUserState", mock.Anything, mock.Anything)
+}
+
 func TestSubmitDepositState_Success(t *testing.T) {
 	// Setup
 	mockStore := new(MockStore)

--- a/clearnode/api/apps_v1/get_apps.go
+++ b/clearnode/api/apps_v1/get_apps.go
@@ -16,6 +16,15 @@ func (h *Handler) GetApps(c *rpc.Context) {
 		return
 	}
 
+	if req.OwnerWallet != nil {
+		normalizedOwnerWallet, err := core.NormalizeHexAddress(*req.OwnerWallet)
+		if err != nil {
+			c.Fail(rpc.Errorf("invalid owner_wallet: %v", err), "")
+			return
+		}
+		req.OwnerWallet = &normalizedOwnerWallet
+	}
+
 	var paginationParams core.PaginationParams
 	if req.Pagination != nil {
 		paginationParams.Offset = req.Pagination.Offset

--- a/clearnode/api/apps_v1/get_apps_test.go
+++ b/clearnode/api/apps_v1/get_apps_test.go
@@ -15,7 +15,7 @@ func TestGetApps_Success(t *testing.T) {
 	mockStore := &MockStore{
 		getAppsFn: func(appID *string, ownerWallet *string, pagination *core.PaginationParams) ([]app.AppInfoV1, core.PaginationMetadata, error) {
 			return []app.AppInfoV1{
-				{App: app.AppV1{ID: "app-1", OwnerWallet: "0x1111", Metadata: "0x00", Version: 1}},
+				{App: app.AppV1{ID: "app-1", OwnerWallet: "0x1111111111111111111111111111111111111111", Metadata: "0x00", Version: 1}},
 				{App: app.AppV1{ID: "app-2", OwnerWallet: "0x2222", Metadata: "0x00", Version: 1}},
 			}, core.PaginationMetadata{TotalCount: 2, Page: 1, PerPage: 50}, nil
 		},
@@ -80,7 +80,7 @@ func TestGetApps_FilterByAppID(t *testing.T) {
 			require.NotNil(t, appID)
 			assert.Equal(t, "app-1", *appID)
 			return []app.AppInfoV1{
-				{App: app.AppV1{ID: "app-1", OwnerWallet: "0x1111", Version: 1}},
+				{App: app.AppV1{ID: "app-1", OwnerWallet: "0x1111111111111111111111111111111111111111", Version: 1}},
 			}, core.PaginationMetadata{TotalCount: 1, Page: 1, PerPage: 50}, nil
 		},
 	}
@@ -112,16 +112,16 @@ func TestGetApps_FilterByOwnerWallet(t *testing.T) {
 	mockStore := &MockStore{
 		getAppsFn: func(appID *string, ownerWallet *string, pagination *core.PaginationParams) ([]app.AppInfoV1, core.PaginationMetadata, error) {
 			require.NotNil(t, ownerWallet)
-			assert.Equal(t, "0x1111", *ownerWallet)
+			assert.Equal(t, "0x1111111111111111111111111111111111111111", *ownerWallet)
 			return []app.AppInfoV1{
-				{App: app.AppV1{ID: "app-1", OwnerWallet: "0x1111", Version: 1}},
+				{App: app.AppV1{ID: "app-1", OwnerWallet: "0x1111111111111111111111111111111111111111", Version: 1}},
 			}, core.PaginationMetadata{TotalCount: 1, Page: 1, PerPage: 50}, nil
 		},
 	}
 
 	handler := NewHandler(mockStore, nil, nil, 4096)
 
-	owner := "0x1111"
+	owner := "0x1111111111111111111111111111111111111111"
 	reqPayload := rpc.AppsV1GetAppsRequest{OwnerWallet: &owner}
 	payload, err := rpc.NewPayload(reqPayload)
 	require.NoError(t, err)
@@ -139,5 +139,36 @@ func TestGetApps_FilterByOwnerWallet(t *testing.T) {
 	var resp rpc.AppsV1GetAppsResponse
 	require.NoError(t, ctx.Response.Payload.Translate(&resp))
 	assert.Len(t, resp.Apps, 1)
-	assert.Equal(t, "0x1111", resp.Apps[0].OwnerWallet)
+	assert.Equal(t, "0x1111111111111111111111111111111111111111", resp.Apps[0].OwnerWallet)
+}
+
+// TestGetApps_NormalizesOwnerWallet verifies that an owner_wallet filter submitted in
+// mixed case is normalized to canonical lowercase before being passed to the store.
+func TestGetApps_NormalizesOwnerWallet(t *testing.T) {
+	canonicalOwner := "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+	mixedCaseOwner := "0xABCDEFabcdefABCDEFabcdefABCDEFabcdefABCD"
+
+	mockStore := &MockStore{
+		getAppsFn: func(appID *string, ownerWallet *string, _ *core.PaginationParams) ([]app.AppInfoV1, core.PaginationMetadata, error) {
+			require.NotNil(t, ownerWallet)
+			assert.Equal(t, canonicalOwner, *ownerWallet)
+			return []app.AppInfoV1{}, core.PaginationMetadata{}, nil
+		},
+	}
+
+	handler := NewHandler(mockStore, nil, nil, 4096)
+
+	reqPayload := rpc.AppsV1GetAppsRequest{OwnerWallet: &mixedCaseOwner}
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, string(rpc.AppsV1GetAppsMethod), payload),
+	}
+
+	handler.GetApps(ctx)
+
+	require.NotNil(t, ctx.Response)
+	require.NoError(t, ctx.Response.Error())
 }

--- a/clearnode/api/apps_v1/submit_app_version.go
+++ b/clearnode/api/apps_v1/submit_app_version.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 
 	"github.com/layer-3/nitrolite/pkg/app"
+	"github.com/layer-3/nitrolite/pkg/core"
 	"github.com/layer-3/nitrolite/pkg/rpc"
 	"github.com/layer-3/nitrolite/pkg/sign"
 )
@@ -25,6 +26,11 @@ func (h *Handler) SubmitAppVersion(c *rpc.Context) {
 	}
 	if req.App.OwnerWallet == "" {
 		c.Fail(nil, "owner_wallet is required")
+		return
+	}
+	normalizedOwnerWallet, err := core.NormalizeHexAddress(req.App.OwnerWallet)
+	if err != nil {
+		c.Fail(rpc.Errorf("invalid owner_wallet: %v", err), "")
 		return
 	}
 	if req.OwnerSig == "" {
@@ -49,14 +55,14 @@ func (h *Handler) SubmitAppVersion(c *rpc.Context) {
 	}
 
 	err = h.useStoreInTx(func(tx Store) error {
-		err := h.actionGateway.AllowAppRegistration(tx, req.App.OwnerWallet)
+		err := h.actionGateway.AllowAppRegistration(tx, normalizedOwnerWallet)
 		if err != nil {
 			return rpc.NewError(err)
 		}
 
 		appEntry := app.AppV1{
 			ID:                          strings.ToLower(req.App.ID),
-			OwnerWallet:                 strings.ToLower(req.App.OwnerWallet),
+			OwnerWallet:                 normalizedOwnerWallet,
 			Metadata:                    req.App.Metadata,
 			Version:                     version,
 			CreationApprovalNotRequired: req.App.CreationApprovalNotRequired,

--- a/clearnode/api/apps_v1/submit_app_version_test.go
+++ b/clearnode/api/apps_v1/submit_app_version_test.go
@@ -211,6 +211,58 @@ func TestSubmitAppVersion_InvalidVersion(t *testing.T) {
 	assert.Contains(t, err.Error(), "version 1")
 }
 
+// TestSubmitAppVersion_NormalizesMixedCaseOwnerWallet verifies that an owner_wallet
+// submitted in mixed case is normalized to the canonical lowercase form before being
+// persisted and used for signature verification.
+func TestSubmitAppVersion_NormalizesMixedCaseOwnerWallet(t *testing.T) {
+	appEntry := app.AppV1{
+		ID:       "test-app",
+		Metadata: "0x0000000000000000000000000000000000000000000000000000000000000000",
+		Version:  1,
+	}
+
+	addr, sig := testOwnerWallet(t, appEntry)
+
+	mockStore := &MockStore{
+		createAppFn: func(entry app.AppV1) error {
+			assert.Equal(t, addr, entry.OwnerWallet, "owner wallet must be persisted as canonical lowercase form")
+			return nil
+		},
+	}
+
+	storeTxProvider := func(fn StoreTxHandler) error {
+		return fn(mockStore)
+	}
+
+	handler := NewHandler(mockStore, storeTxProvider, &MockActionGateway{}, 4096)
+
+	mixedCaseOwner := "0x" + strings.ToUpper(strings.TrimPrefix(addr, "0x"))
+	require.NotEqual(t, addr, mixedCaseOwner)
+
+	reqPayload := rpc.AppsV1SubmitAppVersionRequest{
+		App: rpc.AppV1{
+			ID:          "test-app",
+			OwnerWallet: mixedCaseOwner,
+			Metadata:    "0x0000000000000000000000000000000000000000000000000000000000000000",
+			Version:     "1",
+		},
+		OwnerSig: sig,
+	}
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, string(rpc.AppsV1SubmitAppVersionMethod), payload),
+	}
+
+	handler.SubmitAppVersion(ctx)
+
+	require.NotNil(t, ctx.Response)
+	require.NoError(t, ctx.Response.Error())
+}
+
 func TestSubmitAppVersion_InvalidSignature(t *testing.T) {
 	mockStore := &MockStore{}
 	handler := newHandlerWithDefaults(mockStore)

--- a/clearnode/api/channel_v1/get_channels.go
+++ b/clearnode/api/channel_v1/get_channels.go
@@ -46,6 +46,12 @@ func (h *Handler) GetChannels(c *rpc.Context) {
 		c.Fail(rpc.Errorf("wallet is required"), "missing wallet")
 		return
 	}
+	normalizedWallet, err := core.NormalizeHexAddress(req.Wallet)
+	if err != nil {
+		c.Fail(rpc.Errorf("invalid wallet: %v", err), "")
+		return
+	}
+	req.Wallet = normalizedWallet
 
 	var statusFilter *core.ChannelStatus
 	if req.Status != nil && *req.Status != "" {
@@ -89,7 +95,7 @@ func (h *Handler) GetChannels(c *rpc.Context) {
 	var channels []core.Channel
 	var totalCount uint32
 
-	err := h.useStoreInTx(func(tx Store) error {
+	err = h.useStoreInTx(func(tx Store) error {
 		var err error
 		channels, totalCount, err = tx.GetUserChannels(req.Wallet, statusFilter, req.Asset, typeFilter, limit, offset)
 		if err != nil {

--- a/clearnode/api/channel_v1/get_channels_test.go
+++ b/clearnode/api/channel_v1/get_channels_test.go
@@ -207,7 +207,7 @@ func TestGetChannels_EmptyResult(t *testing.T) {
 	mockTxStore := new(MockStore)
 	handler := newGetChannelsHandler(mockTxStore)
 
-	userWallet := "0xNoChannelsUser"
+	userWallet := "0x0000000000000000000000000000000000000099"
 
 	mockTxStore.On("GetUserChannels", userWallet, (*core.ChannelStatus)(nil), (*string)(nil), (*core.ChannelType)(nil), uint32(100), uint32(0)).
 		Return([]core.Channel{}, uint32(0), nil)
@@ -281,6 +281,33 @@ func TestGetChannels_InvalidStatus(t *testing.T) {
 
 	assert.Equal(t, rpc.MsgTypeRespErr, ctx.Response.Type, "invalid status should produce error response")
 
+	mockTxStore.AssertExpectations(t)
+}
+
+// TestGetChannels_NormalizesWallet verifies that a wallet submitted in mixed case is
+// normalized to canonical lowercase before being passed to the store.
+func TestGetChannels_NormalizesWallet(t *testing.T) {
+	mockTxStore := new(MockStore)
+	handler := newGetChannelsHandler(mockTxStore)
+
+	canonicalWallet := "0x1234567890abcdef1234567890abcdef12345678"
+	mixedCaseWallet := "0x1234567890ABCDEF1234567890abcdef12345678"
+
+	mockTxStore.On("GetUserChannels", canonicalWallet, (*core.ChannelStatus)(nil), (*string)(nil), (*core.ChannelType)(nil), uint32(100), uint32(0)).
+		Return([]core.Channel{}, uint32(0), nil)
+
+	reqPayload := rpc.ChannelsV1GetChannelsRequest{Wallet: mixedCaseWallet}
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.Message{Method: "channels.v1.get_channels", Payload: payload},
+	}
+
+	handler.GetChannels(ctx)
+
+	require.Nil(t, ctx.Response.Error())
 	mockTxStore.AssertExpectations(t)
 }
 

--- a/clearnode/api/channel_v1/get_home_channel.go
+++ b/clearnode/api/channel_v1/get_home_channel.go
@@ -13,8 +13,15 @@ func (h *Handler) GetHomeChannel(c *rpc.Context) {
 		return
 	}
 
+	normalizedWallet, err := core.NormalizeHexAddress(req.Wallet)
+	if err != nil {
+		c.Fail(rpc.Errorf("invalid wallet: %v", err), "")
+		return
+	}
+	req.Wallet = normalizedWallet
+
 	var channel *core.Channel
-	err := h.useStoreInTx(func(tx Store) error {
+	err = h.useStoreInTx(func(tx Store) error {
 		var err error
 		channel, err = tx.GetActiveHomeChannel(req.Wallet, req.Asset)
 		if err != nil {

--- a/clearnode/api/channel_v1/get_home_channel_test.go
+++ b/clearnode/api/channel_v1/get_home_channel_test.go
@@ -163,3 +163,34 @@ func TestGetHomeChannel_NotFound(t *testing.T) {
 	// Verify all mock expectations
 	mockTxStore.AssertExpectations(t)
 }
+
+// TestGetHomeChannel_NormalizesWallet verifies the wallet is normalized before the store call.
+func TestGetHomeChannel_NormalizesWallet(t *testing.T) {
+	mockTxStore := new(MockStore)
+
+	handler := &Handler{
+		useStoreInTx: func(h StoreTxHandler) error { return h(mockTxStore) },
+		metrics:      metrics.NewNoopRuntimeMetricExporter(),
+	}
+
+	canonicalWallet := "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+	mixedCaseWallet := "0xABCDEFabcdefABCDEFabcdefABCDEFabcdefABCD"
+	asset := "USDC"
+
+	homeChannel := core.Channel{ChannelID: "0xch", UserWallet: canonicalWallet, Asset: asset, Type: core.ChannelTypeHome}
+	mockTxStore.On("GetActiveHomeChannel", canonicalWallet, asset).Return(&homeChannel, nil)
+
+	reqPayload := rpc.ChannelsV1GetHomeChannelRequest{Wallet: mixedCaseWallet, Asset: asset}
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.Message{Method: "channels.v1.get_home_channel", Payload: payload},
+	}
+
+	handler.GetHomeChannel(ctx)
+
+	require.Nil(t, ctx.Response.Error())
+	mockTxStore.AssertExpectations(t)
+}

--- a/clearnode/api/channel_v1/get_latest_state.go
+++ b/clearnode/api/channel_v1/get_latest_state.go
@@ -13,8 +13,15 @@ func (h *Handler) GetLatestState(c *rpc.Context) {
 		return
 	}
 
+	normalizedWallet, err := core.NormalizeHexAddress(req.Wallet)
+	if err != nil {
+		c.Fail(rpc.Errorf("invalid wallet: %v", err), "")
+		return
+	}
+	req.Wallet = normalizedWallet
+
 	var state core.State
-	err := h.useStoreInTx(func(tx Store) error {
+	err = h.useStoreInTx(func(tx Store) error {
 		lastState, err := tx.GetLastUserState(req.Wallet, req.Asset, req.OnlySigned)
 		if err != nil {
 			return rpc.Errorf("failed to get last user state: %v", err)

--- a/clearnode/api/channel_v1/get_latest_state_test.go
+++ b/clearnode/api/channel_v1/get_latest_state_test.go
@@ -205,3 +205,34 @@ func TestGetLatestState_OnlySigned(t *testing.T) {
 	// Verify all mock expectations
 	mockTxStore.AssertExpectations(t)
 }
+
+// TestGetLatestState_NormalizesWallet verifies the wallet is normalized before the store call.
+func TestGetLatestState_NormalizesWallet(t *testing.T) {
+	mockTxStore := new(MockStore)
+
+	handler := &Handler{
+		useStoreInTx: func(h StoreTxHandler) error { return h(mockTxStore) },
+		metrics:      metrics.NewNoopRuntimeMetricExporter(),
+	}
+
+	canonicalWallet := "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+	mixedCaseWallet := "0xABCDEFabcdefABCDEFabcdefABCDEFabcdefABCD"
+	asset := "USDC"
+
+	state := core.State{UserWallet: canonicalWallet, Asset: asset, Version: 1}
+	mockTxStore.On("GetLastUserState", canonicalWallet, asset, false).Return(state, nil)
+
+	reqPayload := rpc.ChannelsV1GetLatestStateRequest{Wallet: mixedCaseWallet, Asset: asset}
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.Message{Method: "channels.v1.get_latest_state", Payload: payload},
+	}
+
+	handler.GetLatestState(ctx)
+
+	require.Nil(t, ctx.Response.Error())
+	mockTxStore.AssertExpectations(t)
+}

--- a/clearnode/api/channel_v1/submit_state.go
+++ b/clearnode/api/channel_v1/submit_state.go
@@ -21,6 +21,13 @@ func (h *Handler) SubmitState(c *rpc.Context) {
 		return
 	}
 
+	var err error
+	reqPayload.State.UserWallet, err = core.NormalizeHexAddress(reqPayload.State.UserWallet)
+	if err != nil {
+		c.Fail(rpc.Errorf("invalid user_wallet: %v", err), "")
+		return
+	}
+
 	incomingState, err := toCoreState(reqPayload.State)
 	if err != nil {
 		c.Fail(err, "failed to parse state")

--- a/clearnode/api/channel_v1/submit_state_test.go
+++ b/clearnode/api/channel_v1/submit_state_test.go
@@ -16,6 +16,40 @@ import (
 	"github.com/layer-3/nitrolite/pkg/rpc"
 )
 
+func TestSubmitState_InvalidUserWallet_Rejected(t *testing.T) {
+	mockTxStore := new(MockStore)
+
+	handler := &Handler{
+		useStoreInTx: func(h StoreTxHandler) error { return h(mockTxStore) },
+		metrics:      metrics.NewNoopRuntimeMetricExporter(),
+	}
+
+	reqPayload := rpc.ChannelsV1SubmitStateRequest{
+		State: rpc.StateV1{
+			UserWallet: "0xnot-a-valid-address",
+			Asset:      "USDC",
+			Epoch:      "1",
+			Version:    "1",
+			Transition: rpc.TransitionV1{Amount: "0"},
+		},
+	}
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.Message{Method: "channels.v1.submit_state", Payload: payload},
+	}
+
+	handler.SubmitState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.NotNil(t, respErr)
+	assert.Contains(t, respErr.Error(), "invalid user_wallet")
+	mockTxStore.AssertNotCalled(t, "LockUserState", mock.Anything, mock.Anything)
+}
+
 func TestSubmitState_TransferSend_Success(t *testing.T) {
 	// Setup
 	mockTxStore := new(MockStore)

--- a/clearnode/api/user_v1/get_balances.go
+++ b/clearnode/api/user_v1/get_balances.go
@@ -1,6 +1,7 @@
 package user_v1
 
 import (
+	"github.com/layer-3/nitrolite/pkg/core"
 	"github.com/layer-3/nitrolite/pkg/rpc"
 )
 
@@ -11,6 +12,13 @@ func (h *Handler) GetBalances(c *rpc.Context) {
 		c.Fail(err, "failed to parse parameters")
 		return
 	}
+
+	normalizedWallet, err := core.NormalizeHexAddress(req.Wallet)
+	if err != nil {
+		c.Fail(rpc.Errorf("invalid wallet: %v", err), "")
+		return
+	}
+	req.Wallet = normalizedWallet
 
 	balances, err := h.store.GetUserBalances(req.Wallet)
 	if err != nil {

--- a/clearnode/api/user_v1/get_balances_test.go
+++ b/clearnode/api/user_v1/get_balances_test.go
@@ -82,3 +82,31 @@ func TestGetBalances_Success(t *testing.T) {
 	// Verify all mock expectations
 	mockStore.AssertExpectations(t)
 }
+
+// TestGetBalances_NormalizesWallet verifies the wallet is normalized before the store call.
+func TestGetBalances_NormalizesWallet(t *testing.T) {
+	mockStore := new(MockStore)
+
+	handler := &Handler{
+		store: mockStore,
+	}
+
+	canonicalWallet := "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+	mixedCaseWallet := "0xABCDEFabcdefABCDEFabcdefABCDEFabcdefABCD"
+
+	mockStore.On("GetUserBalances", canonicalWallet).Return([]core.BalanceEntry{}, nil)
+
+	reqPayload := rpc.UserV1GetBalancesRequest{Wallet: mixedCaseWallet}
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.Message{Method: "user.v1.get_balances", Payload: payload},
+	}
+
+	handler.GetBalances(ctx)
+
+	require.Nil(t, ctx.Response.Error())
+	mockStore.AssertExpectations(t)
+}

--- a/clearnode/api/user_v1/get_transactions.go
+++ b/clearnode/api/user_v1/get_transactions.go
@@ -13,6 +13,13 @@ func (h *Handler) GetTransactions(c *rpc.Context) {
 		return
 	}
 
+	normalizedWallet, err := core.NormalizeHexAddress(req.Wallet)
+	if err != nil {
+		c.Fail(rpc.Errorf("invalid wallet: %v", err), "")
+		return
+	}
+	req.Wallet = normalizedWallet
+
 	var paginationParams core.PaginationParams
 	if req.Pagination != nil {
 		paginationParams.Offset = req.Pagination.Offset
@@ -23,7 +30,7 @@ func (h *Handler) GetTransactions(c *rpc.Context) {
 	var transactions []core.Transaction
 	var metadata core.PaginationMetadata
 
-	transactions, metadata, err := h.store.GetUserTransactions(req.Wallet, req.Asset, req.TxType, req.FromTime, req.ToTime, &paginationParams)
+	transactions, metadata, err = h.store.GetUserTransactions(req.Wallet, req.Asset, req.TxType, req.FromTime, req.ToTime, &paginationParams)
 	if err != nil {
 		c.Fail(err, "failed to retrieve transactions")
 		return

--- a/clearnode/api/user_v1/get_transactions_test.go
+++ b/clearnode/api/user_v1/get_transactions_test.go
@@ -118,3 +118,39 @@ func TestGetTransactions_Success(t *testing.T) {
 	// Verify all mock expectations
 	mockStore.AssertExpectations(t)
 }
+
+// TestGetTransactions_NormalizesWallet verifies the wallet is normalized before the store call.
+func TestGetTransactions_NormalizesWallet(t *testing.T) {
+	mockStore := new(MockStore)
+
+	handler := &Handler{
+		store: mockStore,
+	}
+
+	canonicalWallet := "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+	mixedCaseWallet := "0xABCDEFabcdefABCDEFabcdefABCDEFabcdefABCD"
+
+	mockStore.On(
+		"GetUserTransactions",
+		canonicalWallet,
+		(*string)(nil),
+		(*core.TransactionType)(nil),
+		(*uint64)(nil),
+		(*uint64)(nil),
+		&core.PaginationParams{},
+	).Return([]core.Transaction{}, core.PaginationMetadata{}, nil)
+
+	reqPayload := rpc.UserV1GetTransactionsRequest{Wallet: mixedCaseWallet}
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.Message{Method: "user.v1.get_transactions", Payload: payload},
+	}
+
+	handler.GetTransactions(ctx)
+
+	require.Nil(t, ctx.Response.Error())
+	mockStore.AssertExpectations(t)
+}


### PR DESCRIPTION
## Summary

Audit finding **M2-I02** flagged that `NormalizeHexAddress` was applied in some RPC paths (`RequestCreation`, the channel/app session-key state endpoints, `issueTransferReceiverState`) but not others, so equivalent representations of the same Ethereum address — mixed case, missing \`0x\` prefix, or EIP-55 checksum vs lowercased — bypassed duplicate checks and reached the store / signature verification in non-canonical form.

This PR funnels every wallet/owner/participant address that crosses an RPC boundary through `pkg/core.NormalizeHexAddress` before it is used for duplicate detection, packing, signing, or store queries.

### Handlers

| Endpoint | Change |
|---|---|
| `channel_v1.SubmitState` | normalize \`State.UserWallet\` before \`toCoreState\` so lock / channel check / store lookup / signature verify all see canonical form |
| `app_session_v1.SubmitDepositState` | same for \`UserState.UserWallet\` |
| `app_session_v1.CreateAppSession` | replace \`strings.ToLower\` with \`NormalizeHexAddress\` in the participant duplicate-check loop, propagate the normalized address into \`appDef.Participants\` so packing, app session ID derivation, and the persisted participant list all use canonical form. **The audit's central concern — case-only-differing duplicates are now rejected.** |
| `apps_v1.SubmitAppVersion` | validate and normalize \`req.App.OwnerWallet\` early; use the normalized form for \`AllowAppRegistration\`, persistence, and signature verification (replacing the previous bare \`strings.ToLower\` at storage time) |

### Getters

`channel_v1.GetChannels`, `GetLatestState`, `GetHomeChannel`; `app_session_v1.GetAppSessions` (participant filter); `user_v1.GetBalances`, `GetTransactions`; `apps_v1.GetApps` (owner_wallet filter) — all now reject malformed addresses up-front and pass the canonical lowercase form to the store layer.

### Tests

One focused test per touched endpoint exercises the normalization contract:
- Getters assert that a mixed-case input reaches the store as canonical lowercase.
- Submit handlers assert that an invalid hex input is rejected before any store interaction.
- `CreateAppSession` asserts two participant addresses that differ only in case are detected as duplicates.
- `SubmitAppVersion` asserts a mixed-case \`owner_wallet\` is persisted in canonical lowercase form.

The store layer's existing internal \`strings.ToLower\` calls are left untouched — they remain a defence-in-depth safety net for legacy data, but normalization now happens at the API boundary so the canonical form flows through packing, signing, and duplicate detection.

## Test plan

- [x] \`go test ./clearnode/api/...\`
- [x] \`go test ./...\` (full repo)
- [x] \`go vet ./clearnode/...\`
- [x] \`go build ./clearnode/...\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Enhancements**
  * Wallet addresses are now validated and normalized to a consistent canonical format across all API endpoints, ensuring data consistency.
  * Invalid wallet formats are rejected immediately with clear error messages, preventing invalid data from being processed.

* **Tests**
  * Added comprehensive test coverage for wallet address validation and normalization across multiple API handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->