### PR TITLE
YNU-912: Package SDK MCP for npm publishing

### DIFF
--- a/.github/workflows/publish-sdk-mcp.yml
+++ b/.github/workflows/publish-sdk-mcp.yml
@@ -1,0 +1,177 @@
+name: Publish SDK MCP
+
+on:
+  push:
+    tags:
+      - 'mcp-v*'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish @yellow-org/sdk-mcp
+    runs-on: ubuntu-latest
+    env:
+      MCP_PUBLISHER_VERSION: v1.7.6
+      MCP_PUBLISHER_SHA256_LINUX_AMD64: bcc96ca630cae4cf503b4550bd4a17462d42ad4819273bee56f4385bb059ddee
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+          cache: npm
+          cache-dependency-path: 'sdk/mcp/package-lock.json'
+
+      - name: Install dependencies
+        working-directory: ./sdk/mcp
+        run: npm ci
+
+      - name: Build package
+        working-directory: ./sdk/mcp
+        run: npm run build
+
+      - name: Pack and verify package contents
+        id: pack
+        working-directory: ./sdk/mcp
+        run: |
+          PACK_JSON=$(npm pack --json)
+          printf '%s\n' "$PACK_JSON" > pack.json
+          TARBALL=$(node -e "const pack = require('./pack.json')[0]; console.log(pack.filename)")
+          echo "tarball=$TARBALL" >> "$GITHUB_OUTPUT"
+
+          node - <<'NODE'
+          const pack = require('./pack.json')[0];
+          const paths = new Set(pack.files.map((file) => file.path));
+          const required = [
+            'dist/index.js',
+            'dist/index.d.ts',
+            'content/docs/api.yaml',
+            'content/docs/protocol/overview.md',
+            'content/sdk/ts/package.json',
+            'content/sdk/ts/src/client.ts',
+            'content/sdk/ts-compat/package.json',
+            'content/sdk/ts-compat/src/client.ts',
+            'content/sdk/go/client.go',
+            'README.md',
+            'package.json',
+            'server.json',
+          ];
+
+          for (const path of required) {
+            if (!paths.has(path)) throw new Error(`missing package file: ${path}`);
+          }
+
+          for (const path of paths) {
+            if (path.startsWith('src/') || path.startsWith('scripts/')) {
+              throw new Error(`source-only file leaked into package: ${path}`);
+            }
+            if (path.endsWith('.test.ts') || path.endsWith('.spec.ts') || path.endsWith('_test.go')) {
+              throw new Error(`test file leaked into package: ${path}`);
+            }
+          }
+          NODE
+
+      - name: Smoke test packed MCP server
+        working-directory: ./sdk/mcp
+        run: |
+          set -euo pipefail
+          TMPDIR=$(mktemp -d)
+          mkdir "$TMPDIR/app"
+          EXPECTED_VERSION=$(node -p "require('./package.json').version")
+          npm --prefix "$TMPDIR/app" install "./${{ steps.pack.outputs.tarball }}"
+          BIN="$TMPDIR/app/node_modules/.bin/yellow-sdk-mcp"
+          cd "$TMPDIR/app"
+          BIN="$BIN" EXPECTED_VERSION="$EXPECTED_VERSION" node --input-type=module <<'NODE'
+          import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+          import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+          const transport = new StdioClientTransport({ command: process.env.BIN, args: [] });
+          const client = new Client({ name: 'sdk-mcp-smoke', version: '0.0.0' });
+          await client.connect(transport);
+
+          const tools = await client.listTools();
+          if (!tools.tools.some((tool) => tool.name === 'server_info')) {
+            throw new Error('server_info tool missing');
+          }
+
+          const infoResult = await client.callTool({ name: 'server_info', arguments: {} });
+          const info = JSON.parse(infoResult.content[0].text);
+          if (info.version !== process.env.EXPECTED_VERSION) {
+            throw new Error(`unexpected server version ${info.version}`);
+          }
+          if (info.sdkVersion !== process.env.EXPECTED_VERSION) {
+            throw new Error(`unexpected sdk version ${info.sdkVersion}`);
+          }
+          if (info.contentMode !== 'packaged-snapshot') {
+            throw new Error(`expected packaged-snapshot mode, got ${info.contentMode}`);
+          }
+
+          const methodResult = await client.callTool({
+            name: 'lookup_method',
+            arguments: { name: 'deposit', language: 'typescript' },
+          });
+          if (!methodResult.content[0].text.includes('deposit')) {
+            throw new Error('lookup_method did not return packaged TypeScript SDK content');
+          }
+
+          const rpcResult = await client.callTool({
+            name: 'lookup_rpc_method',
+            arguments: { method: 'channels.v1.get_home_channel' },
+          });
+          if (!rpcResult.content[0].text.includes('channels.v1.get_home_channel')) {
+            throw new Error('lookup_rpc_method did not return packaged API docs content');
+          }
+
+          await client.close();
+          NODE
+
+      - name: Validate MCP registry metadata
+        working-directory: ./sdk/mcp
+        run: |
+          node - <<'NODE'
+          const pkg = require('./package.json');
+          const server = require('./server.json');
+          const npmPackage = server.packages.find((entry) => entry.registryType === 'npm');
+
+          if (server.name !== pkg.mcpName) {
+            throw new Error(`server.json name ${server.name} does not match package.json mcpName ${pkg.mcpName}`);
+          }
+          if (!npmPackage) {
+            throw new Error('server.json is missing an npm package entry');
+          }
+          if (npmPackage.identifier !== pkg.name) {
+            throw new Error(`server.json package ${npmPackage.identifier} does not match package.json name ${pkg.name}`);
+          }
+          if (server.version !== pkg.version || npmPackage.version !== pkg.version) {
+            throw new Error('server.json versions must match package.json version');
+          }
+          NODE
+
+      - name: Publish package
+        working-directory: ./sdk/mcp
+        run: npm publish "./${{ steps.pack.outputs.tarball }}" --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Install MCP publisher
+        working-directory: ./sdk/mcp
+        run: |
+          ASSET="mcp-publisher_linux_amd64.tar.gz"
+          curl -fL "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/${ASSET}" -o "$ASSET"
+          echo "${MCP_PUBLISHER_SHA256_LINUX_AMD64}  ${ASSET}" | sha256sum -c -
+          tar xzf "$ASSET" mcp-publisher
+          chmod +x mcp-publisher
+
+      - name: Authenticate to MCP Registry
+        working-directory: ./sdk/mcp
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish MCP registry metadata
+        working-directory: ./sdk/mcp
+        run: ./mcp-publisher publish

--- a/.github/workflows/publish-sdk-mcp.yml
+++ b/.github/workflows/publish-sdk-mcp.yml
@@ -1,21 +1,35 @@
 name: Publish SDK MCP
 
 on:
+  pull_request:
+    paths:
+      - '.github/workflows/publish-sdk-mcp.yml'
+      - 'docs/api.yaml'
+      - 'docs/protocol/**'
+      - 'pkg/app/**'
+      - 'pkg/core/**'
+      - 'pkg/rpc/**'
+      - 'sdk/go/**'
+      - 'sdk/mcp/**'
+      - 'sdk/ts/**'
+      - 'sdk/ts-compat/**'
   push:
     tags:
       - 'mcp-v*'
 
 permissions:
   contents: read
-  id-token: write
+
+env:
+  MCP_PUBLISHER_VERSION: v1.7.6
+  MCP_PUBLISHER_SHA256_LINUX_AMD64: bcc96ca630cae4cf503b4550bd4a17462d42ad4819273bee56f4385bb059ddee
 
 jobs:
-  publish:
-    name: Publish @yellow-org/sdk-mcp
+  verify-and-pack:
+    name: Verify and pack @yellow-org/sdk-mcp
     runs-on: ubuntu-latest
-    env:
-      MCP_PUBLISHER_VERSION: v1.7.6
-      MCP_PUBLISHER_SHA256_LINUX_AMD64: bcc96ca630cae4cf503b4550bd4a17462d42ad4819273bee56f4385bb059ddee
+    outputs:
+      tarball: ${{ steps.pack.outputs.tarball }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -32,92 +46,145 @@ jobs:
         working-directory: ./sdk/mcp
         run: npm ci
 
+      - name: Audit production dependencies
+        working-directory: ./sdk/mcp
+        run: npm audit --omit=dev --audit-level=moderate
+
+      - name: Typecheck
+        working-directory: ./sdk/mcp
+        run: npm run typecheck
+
       - name: Build package
         working-directory: ./sdk/mcp
         run: npm run build
 
-      - name: Pack and verify package contents
+      - name: Verify release preflight
+        if: startsWith(github.ref, 'refs/tags/mcp-v')
+        working-directory: ./sdk/mcp
+        run: npm run verify:release-preflight
+
+      - name: Pack package
         id: pack
         working-directory: ./sdk/mcp
         run: |
-          PACK_JSON=$(npm pack --json)
+          PACK_JSON="$(npm pack --json)"
           printf '%s\n' "$PACK_JSON" > pack.json
-          TARBALL=$(node -e "const pack = require('./pack.json')[0]; console.log(pack.filename)")
+          TARBALL="$(node -e "const pack = require('./pack.json')[0]; console.log(pack.filename)")"
           echo "tarball=$TARBALL" >> "$GITHUB_OUTPUT"
 
-          node - <<'NODE'
-          const pack = require('./pack.json')[0];
-          const paths = new Set(pack.files.map((file) => file.path));
-          const required = [
-            'dist/index.js',
-            'dist/index.d.ts',
-            'content/docs/api.yaml',
-            'content/docs/protocol/overview.md',
-            'content/sdk/ts/package.json',
-            'content/sdk/ts/src/client.ts',
-            'content/sdk/ts-compat/package.json',
-            'content/sdk/ts-compat/src/client.ts',
-            'content/sdk/go/client.go',
-            'README.md',
-            'package.json',
-            'server.json',
-          ];
-
-          for (const path of required) {
-            if (!paths.has(path)) throw new Error(`missing package file: ${path}`);
-          }
-
-          for (const path of paths) {
-            if (path.startsWith('src/') || path.startsWith('scripts/')) {
-              throw new Error(`source-only file leaked into package: ${path}`);
-            }
-            if (path.endsWith('.test.ts') || path.endsWith('.spec.ts') || path.endsWith('_test.go')) {
-              throw new Error(`test file leaked into package: ${path}`);
-            }
-          }
-          NODE
-
-      - name: Smoke test packed MCP server
+      - name: Adversarial tarball validation
         working-directory: ./sdk/mcp
+        run: npm run verify:package -- pack.json
+
+      - name: Upload package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdk-mcp-package
+          path: |
+            sdk/mcp/${{ steps.pack.outputs.tarball }}
+            sdk/mcp/pack.json
+            sdk/mcp/server.json
+          if-no-files-found: error
+
+  smoke:
+    name: Smoke packed MCP server
+    runs-on: ubuntu-latest
+    needs: verify-and-pack
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Download package artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: sdk-mcp-package
+          path: sdk-mcp-package
+
+      - name: Adversarial runtime smoke test
         run: |
           set -euo pipefail
-          TMPDIR=$(mktemp -d)
-          mkdir "$TMPDIR/app"
-          EXPECTED_VERSION=$(node -p "require('./package.json').version")
-          npm --prefix "$TMPDIR/app" install "./${{ steps.pack.outputs.tarball }}"
-          BIN="$TMPDIR/app/node_modules/.bin/yellow-sdk-mcp"
-          cd "$TMPDIR/app"
+          SMOKE_DIR="$(mktemp -d)"
+          mkdir "$SMOKE_DIR/app"
+          EXPECTED_VERSION="$(node -e "const pack = require('./sdk-mcp-package/pack.json')[0]; console.log(pack.version)")"
+          TARBALL="${{ needs.verify-and-pack.outputs.tarball }}"
+          npm --prefix "$SMOKE_DIR/app" install "./sdk-mcp-package/$TARBALL"
+          BIN="$SMOKE_DIR/app/node_modules/.bin/yellow-sdk-mcp"
+          cd "$SMOKE_DIR/app"
           BIN="$BIN" EXPECTED_VERSION="$EXPECTED_VERSION" node --input-type=module <<'NODE'
           import { Client } from '@modelcontextprotocol/sdk/client/index.js';
           import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 
+          const expectedVersion = process.env.EXPECTED_VERSION;
+          const expectedGoVersion = `v${expectedVersion}`;
           const transport = new StdioClientTransport({ command: process.env.BIN, args: [] });
           const client = new Client({ name: 'sdk-mcp-smoke', version: '0.0.0' });
           await client.connect(transport);
 
           const tools = await client.listTools();
+          if (tools.tools.length !== 9) {
+            throw new Error(`expected 9 tools, got ${tools.tools.length}`);
+          }
           if (!tools.tools.some((tool) => tool.name === 'server_info')) {
             throw new Error('server_info tool missing');
           }
 
+          const resources = await client.listResources();
+          if (resources.resources.length !== 31) {
+            throw new Error(`expected 31 resources, got ${resources.resources.length}`);
+          }
+
           const infoResult = await client.callTool({ name: 'server_info', arguments: {} });
           const info = JSON.parse(infoResult.content[0].text);
-          if (info.version !== process.env.EXPECTED_VERSION) {
+          if (info.version !== expectedVersion) {
             throw new Error(`unexpected server version ${info.version}`);
           }
-          if (info.sdkVersion !== process.env.EXPECTED_VERSION) {
+          if (info.sdkVersion !== expectedVersion) {
             throw new Error(`unexpected sdk version ${info.sdkVersion}`);
+          }
+          if (info.compatVersion !== expectedVersion) {
+            throw new Error(`unexpected compat version ${info.compatVersion}`);
+          }
+          if (info.goModuleVersion !== expectedGoVersion) {
+            throw new Error(`unexpected Go module version ${info.goModuleVersion}`);
           }
           if (info.contentMode !== 'packaged-snapshot') {
             throw new Error(`expected packaged-snapshot mode, got ${info.contentMode}`);
           }
+          if (info.versionPolicy !== 'strict-mirror') {
+            throw new Error(`expected strict-mirror policy, got ${info.versionPolicy}`);
+          }
+          if (!info.sourceCommit || info.sourceCommit === 'unknown') {
+            throw new Error('sourceCommit must be present in packaged metadata');
+          }
+          if (!Number.isInteger(info.contentManifestFiles) || info.contentManifestFiles < 70) {
+            throw new Error(`unexpected manifest file count ${info.contentManifestFiles}`);
+          }
 
-          const methodResult = await client.callTool({
+          const tsMethodResult = await client.callTool({
             name: 'lookup_method',
             arguments: { name: 'deposit', language: 'typescript' },
           });
-          if (!methodResult.content[0].text.includes('deposit')) {
+          if (!tsMethodResult.content[0].text.includes('deposit')) {
             throw new Error('lookup_method did not return packaged TypeScript SDK content');
+          }
+
+          const goMethodResult = await client.callTool({
+            name: 'lookup_method',
+            arguments: { name: 'Deposit', language: 'go' },
+          });
+          if (!goMethodResult.content[0].text.includes('Deposit')) {
+            throw new Error('lookup_method did not return packaged Go SDK content');
+          }
+
+          const typeResult = await client.callTool({
+            name: 'lookup_type',
+            arguments: { name: 'AppDefinitionV1', language: 'both' },
+          });
+          if (!typeResult.content[0].text.includes('AppDefinitionV1')) {
+            throw new Error('lookup_type did not return packaged app type content');
           }
 
           const rpcResult = await client.callTool({
@@ -128,36 +195,58 @@ jobs:
             throw new Error('lookup_rpc_method did not return packaged API docs content');
           }
 
+          const scaffoldResult = await client.callTool({
+            name: 'scaffold_project',
+            arguments: { template: 'go-transfer-app' },
+          });
+          if (!scaffoldResult.content[0].text.includes(`github.com/layer-3/nitrolite ${expectedGoVersion}`)) {
+            throw new Error('Go scaffold did not use the packaged Go module version');
+          }
+
           await client.close();
           NODE
 
-      - name: Validate MCP registry metadata
-        working-directory: ./sdk/mcp
-        run: |
-          node - <<'NODE'
-          const pkg = require('./package.json');
-          const server = require('./server.json');
-          const npmPackage = server.packages.find((entry) => entry.registryType === 'npm');
+  publish-npm:
+    name: Publish npm package
+    runs-on: ubuntu-latest
+    needs:
+      - verify-and-pack
+      - smoke
+    if: startsWith(github.ref, 'refs/tags/mcp-v')
+    environment: mcp-release
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
 
-          if (server.name !== pkg.mcpName) {
-            throw new Error(`server.json name ${server.name} does not match package.json mcpName ${pkg.mcpName}`);
-          }
-          if (!npmPackage) {
-            throw new Error('server.json is missing an npm package entry');
-          }
-          if (npmPackage.identifier !== pkg.name) {
-            throw new Error(`server.json package ${npmPackage.identifier} does not match package.json name ${pkg.name}`);
-          }
-          if (server.version !== pkg.version || npmPackage.version !== pkg.version) {
-            throw new Error('server.json versions must match package.json version');
-          }
-          NODE
+      - name: Download package artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: sdk-mcp-package
+          path: sdk-mcp-package
 
       - name: Publish package
-        working-directory: ./sdk/mcp
-        run: npm publish "./${{ steps.pack.outputs.tarball }}" --access public --provenance
+        run: npm publish "./sdk-mcp-package/${{ needs.verify-and-pack.outputs.tarball }}" --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish-registry:
+    name: Publish MCP Registry metadata
+    runs-on: ubuntu-latest
+    needs: publish-npm
+    if: startsWith(github.ref, 'refs/tags/mcp-v')
+    environment: mcp-release
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       - name: Install MCP publisher
         working-directory: ./sdk/mcp
@@ -172,6 +261,6 @@ jobs:
         working-directory: ./sdk/mcp
         run: ./mcp-publisher login github-oidc
 
-      - name: Publish MCP registry metadata
+      - name: Publish MCP Registry metadata
         working-directory: ./sdk/mcp
         run: ./mcp-publisher publish

--- a/sdk/mcp/.gitignore
+++ b/sdk/mcp/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+content/

--- a/sdk/mcp/README.md
+++ b/sdk/mcp/README.md
@@ -1,20 +1,108 @@
-# Nitrolite MCP Server (Unified)
+# Yellow SDK MCP Server
 
-An MCP (Model Context Protocol) server that exposes the **Nitrolite SDK** knowledge base to AI coding tools — covering both the **TypeScript SDK** (`@yellow-org/sdk`) and the **Go SDK** (`github.com/layer-3/nitrolite/sdk/go`). It reads SDK source code, protocol documentation, and Go type definitions at startup, making every method, type, enum, and protocol concept discoverable by AI agents.
+An MCP (Model Context Protocol) server that exposes the **Yellow SDK / Nitrolite SDK** knowledge base to AI coding tools — covering both the **TypeScript SDK** (`@yellow-org/sdk`) and the **Go SDK** (`github.com/layer-3/nitrolite/sdk/go`).
+
+The npm package ships with a release-time content snapshot, so external users do **not** need to clone the Nitrolite repository. When running from this monorepo, the server reads local source files first and falls back to the packaged snapshot only when source files are unavailable.
 
 ## Quick Start
 
+Choose the client you use. All published-package examples run the server from npm, so no Nitrolite repo clone is required.
+
+### Claude Code
+
+For your current project:
+
 ```bash
-# From repo root:
-cd sdk/mcp && npm install && cd ../..
+claude mcp add --transport stdio nitrolite -- npx -y @yellow-org/sdk-mcp@^1
 ```
 
-Add to `.mcp.json` (already configured in this repo):
+For a shareable project config, add this to `.mcp.json` at the repository root:
 
 ```json
 {
   "mcpServers": {
     "nitrolite": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@yellow-org/sdk-mcp@^1"]
+    }
+  }
+}
+```
+
+### Claude Desktop
+
+Add this to `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS, or `%APPDATA%\Claude\claude_desktop_config.json` on Windows, then restart Claude Desktop:
+
+```json
+{
+  "mcpServers": {
+    "nitrolite": {
+      "command": "npx",
+      "args": ["-y", "@yellow-org/sdk-mcp@^1"]
+    }
+  }
+}
+```
+
+### Codex
+
+```bash
+codex mcp add nitrolite -- npx -y @yellow-org/sdk-mcp@^1
+```
+
+### Cursor
+
+Add this to `~/.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "nitrolite": {
+      "command": "npx",
+      "args": ["-y", "@yellow-org/sdk-mcp@^1"]
+    }
+  }
+}
+```
+
+### VS Code
+
+Add this to `.vscode/mcp.json` in your workspace, or to your VS Code user MCP config:
+
+```json
+{
+  "servers": {
+    "nitrolite": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@yellow-org/sdk-mcp@^1"]
+    }
+  }
+}
+```
+
+You can also install it from the VS Code command line:
+
+```bash
+code --add-mcp '{"name":"nitrolite","type":"stdio","command":"npx","args":["-y","@yellow-org/sdk-mcp@^1"]}'
+```
+
+### Local Development
+
+From this repository:
+
+```bash
+cd sdk/mcp && npm install && cd ../..
+```
+
+Add this to `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "nitrolite": {
+      "type": "stdio",
       "command": "npm",
       "args": ["--prefix", "sdk/mcp", "exec", "--", "tsx", "sdk/mcp/src/index.ts"]
     }
@@ -22,17 +110,23 @@ Add to `.mcp.json` (already configured in this repo):
 }
 ```
 
-Any MCP-compatible tool (Claude Code, Cursor, Windsurf, VS Code Copilot) auto-discovers the server from `.mcp.json`.
+Any MCP-compatible client that supports stdio servers can launch the package with the same `npx -y @yellow-org/sdk-mcp@^1` command.
 
 ## What's Inside
 
 - **30 resources** — API reference (TS + Go), protocol docs, security patterns, examples (TS + Go), use cases, migration
-- **8 tools** — method lookup, type lookup, search, RPC format, import validation, concept explanation, scaffolding (TS + Go)
+- **9 tools** — server info, method lookup, type lookup, search, RPC format, import validation, concept explanation, scaffolding (TS + Go)
 - **3 prompts** — guided workflows for building apps (covers both TS and Go), migrating from v0.5.3, building AI agents
 
----
-
 ## Tools
+
+### `server_info`
+
+Return package, SDK, compat, Go module, protocol, and content mode metadata. Use this in bug reports.
+
+```text
+> server_info()
+```
 
 ### `lookup_method`
 
@@ -83,6 +177,26 @@ Generate a starter project. TypeScript templates output `package.json` + `tsconf
 - `validate_import` — check if a symbol is in `@yellow-org/sdk-compat` or `@yellow-org/sdk`
 - `explain_concept` — plain-English explanation of protocol concepts
 - `lookup_rpc_method` — full v1 RPC method lookup from `docs/api.yaml`
+
+---
+
+## Publishing
+
+The package is designed for npm distribution:
+
+```bash
+cd sdk/mcp
+npm ci
+npm run build
+npm pack --dry-run
+npm publish --access public
+```
+
+`npm run build` copies the release source/docs snapshot into `content/`, compiles to `dist/`, and makes the binary executable. The npm tarball includes only `dist`, `content`, `README.md`, `package.json`, and `server.json`.
+
+Release tags matching `mcp-v*` run `.github/workflows/publish-sdk-mcp.yml`, which publishes the npm package and then publishes `server.json` to the MCP Registry.
+
+Version policy: the MCP package mirrors the SDK release it documents. If `@yellow-org/sdk` is `1.2.1`, publish `@yellow-org/sdk-mcp@1.2.1` from the same release commit. Consumers can use `@^1` to track compatible v1 SDK docs, or pin an exact MCP version for audited builds.
 
 ---
 

--- a/sdk/mcp/README.md
+++ b/sdk/mcp/README.md
@@ -116,7 +116,7 @@ Any MCP-compatible client that supports stdio servers can launch the package wit
 
 ## What's Inside
 
-- **30 resources** — API reference (TS + Go), protocol docs, security patterns, examples (TS + Go), use cases, migration
+- **31 resources** — API reference (TS + Go), protocol docs, security patterns, examples (TS + Go), use cases, migration
 - **9 tools** — server info, method lookup, type lookup, search, RPC format, import validation, concept explanation, scaffolding (TS + Go)
 - **3 prompts** — guided workflows for building apps (covers both TS and Go), migrating from v0.5.3, building AI agents
 
@@ -194,11 +194,11 @@ npm pack --dry-run
 npm publish --access public
 ```
 
-`npm run build` copies the release source/docs snapshot into `content/`, compiles to `dist/`, and makes the binary executable. The npm tarball includes only `dist`, `content`, `README.md`, `package.json`, and `server.json`.
+`npm run build` copies the release source/docs snapshot into `content/`, writes `content/release.json` and `content/manifest.json`, compiles to `dist/`, and marks the binary executable. The npm tarball includes only `dist`, `content`, `README.md`, `package.json`, and `server.json`.
 
-Release tags matching `mcp-v*` run `.github/workflows/publish-sdk-mcp.yml`, which publishes the npm package and then publishes `server.json` to the MCP Registry.
+Release tags matching `mcp-v*` run `.github/workflows/publish-sdk-mcp.yml`. The workflow validates the content manifest, smokes the packed server from a clean install, publishes the npm package, and then publishes `server.json` to the MCP Registry from a separate retryable job.
 
-Version policy: the MCP package mirrors the SDK release it documents. If `@yellow-org/sdk` is `1.2.1`, publish `@yellow-org/sdk-mcp@1.2.1` from the same release commit. Consumers can use `@^1` to track compatible v1 SDK docs, or pin an exact MCP version for audited builds.
+Version policy: the MCP package mirrors the SDK release it documents. If `@yellow-org/sdk` is `1.2.1`, publish `@yellow-org/sdk-mcp@1.2.1` only after `@yellow-org/sdk@1.2.1`, `@yellow-org/sdk-compat@1.2.1`, and the Go module tag `v1.2.1` are available. The server never fetches the latest GitHub release at runtime; scaffolds and `server_info` use the packaged release metadata. Consumers can use `@^1` to track compatible v1 SDK docs, or pin an exact MCP version for audited builds.
 
 ---
 

--- a/sdk/mcp/README.md
+++ b/sdk/mcp/README.md
@@ -1,22 +1,110 @@
-# Nitrolite MCP Server (Unified)
+# Yellow SDK MCP Server
 
-An MCP (Model Context Protocol) server that exposes the **Nitrolite SDK** knowledge base to AI coding tools — covering both the **TypeScript SDK** (`@yellow-org/sdk`) and the **Go SDK** (`github.com/layer-3/nitrolite/sdk/go`). It reads SDK source code, protocol documentation, and Go type definitions at startup, making every method, type, enum, and protocol concept discoverable by AI agents.
+An MCP (Model Context Protocol) server that exposes the **Yellow SDK / Nitrolite SDK** knowledge base to AI coding tools — covering both the **TypeScript SDK** (`@yellow-org/sdk`) and the **Go SDK** (`github.com/layer-3/nitrolite/sdk/go`).
+
+The npm package ships with a release-time content snapshot, so external users do **not** need to clone the Nitrolite repository. When running from this monorepo, the server reads local source files first and falls back to the packaged snapshot only when source files are unavailable.
 
 > **Renamed in v1.3.0** — the off-chain broker was renamed from `clearnode` to `nitronode`. v1.2.0 and earlier ship as `clearnode`; v1.3.0 and later ship as `nitronode`. See [`MIGRATION-NITRONODE.md`](../../MIGRATION-NITRONODE.md) (also exposed as the `nitrolite://migration/nitronode` MCP resource).
 
 ## Quick Start
 
+Choose the client you use. All published-package examples run the server from npm, so no Nitrolite repo clone is required.
+
+### Claude Code
+
+For your current project:
+
 ```bash
-# From repo root:
-cd sdk/mcp && npm install && cd ../..
+claude mcp add --transport stdio nitrolite -- npx -y @yellow-org/sdk-mcp@^1
 ```
 
-Add to `.mcp.json` (already configured in this repo):
+For a shareable project config, add this to `.mcp.json` at the repository root:
 
 ```json
 {
   "mcpServers": {
     "nitrolite": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@yellow-org/sdk-mcp@^1"]
+    }
+  }
+}
+```
+
+### Claude Desktop
+
+Add this to `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS, or `%APPDATA%\Claude\claude_desktop_config.json` on Windows, then restart Claude Desktop:
+
+```json
+{
+  "mcpServers": {
+    "nitrolite": {
+      "command": "npx",
+      "args": ["-y", "@yellow-org/sdk-mcp@^1"]
+    }
+  }
+}
+```
+
+### Codex
+
+```bash
+codex mcp add nitrolite -- npx -y @yellow-org/sdk-mcp@^1
+```
+
+### Cursor
+
+Add this to `~/.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "nitrolite": {
+      "command": "npx",
+      "args": ["-y", "@yellow-org/sdk-mcp@^1"]
+    }
+  }
+}
+```
+
+### VS Code
+
+Add this to `.vscode/mcp.json` in your workspace, or to your VS Code user MCP config:
+
+```json
+{
+  "servers": {
+    "nitrolite": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@yellow-org/sdk-mcp@^1"]
+    }
+  }
+}
+```
+
+You can also install it from the VS Code command line:
+
+```bash
+code --add-mcp '{"name":"nitrolite","type":"stdio","command":"npx","args":["-y","@yellow-org/sdk-mcp@^1"]}'
+```
+
+### Local Development
+
+From this repository:
+
+```bash
+cd sdk/mcp && npm install && cd ../..
+```
+
+Add this to `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "nitrolite": {
+      "type": "stdio",
       "command": "npm",
       "args": ["--prefix", "sdk/mcp", "exec", "--", "tsx", "sdk/mcp/src/index.ts"]
     }
@@ -24,17 +112,23 @@ Add to `.mcp.json` (already configured in this repo):
 }
 ```
 
-Any MCP-compatible tool (Claude Code, Cursor, Windsurf, VS Code Copilot) auto-discovers the server from `.mcp.json`.
+Any MCP-compatible client that supports stdio servers can launch the package with the same `npx -y @yellow-org/sdk-mcp@^1` command.
 
 ## What's Inside
 
 - **30 resources** — API reference (TS + Go), protocol docs, security patterns, examples (TS + Go), use cases, migration
-- **8 tools** — method lookup, type lookup, search, RPC format, import validation, concept explanation, scaffolding (TS + Go)
+- **9 tools** — server info, method lookup, type lookup, search, RPC format, import validation, concept explanation, scaffolding (TS + Go)
 - **3 prompts** — guided workflows for building apps (covers both TS and Go), migrating from v0.5.3, building AI agents
 
----
-
 ## Tools
+
+### `server_info`
+
+Return package, SDK, compat, Go module, protocol, and content mode metadata. Use this in bug reports.
+
+```text
+> server_info()
+```
 
 ### `lookup_method`
 
@@ -85,6 +179,26 @@ Generate a starter project. TypeScript templates output `package.json` + `tsconf
 - `validate_import` — check if a symbol is in `@yellow-org/sdk-compat` or `@yellow-org/sdk`
 - `explain_concept` — plain-English explanation of protocol concepts
 - `lookup_rpc_method` — full v1 RPC method lookup from `docs/api.yaml`
+
+---
+
+## Publishing
+
+The package is designed for npm distribution:
+
+```bash
+cd sdk/mcp
+npm ci
+npm run build
+npm pack --dry-run
+npm publish --access public
+```
+
+`npm run build` copies the release source/docs snapshot into `content/`, compiles to `dist/`, and makes the binary executable. The npm tarball includes only `dist`, `content`, `README.md`, `package.json`, and `server.json`.
+
+Release tags matching `mcp-v*` run `.github/workflows/publish-sdk-mcp.yml`, which publishes the npm package and then publishes `server.json` to the MCP Registry.
+
+Version policy: the MCP package mirrors the SDK release it documents. If `@yellow-org/sdk` is `1.2.1`, publish `@yellow-org/sdk-mcp@1.2.1` from the same release commit. Consumers can use `@^1` to track compatible v1 SDK docs, or pin an exact MCP version for audited builds.
 
 ---
 

--- a/sdk/mcp/package-lock.json
+++ b/sdk/mcp/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@yellow-org/sdk-mcp",
-  "version": "0.1.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yellow-org/sdk-mcp",
-      "version": "0.1.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0",
         "zod": "^3.23.0"
       },
       "bin": {
-        "nitrolite-sdk-mcp": "src/index.ts"
+        "yellow-sdk-mcp": "dist/index.js"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/sdk/mcp/package-lock.json
+++ b/sdk/mcp/package-lock.json
@@ -1154,9 +1154,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/sdk/mcp/package.json
+++ b/sdk/mcp/package.json
@@ -1,16 +1,26 @@
 {
   "name": "@yellow-org/sdk-mcp",
-  "version": "0.1.0",
-  "description": "Unified MCP server for Nitrolite — TypeScript and Go SDK context for AI agents and IDEs",
+  "version": "1.2.1",
+  "description": "Unified MCP server for Yellow SDK and Nitrolite protocol context for AI agents and IDEs",
   "type": "module",
-  "main": "src/index.ts",
+  "mcpName": "io.github.layer-3/yellow-sdk-mcp",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "bin": {
-    "nitrolite-sdk-mcp": "src/index.ts"
+    "yellow-sdk-mcp": "dist/index.js"
   },
+  "files": [
+    "dist",
+    "content",
+    "README.md",
+    "server.json"
+  ],
   "scripts": {
     "start": "tsx src/index.ts",
-    "build": "tsc",
-    "typecheck": "tsc --noEmit"
+    "prepare-content": "node scripts/prepare-package-content.mjs",
+    "build": "npm run prepare-content && tsc && chmod +x dist/index.js",
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.28.0",
@@ -24,5 +34,23 @@
   "engines": {
     "node": ">=20.0.0"
   },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/layer-3/nitrolite.git",
+    "directory": "sdk/mcp"
+  },
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "yellow",
+    "yellow-org",
+    "nitrolite",
+    "state-channels",
+    "sdk"
+  ],
+  "author": "Nitro Team",
   "license": "MIT"
 }

--- a/sdk/mcp/package.json
+++ b/sdk/mcp/package.json
@@ -18,13 +18,18 @@
   "scripts": {
     "start": "tsx src/index.ts",
     "prepare-content": "node scripts/prepare-package-content.mjs",
-    "build": "npm run prepare-content && tsc && chmod +x dist/index.js",
+    "build": "npm run prepare-content && tsc && node scripts/set-executable.mjs dist/index.js",
     "typecheck": "tsc --noEmit",
+    "verify:package": "node scripts/verify-package-content.mjs",
+    "verify:release-preflight": "node scripts/verify-release-preflight.mjs",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.28.0",
     "zod": "^3.23.0"
+  },
+  "overrides": {
+    "ip-address": "^10.2.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/sdk/mcp/scripts/prepare-package-content.mjs
+++ b/sdk/mcp/scripts/prepare-package-content.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+import { cpSync, existsSync, mkdirSync, readdirSync, rmSync, statSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(scriptDir, '..');
+const repoRoot = resolve(packageRoot, '../..');
+const contentRoot = join(packageRoot, 'content');
+
+const copySpecs = [
+  { from: 'docs/api.yaml', to: 'docs/api.yaml' },
+  { from: 'docs/protocol', to: 'docs/protocol', extensions: ['.md'] },
+  { from: 'sdk/ts/package.json', to: 'sdk/ts/package.json' },
+  { from: 'sdk/ts/src', to: 'sdk/ts/src', extensions: ['.ts'] },
+  { from: 'sdk/ts-compat/package.json', to: 'sdk/ts-compat/package.json' },
+  { from: 'sdk/ts-compat/src', to: 'sdk/ts-compat/src', extensions: ['.ts'] },
+  { from: 'sdk/ts-compat/docs', to: 'sdk/ts-compat/docs', extensions: ['.md'] },
+  { from: 'sdk/go', to: 'sdk/go', extensions: ['.go', '.md'] },
+  { from: 'pkg/app', to: 'pkg/app', extensions: ['.go'] },
+  { from: 'pkg/core', to: 'pkg/core', extensions: ['.go', '.md'] },
+  { from: 'pkg/rpc', to: 'pkg/rpc', extensions: ['.go', '.md'] },
+];
+
+function shouldCopy(filePath, extensions) {
+  if (filePath.endsWith('_test.go')) return false;
+  if (filePath.endsWith('.test.ts') || filePath.endsWith('.spec.ts')) return false;
+  if (!extensions) return true;
+  return extensions.some((extension) => filePath.endsWith(extension));
+}
+
+function copyFilteredDirectory(sourceDir, targetDir, extensions) {
+  for (const entry of readdirSync(sourceDir)) {
+    if (entry === 'node_modules' || entry === 'dist') continue;
+    const sourcePath = join(sourceDir, entry);
+    const targetPath = join(targetDir, entry);
+    const stats = statSync(sourcePath);
+    if (stats.isDirectory()) {
+      copyFilteredDirectory(sourcePath, targetPath, extensions);
+      continue;
+    }
+    if (!stats.isFile() || !shouldCopy(sourcePath, extensions)) continue;
+    mkdirSync(dirname(targetPath), { recursive: true });
+    cpSync(sourcePath, targetPath);
+  }
+}
+
+rmSync(contentRoot, { recursive: true, force: true });
+mkdirSync(contentRoot, { recursive: true });
+
+for (const spec of copySpecs) {
+  const sourcePath = resolve(repoRoot, spec.from);
+  const targetPath = resolve(contentRoot, spec.to);
+  if (!existsSync(sourcePath)) {
+    console.warn(`Skipping missing content source: ${relative(repoRoot, sourcePath)}`);
+    continue;
+  }
+  const stats = statSync(sourcePath);
+  if (stats.isDirectory()) {
+    copyFilteredDirectory(sourcePath, targetPath, spec.extensions);
+  } else {
+    mkdirSync(dirname(targetPath), { recursive: true });
+    cpSync(sourcePath, targetPath);
+  }
+}
+
+console.error(`Prepared MCP package content in ${relative(packageRoot, contentRoot)}`);

--- a/sdk/mcp/scripts/prepare-package-content.mjs
+++ b/sdk/mcp/scripts/prepare-package-content.mjs
@@ -1,26 +1,50 @@
 #!/usr/bin/env node
-import { cpSync, existsSync, mkdirSync, readdirSync, rmSync, statSync } from 'node:fs';
-import { dirname, join, relative, resolve } from 'node:path';
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { dirname, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const packageRoot = resolve(scriptDir, '..');
 const repoRoot = resolve(packageRoot, '../..');
 const contentRoot = join(packageRoot, 'content');
+const goModulePath = 'github.com/layer-3/nitrolite';
 
 const copySpecs = [
-  { from: 'docs/api.yaml', to: 'docs/api.yaml' },
-  { from: 'docs/protocol', to: 'docs/protocol', extensions: ['.md'] },
-  { from: 'sdk/ts/package.json', to: 'sdk/ts/package.json' },
-  { from: 'sdk/ts/src', to: 'sdk/ts/src', extensions: ['.ts'] },
-  { from: 'sdk/ts-compat/package.json', to: 'sdk/ts-compat/package.json' },
-  { from: 'sdk/ts-compat/src', to: 'sdk/ts-compat/src', extensions: ['.ts'] },
-  { from: 'sdk/ts-compat/docs', to: 'sdk/ts-compat/docs', extensions: ['.md'] },
-  { from: 'sdk/go', to: 'sdk/go', extensions: ['.go', '.md'] },
-  { from: 'pkg/app', to: 'pkg/app', extensions: ['.go'] },
-  { from: 'pkg/core', to: 'pkg/core', extensions: ['.go', '.md'] },
-  { from: 'pkg/rpc', to: 'pkg/rpc', extensions: ['.go', '.md'] },
+  { from: 'docs/api.yaml', to: 'docs/api.yaml', required: true },
+  { from: 'docs/protocol', to: 'docs/protocol', extensions: ['.md'], required: true },
+  { from: 'sdk/ts/package.json', to: 'sdk/ts/package.json', required: true },
+  { from: 'sdk/ts/src', to: 'sdk/ts/src', extensions: ['.ts'], required: true },
+  { from: 'sdk/ts-compat/package.json', to: 'sdk/ts-compat/package.json', required: true },
+  { from: 'sdk/ts-compat/src', to: 'sdk/ts-compat/src', extensions: ['.ts'], required: true },
+  { from: 'sdk/ts-compat/docs', to: 'sdk/ts-compat/docs', extensions: ['.md'], required: true },
+  { from: 'sdk/go', to: 'sdk/go', extensions: ['.go', '.md'], required: true },
+  { from: 'pkg/app', to: 'pkg/app', extensions: ['.go'], required: true },
+  { from: 'pkg/core', to: 'pkg/core', extensions: ['.go', '.md'], required: true },
+  { from: 'pkg/rpc', to: 'pkg/rpc', extensions: ['.go', '.md'], required: true },
 ];
+
+function toPosixPath(path) {
+  return path.split(sep).join('/');
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf-8'));
+}
+
+function getSourceCommit() {
+  if (process.env.GITHUB_SHA) return process.env.GITHUB_SHA;
+  try {
+    return execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: repoRoot,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return 'unknown';
+  }
+}
 
 function shouldCopy(filePath, extensions) {
   if (filePath.endsWith('_test.go')) return false;
@@ -30,38 +54,130 @@ function shouldCopy(filePath, extensions) {
 }
 
 function copyFilteredDirectory(sourceDir, targetDir, extensions) {
-  for (const entry of readdirSync(sourceDir)) {
+  let copied = 0;
+  for (const entry of readdirSync(sourceDir).sort()) {
     if (entry === 'node_modules' || entry === 'dist') continue;
     const sourcePath = join(sourceDir, entry);
     const targetPath = join(targetDir, entry);
     const stats = statSync(sourcePath);
     if (stats.isDirectory()) {
-      copyFilteredDirectory(sourcePath, targetPath, extensions);
+      copied += copyFilteredDirectory(sourcePath, targetPath, extensions);
       continue;
     }
     if (!stats.isFile() || !shouldCopy(sourcePath, extensions)) continue;
     mkdirSync(dirname(targetPath), { recursive: true });
     cpSync(sourcePath, targetPath);
+    copied += 1;
   }
+  return copied;
+}
+
+function collectContentFiles(root) {
+  const files = [];
+  function walk(dir) {
+    for (const entry of readdirSync(dir).sort()) {
+      const path = join(dir, entry);
+      const stats = statSync(path);
+      if (stats.isDirectory()) {
+        walk(path);
+        continue;
+      }
+      if (!stats.isFile()) continue;
+      const bytes = readFileSync(path);
+      files.push({
+        path: toPosixPath(relative(root, path)),
+        size: stats.size,
+        sha256: createHash('sha256').update(bytes).digest('hex'),
+      });
+    }
+  }
+  walk(root);
+  return files;
+}
+
+function countByPrefix(files) {
+  const counts = {};
+  for (const file of files) {
+    const [first, second] = file.path.split('/');
+    const prefix = second ? `${first}/${second}` : first;
+    counts[prefix] = (counts[prefix] ?? 0) + 1;
+  }
+  return counts;
 }
 
 rmSync(contentRoot, { recursive: true, force: true });
 mkdirSync(contentRoot, { recursive: true });
 
+const copyResults = [];
 for (const spec of copySpecs) {
   const sourcePath = resolve(repoRoot, spec.from);
   const targetPath = resolve(contentRoot, spec.to);
   if (!existsSync(sourcePath)) {
-    console.warn(`Skipping missing content source: ${relative(repoRoot, sourcePath)}`);
+    if (spec.required) {
+      throw new Error(`Missing required content source: ${relative(repoRoot, sourcePath)}`);
+    }
+    copyResults.push({ from: spec.from, to: spec.to, required: false, files: 0 });
     continue;
   }
   const stats = statSync(sourcePath);
+  let files = 0;
   if (stats.isDirectory()) {
-    copyFilteredDirectory(sourcePath, targetPath, spec.extensions);
+    files = copyFilteredDirectory(sourcePath, targetPath, spec.extensions);
   } else {
     mkdirSync(dirname(targetPath), { recursive: true });
     cpSync(sourcePath, targetPath);
+    files = 1;
   }
+  if (spec.required && files === 0) {
+    throw new Error(`Required content source copied no files: ${relative(repoRoot, sourcePath)}`);
+  }
+  copyResults.push({ from: spec.from, to: spec.to, required: spec.required !== false, files });
 }
 
-console.error(`Prepared MCP package content in ${relative(packageRoot, contentRoot)}`);
+const mcpPackage = readJson(join(packageRoot, 'package.json'));
+const sdkPackage = readJson(resolve(repoRoot, 'sdk/ts/package.json'));
+const compatPackage = readJson(resolve(repoRoot, 'sdk/ts-compat/package.json'));
+
+if (mcpPackage.version !== sdkPackage.version || mcpPackage.version !== compatPackage.version) {
+  throw new Error(
+    `Strict MCP version policy requires package versions to match: ${mcpPackage.name}@${mcpPackage.version}, ${sdkPackage.name}@${sdkPackage.version}, ${compatPackage.name}@${compatPackage.version}`,
+  );
+}
+
+const release = {
+  schemaVersion: 1,
+  serverPackage: mcpPackage.name,
+  mcpName: mcpPackage.mcpName,
+  serverVersion: mcpPackage.version,
+  sdkPackage: sdkPackage.name,
+  sdkVersion: sdkPackage.version,
+  compatPackage: compatPackage.name,
+  compatVersion: compatPackage.version,
+  goModule: goModulePath,
+  goModuleVersion: `v${mcpPackage.version}`,
+  sourceCommit: getSourceCommit(),
+  generatedAt: new Date().toISOString(),
+  contentMode: 'packaged-snapshot',
+  versionPolicy: 'strict-mirror',
+};
+
+writeFileSync(join(contentRoot, 'release.json'), `${JSON.stringify(release, null, 2)}\n`);
+
+const files = collectContentFiles(contentRoot);
+const manifest = {
+  schemaVersion: 1,
+  generatedAt: release.generatedAt,
+  sourceCommit: release.sourceCommit,
+  contentMode: release.contentMode,
+  versionPolicy: release.versionPolicy,
+  copyResults,
+  counts: {
+    totalFiles: files.length,
+    byPrefix: countByPrefix(files),
+  },
+  files,
+};
+
+writeFileSync(join(contentRoot, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`);
+
+console.error(`Prepared MCP package content in ${relative(packageRoot, contentRoot)} with ${files.length} files`);

--- a/sdk/mcp/scripts/set-executable.mjs
+++ b/sdk/mcp/scripts/set-executable.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+import { chmodSync, existsSync, statSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const target = process.argv[2];
+
+if (!target) {
+  throw new Error('Usage: node scripts/set-executable.mjs <path>');
+}
+
+const targetPath = resolve(process.cwd(), target);
+
+if (!existsSync(targetPath)) {
+  throw new Error(`Cannot make missing file executable: ${target}`);
+}
+
+if (!statSync(targetPath).isFile()) {
+  throw new Error(`Executable target is not a file: ${target}`);
+}
+
+chmodSync(targetPath, 0o755);

--- a/sdk/mcp/scripts/verify-package-content.mjs
+++ b/sdk/mcp/scripts/verify-package-content.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(scriptDir, '..');
+const packJsonPath = resolve(process.cwd(), process.argv[2] ?? 'pack.json');
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf-8'));
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+const packageJson = readJson(join(packageRoot, 'package.json'));
+const serverJson = readJson(join(packageRoot, 'server.json'));
+const releaseJson = readJson(join(packageRoot, 'content/release.json'));
+const manifestJson = readJson(join(packageRoot, 'content/manifest.json'));
+const packJson = readJson(packJsonPath);
+const pack = Array.isArray(packJson) ? packJson[0] : packJson;
+const paths = new Set(pack.files.map((file) => file.path));
+
+const requiredPackageFiles = [
+  'dist/index.js',
+  'dist/index.d.ts',
+  'content/release.json',
+  'content/manifest.json',
+  'content/docs/api.yaml',
+  'content/docs/protocol/overview.md',
+  'content/docs/protocol/cryptography.md',
+  'content/docs/protocol/security-and-limitations.md',
+  'content/sdk/ts/package.json',
+  'content/sdk/ts/src/client.ts',
+  'content/sdk/ts/src/index.ts',
+  'content/sdk/ts/src/core/types.ts',
+  'content/sdk/ts/src/rpc/methods.ts',
+  'content/sdk/ts-compat/package.json',
+  'content/sdk/ts-compat/src/client.ts',
+  'content/sdk/ts-compat/src/index.ts',
+  'content/sdk/ts-compat/docs/migration-overview.md',
+  'content/sdk/go/client.go',
+  'content/sdk/go/README.md',
+  'content/pkg/app/app_v1.go',
+  'content/pkg/core/types.go',
+  'content/pkg/rpc/methods.go',
+  'README.md',
+  'package.json',
+  'server.json',
+];
+
+for (const path of requiredPackageFiles) {
+  assert(paths.has(path), `missing package file: ${path}`);
+}
+
+// Defense-in-depth against a future package.json files allowlist expansion.
+for (const path of paths) {
+  assert(!path.startsWith('src/'), `source-only file leaked into package: ${path}`);
+  assert(!path.startsWith('scripts/'), `script file leaked into package: ${path}`);
+  assert(!path.endsWith('.test.ts'), `test file leaked into package: ${path}`);
+  assert(!path.endsWith('.spec.ts'), `test file leaked into package: ${path}`);
+  assert(!path.endsWith('_test.go'), `test file leaked into package: ${path}`);
+}
+
+assert(serverJson.name === packageJson.mcpName, `server.json name ${serverJson.name} does not match package.json mcpName ${packageJson.mcpName}`);
+const npmPackage = serverJson.packages.find((entry) => entry.registryType === 'npm');
+assert(npmPackage, 'server.json is missing an npm package entry');
+assert(npmPackage.identifier === packageJson.name, `server.json package ${npmPackage.identifier} does not match package.json name ${packageJson.name}`);
+assert(serverJson.version === packageJson.version, 'server.json version must match package.json version');
+assert(npmPackage.version === packageJson.version, 'server.json npm package version must match package.json version');
+
+assert(releaseJson.serverPackage === packageJson.name, 'release.json serverPackage must match package.json name');
+assert(releaseJson.mcpName === packageJson.mcpName, 'release.json mcpName must match package.json mcpName');
+assert(releaseJson.serverVersion === packageJson.version, 'release.json serverVersion must match package.json version');
+assert(releaseJson.sdkVersion === packageJson.version, 'release.json sdkVersion must match MCP package version under strict-mirror policy');
+assert(releaseJson.compatVersion === packageJson.version, 'release.json compatVersion must match MCP package version under strict-mirror policy');
+assert(releaseJson.goModule === 'github.com/layer-3/nitrolite', 'release.json goModule is unexpected');
+assert(releaseJson.goModuleVersion === `v${packageJson.version}`, `release.json goModuleVersion must be v${packageJson.version}`);
+assert(releaseJson.contentMode === 'packaged-snapshot', 'release.json contentMode must be packaged-snapshot');
+assert(releaseJson.versionPolicy === 'strict-mirror', 'release.json versionPolicy must be strict-mirror');
+assert(typeof releaseJson.sourceCommit === 'string' && releaseJson.sourceCommit.length > 0, 'release.json sourceCommit must be present');
+
+assert(manifestJson.contentMode === 'packaged-snapshot', 'manifest contentMode must be packaged-snapshot');
+assert(manifestJson.versionPolicy === 'strict-mirror', 'manifest versionPolicy must be strict-mirror');
+assert(Array.isArray(manifestJson.files), 'manifest files must be an array');
+assert(manifestJson.files.length >= 70, `manifest contains too few files: ${manifestJson.files.length}`);
+assert(manifestJson.counts?.totalFiles === manifestJson.files.length, 'manifest totalFiles must match files length');
+
+for (const file of manifestJson.files) {
+  const packagePath = `content/${file.path}`;
+  assert(paths.has(packagePath), `manifest file missing from package: ${packagePath}`);
+  assert(typeof file.sha256 === 'string' && /^[a-f0-9]{64}$/.test(file.sha256), `manifest file has invalid sha256: ${file.path}`);
+  assert(typeof file.size === 'number' && file.size >= 0, `manifest file has invalid size: ${file.path}`);
+}
+
+console.error(`Verified ${pack.filename} with ${manifestJson.files.length} manifest files`);

--- a/sdk/mcp/scripts/verify-release-preflight.mjs
+++ b/sdk/mcp/scripts/verify-release-preflight.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(scriptDir, '..');
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf-8'));
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function run(command, args) {
+  return execFileSync(command, args, {
+    cwd: packageRoot,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function npmVersionExists(packageName, version) {
+  let resolved;
+  try {
+    resolved = run('npm', ['view', `${packageName}@${version}`, 'version']);
+  } catch {
+    throw new Error(`${packageName}@${version} is not available on npm`);
+  }
+  assert(resolved === version, `${packageName}@${version} is not available on npm`);
+}
+
+function goTagExists(tag) {
+  try {
+    run('git', ['ls-remote', '--exit-code', 'origin', `refs/tags/${tag}`]);
+  } catch {
+    throw new Error(`Go module tag ${tag} is not available on origin`);
+  }
+}
+
+const packageJson = readJson(join(packageRoot, 'package.json'));
+const serverJson = readJson(join(packageRoot, 'server.json'));
+const releaseJson = readJson(join(packageRoot, 'content/release.json'));
+const version = packageJson.version;
+const expectedMcpTag = `mcp-v${version}`;
+const expectedGoTag = `v${version}`;
+
+assert(serverJson.version === version, 'server.json version must match package.json version');
+const npmPackage = serverJson.packages.find((entry) => entry.registryType === 'npm');
+assert(npmPackage?.version === version, 'server.json npm package version must match package.json version');
+assert(releaseJson.serverVersion === version, 'release.json serverVersion must match package.json version');
+assert(releaseJson.sdkVersion === version, 'release.json sdkVersion must match package.json version');
+assert(releaseJson.compatVersion === version, 'release.json compatVersion must match package.json version');
+assert(releaseJson.goModuleVersion === expectedGoTag, `release.json goModuleVersion must be ${expectedGoTag}`);
+assert(releaseJson.versionPolicy === 'strict-mirror', 'release.json versionPolicy must be strict-mirror');
+
+if (process.env.GITHUB_REF_NAME) {
+  assert(process.env.GITHUB_REF_NAME === expectedMcpTag, `release tag ${process.env.GITHUB_REF_NAME} must be ${expectedMcpTag}`);
+}
+
+goTagExists(expectedGoTag);
+npmVersionExists('@yellow-org/sdk', version);
+npmVersionExists('@yellow-org/sdk-compat', version);
+
+console.error(`Release preflight passed for ${packageJson.name}@${version}`);

--- a/sdk/mcp/server.json
+++ b/sdk/mcp/server.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.layer-3/yellow-sdk-mcp",
+  "description": "MCP server exposing Yellow SDK and Nitrolite protocol reference material to AI agents and IDEs.",
+  "version": "1.2.1",
+  "repository": {
+    "url": "https://github.com/layer-3/nitrolite",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@yellow-org/sdk-mcp",
+      "version": "1.2.1",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/sdk/mcp/src/index.ts
+++ b/sdk/mcp/src/index.ts
@@ -1,20 +1,22 @@
 #!/usr/bin/env node
 /**
- * Nitrolite SDK MCP Server
+ * Yellow SDK MCP Server
  *
- * Exposes the Nitrolite SDK API surface to AI agents and IDEs via the
- * Model Context Protocol. Reads SDK source at startup to build structured
- * knowledge of methods, types, enums, and examples.
+ * Exposes the Yellow SDK / Nitrolite protocol surface to AI agents and IDEs via
+ * the Model Context Protocol. Reads local SDK source first and falls back to the
+ * packaged release snapshot when the monorepo is unavailable.
  */
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
 import { readFileSync, existsSync } from 'node:fs';
-import { resolve, dirname } from 'node:path';
+import { resolve, dirname, isAbsolute, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const PACKAGE_ROOT = resolve(__dirname, '..');
+const CONTENT_ROOT = resolve(PACKAGE_ROOT, 'content');
 const SDK_ROOT = resolve(__dirname, '../../ts');
 const COMPAT_ROOT = resolve(__dirname, '../../ts-compat');
 const REPO_ROOT = resolve(__dirname, '../../..');
@@ -23,15 +25,60 @@ const API_YAML = resolve(REPO_ROOT, 'docs/api.yaml');
 const GO_SDK_ROOT = resolve(REPO_ROOT, 'sdk/go');
 const PKG_ROOT = resolve(REPO_ROOT, 'pkg');
 const GO_MODULE_PATH = 'github.com/layer-3/nitrolite';
-const GO_MODULE_VERSION = 'v1.2.0';
+const GO_MODULE_VERSION = 'v1.2.1';
+const SERVER_NAME = 'yellow-sdk-mcp';
+
+const SOURCE_ROOTS: Array<{ root: string; contentPrefix: string }> = [
+    { root: SDK_ROOT, contentPrefix: 'sdk/ts' },
+    { root: COMPAT_ROOT, contentPrefix: 'sdk/ts-compat' },
+    { root: PROTOCOL_DOCS, contentPrefix: 'docs/protocol' },
+    { root: GO_SDK_ROOT, contentPrefix: 'sdk/go' },
+    { root: PKG_ROOT, contentPrefix: 'pkg' },
+    { root: REPO_ROOT, contentPrefix: '' },
+];
+const MONOREPO_SOURCE_AVAILABLE = existsSync(resolve(SDK_ROOT, 'src/client.ts'));
 
 // ---------------------------------------------------------------------------
 // Helpers — read SDK sources at startup
 // ---------------------------------------------------------------------------
 
+function isWithin(root: string, path: string): boolean {
+    const rel = relative(root, path);
+    return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
+}
+
+function fallbackContentPath(path: string): string | undefined {
+    for (const { root, contentPrefix } of SOURCE_ROOTS) {
+        const rel = relative(root, path);
+        if (!isWithin(root, path)) continue;
+        if (rel === '') continue;
+        return resolve(CONTENT_ROOT, contentPrefix, rel);
+    }
+    return undefined;
+}
+
 function readFile(path: string): string {
-    if (!existsSync(path)) return '';
-    return readFileSync(path, 'utf-8');
+    if (existsSync(path) && (MONOREPO_SOURCE_AVAILABLE || isWithin(PACKAGE_ROOT, path))) {
+        return readFileSync(path, 'utf-8');
+    }
+
+    const packagedPath = fallbackContentPath(path);
+    if (packagedPath && existsSync(packagedPath)) {
+        return readFileSync(packagedPath, 'utf-8');
+    }
+
+    return '';
+}
+
+function readPackageVersion(path: string): string | undefined {
+    const content = readFile(path);
+    if (!content) return undefined;
+    try {
+        const parsed = JSON.parse(content) as { version?: unknown };
+        return typeof parsed.version === 'string' ? parsed.version : undefined;
+    } catch {
+        return undefined;
+    }
 }
 
 /** Extract named exports from a barrel file */
@@ -924,9 +971,13 @@ loadGoSdkMethods();
 // MCP Server
 // ---------------------------------------------------------------------------
 
+const serverVersion = readPackageVersion(resolve(PACKAGE_ROOT, 'package.json')) ?? '1.2.1';
+const sdkVersion = readPackageVersion(resolve(SDK_ROOT, 'package.json')) ?? 'unknown';
+const compatVersion = readPackageVersion(resolve(COMPAT_ROOT, 'package.json')) ?? 'unknown';
+
 const server = new McpServer({
-    name: 'nitrolite-sdk',
-    version: '0.1.0',
+    name: SERVER_NAME,
+    version: serverVersion,
 });
 
 // ========================== RESOURCES ======================================
@@ -1535,7 +1586,7 @@ main().catch(console.error);
 
 \`\`\`json
 {
-  "@yellow-org/sdk": "^1.2.0",
+  "@yellow-org/sdk": "^1.2.1",
   "decimal.js": "^10.4.0",
   "viem": "^2.46.0"
 }
@@ -1644,7 +1695,7 @@ main().catch(console.error);
 
 \`\`\`json
 {
-  "@yellow-org/sdk": "^1.2.0",
+  "@yellow-org/sdk": "^1.2.1",
   "viem": "^2.46.0",
   "decimal.js": "^10.6.0"
 }
@@ -1692,6 +1743,30 @@ server.resource('protocol-auth-flow', 'nitrolite://protocol/auth-flow', async ()
 
 
 // ========================== TOOLS ==========================================
+
+server.tool(
+    'server_info',
+    'Return Yellow SDK MCP package, SDK, compat, and indexed content version information for debugging and support.',
+    {},
+    async () => ({
+        content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+                name: SERVER_NAME,
+                version: serverVersion,
+                sdkPackage: '@yellow-org/sdk',
+                sdkVersion,
+                compatPackage: '@yellow-org/sdk-compat',
+                compatVersion,
+                goModule: GO_MODULE_PATH,
+                goModuleVersion: GO_MODULE_VERSION,
+                protocolVersion: 'v1',
+                transport: 'stdio',
+                contentMode: MONOREPO_SOURCE_AVAILABLE ? 'source-tree' : 'packaged-snapshot',
+            }, null, 2),
+        }],
+    }),
+);
 
 server.tool(
     'lookup_method',
@@ -1991,7 +2066,7 @@ server.tool(
             type: 'module',
             scripts: { start: 'npx tsx src/index.ts', build: 'tsc', typecheck: 'tsc --noEmit' },
             dependencies: {
-                '@yellow-org/sdk': '^1.2.0',
+                '@yellow-org/sdk': '^1.2.1',
                 'decimal.js': '^10.4.0',
                 viem: '^2.46.0',
             },
@@ -2303,7 +2378,7 @@ Use context.Context for timeouts. Use decimal.Decimal for amounts. Follow standa
 async function main() {
     const transport = new StdioServerTransport();
     await server.connect(transport);
-    console.error('Nitrolite SDK MCP server running on stdio');
+    console.error('Yellow SDK MCP server running on stdio');
 }
 
 main().catch((err) => {

--- a/sdk/mcp/src/index.ts
+++ b/sdk/mcp/src/index.ts
@@ -29,7 +29,6 @@ const API_YAML = resolve(REPO_ROOT, 'docs/api.yaml');
 const GO_SDK_ROOT = resolve(REPO_ROOT, 'sdk/go');
 const PKG_ROOT = resolve(REPO_ROOT, 'pkg');
 const GO_MODULE_PATH = 'github.com/layer-3/nitrolite';
-const GO_MODULE_VERSION = 'v1.2.1';
 const SERVER_NAME = 'yellow-sdk-mcp';
 
 const SOURCE_ROOTS: Array<{ root: string; contentPrefix: string }> = [
@@ -83,6 +82,42 @@ function readPackageVersion(path: string): string | undefined {
     } catch {
         return undefined;
     }
+}
+
+interface ReleaseMetadata {
+    schemaVersion: number;
+    serverPackage: string;
+    mcpName: string;
+    serverVersion: string;
+    sdkPackage: string;
+    sdkVersion: string;
+    compatPackage: string;
+    compatVersion: string;
+    goModule: string;
+    goModuleVersion: string;
+    sourceCommit: string;
+    generatedAt: string;
+    contentMode: 'packaged-snapshot';
+    versionPolicy: 'strict-mirror';
+}
+
+interface ContentManifest {
+    files?: Array<{ path: string; size: number; sha256: string }>;
+    counts?: { totalFiles?: number; byPrefix?: Record<string, number> };
+}
+
+function readJsonFile<T>(path: string): T | undefined {
+    const content = readFile(path);
+    if (!content) return undefined;
+    try {
+        return JSON.parse(content) as T;
+    } catch {
+        return undefined;
+    }
+}
+
+function deriveGoModuleVersion(version: string): string {
+    return /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(version) ? `v${version}` : 'unknown';
 }
 
 /** Extract named exports from a barrel file */
@@ -962,6 +997,13 @@ func main() {
 // Initialize
 // ---------------------------------------------------------------------------
 
+const releaseMetadata = readJsonFile<ReleaseMetadata>(resolve(CONTENT_ROOT, 'release.json'));
+const contentManifest = readJsonFile<ContentManifest>(resolve(CONTENT_ROOT, 'manifest.json'));
+
+if (!MONOREPO_SOURCE_AVAILABLE && !releaseMetadata) {
+    throw new Error('Packaged Yellow SDK MCP content is missing content/release.json. Reinstall @yellow-org/sdk-mcp from a published release.');
+}
+
 loadClientMethods();
 loadTypes();
 loadCompatExports();
@@ -975,9 +1017,18 @@ loadGoSdkMethods();
 // MCP Server
 // ---------------------------------------------------------------------------
 
-const serverVersion = readPackageVersion(resolve(PACKAGE_ROOT, 'package.json')) ?? '1.2.1';
-const sdkVersion = readPackageVersion(resolve(SDK_ROOT, 'package.json')) ?? 'unknown';
-const compatVersion = readPackageVersion(resolve(COMPAT_ROOT, 'package.json')) ?? 'unknown';
+const serverPackage = releaseMetadata?.serverPackage ?? '@yellow-org/sdk-mcp';
+const mcpName = releaseMetadata?.mcpName ?? 'io.github.layer-3/yellow-sdk-mcp';
+const serverVersion = readPackageVersion(resolve(PACKAGE_ROOT, 'package.json')) ?? releaseMetadata?.serverVersion ?? 'unknown';
+const sdkPackage = releaseMetadata?.sdkPackage ?? '@yellow-org/sdk';
+const sdkVersion = releaseMetadata?.sdkVersion ?? readPackageVersion(resolve(SDK_ROOT, 'package.json')) ?? 'unknown';
+const compatPackage = releaseMetadata?.compatPackage ?? '@yellow-org/sdk-compat';
+const compatVersion = releaseMetadata?.compatVersion ?? readPackageVersion(resolve(COMPAT_ROOT, 'package.json')) ?? 'unknown';
+const goModule = releaseMetadata?.goModule ?? GO_MODULE_PATH;
+const goModuleVersion = releaseMetadata?.goModuleVersion ?? deriveGoModuleVersion(serverVersion);
+const runtimeContentMode = MONOREPO_SOURCE_AVAILABLE ? 'source-tree' : releaseMetadata?.contentMode ?? 'packaged-snapshot';
+const versionPolicy = releaseMetadata?.versionPolicy ?? 'strict-mirror';
+const scaffoldSdkVersion = sdkVersion === 'unknown' ? (serverVersion === 'unknown' ? '^1' : serverVersion) : sdkVersion;
 
 const server = new McpServer({
     name: SERVER_NAME,
@@ -1598,7 +1649,7 @@ main().catch(console.error);
 
 \`\`\`json
 {
-  "@yellow-org/sdk": "^1.2.1",
+  "@yellow-org/sdk": "${scaffoldSdkVersion}",
   "decimal.js": "^10.4.0",
   "viem": "^2.46.0"
 }
@@ -1707,7 +1758,7 @@ main().catch(console.error);
 
 \`\`\`json
 {
-  "@yellow-org/sdk": "^1.2.1",
+  "@yellow-org/sdk": "${scaffoldSdkVersion}",
   "viem": "^2.46.0",
   "decimal.js": "^10.6.0"
 }
@@ -1765,16 +1816,22 @@ server.tool(
             type: 'text' as const,
             text: JSON.stringify({
                 name: SERVER_NAME,
+                serverPackage,
+                mcpName,
                 version: serverVersion,
-                sdkPackage: '@yellow-org/sdk',
+                sdkPackage,
                 sdkVersion,
-                compatPackage: '@yellow-org/sdk-compat',
+                compatPackage,
                 compatVersion,
-                goModule: GO_MODULE_PATH,
-                goModuleVersion: GO_MODULE_VERSION,
+                goModule,
+                goModuleVersion,
                 protocolVersion: 'v1',
                 transport: 'stdio',
-                contentMode: MONOREPO_SOURCE_AVAILABLE ? 'source-tree' : 'packaged-snapshot',
+                contentMode: runtimeContentMode,
+                versionPolicy,
+                sourceCommit: releaseMetadata?.sourceCommit ?? 'unknown',
+                contentGeneratedAt: releaseMetadata?.generatedAt ?? 'unknown',
+                contentManifestFiles: contentManifest?.counts?.totalFiles ?? contentManifest?.files?.length ?? 0,
             }, null, 2),
         }],
     }),
@@ -2065,7 +2122,7 @@ server.tool(
                 'go-ai-agent': GO_SCAFFOLD_AI_AGENT,
             };
             const baseName = template.replace('go-', '');
-            const goMod = `module my-nitrolite-${baseName}\n\ngo 1.25.0\n\nrequire (\n\t${GO_MODULE_PATH} ${GO_MODULE_VERSION}\n\tgithub.com/shopspring/decimal v1.4.0\n)`;
+            const goMod = `module my-nitrolite-${baseName}\n\ngo 1.25.0\n\nrequire (\n\t${goModule} ${goModuleVersion}\n\tgithub.com/shopspring/decimal v1.4.0\n)`;
             const envKey = template === 'go-ai-agent' ? 'AGENT_PRIVATE_KEY' : 'PRIVATE_KEY';
             const envExtra = template === 'go-transfer-app' ? '\nRECIPIENT=your_recipient_address' : template === 'go-app-session' ? '\nPEER_ADDRESS=peer_wallet_address' : '';
             const text = `# Scaffold: ${template}\n\n## go.mod\n\`\`\`\n${goMod}\n\`\`\`\n\n## main.go\n\`\`\`go\n${goTemplateMap[template]}\`\`\`\n\n## .env.example\n\`\`\`\n${envKey}=your_hex_key\nNITRONODE_URL=wss://nitronode.example.com/ws\nRPC_URL=https://rpc.sepolia.org${envExtra}\n\`\`\`\n\n## Setup\n\`\`\`bash\ngo mod tidy\ngo run .\n\`\`\``;
@@ -2078,7 +2135,7 @@ server.tool(
             type: 'module',
             scripts: { start: 'npx tsx src/index.ts', build: 'tsc', typecheck: 'tsc --noEmit' },
             dependencies: {
-                '@yellow-org/sdk': '^1.2.1',
+                '@yellow-org/sdk': scaffoldSdkVersion,
                 'decimal.js': '^10.4.0',
                 viem: '^2.46.0',
             },

--- a/sdk/mcp/src/index.ts
+++ b/sdk/mcp/src/index.ts
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 /**
- * Nitrolite SDK MCP Server
+ * Yellow SDK MCP Server
  *
  * Exposes the Nitrolite SDK API surface to AI agents and IDEs via the
  * Model Context Protocol. Reads SDK source at startup to build structured
- * knowledge of methods, types, enums, and examples.
+ * knowledge of methods, types, enums, examples, and protocol docs. Falls back
+ * to the packaged release snapshot when the monorepo is unavailable.
  *
  * Naming note: the off-chain broker was named "clearnode" through v1.2.0
  * and renamed to "nitronode" in v1.3.0. See `nitrolite://migration/nitronode`.
@@ -14,10 +15,12 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
 import { readFileSync, existsSync } from 'node:fs';
-import { resolve, dirname } from 'node:path';
+import { resolve, dirname, isAbsolute, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const PACKAGE_ROOT = resolve(__dirname, '..');
+const CONTENT_ROOT = resolve(PACKAGE_ROOT, 'content');
 const SDK_ROOT = resolve(__dirname, '../../ts');
 const COMPAT_ROOT = resolve(__dirname, '../../ts-compat');
 const REPO_ROOT = resolve(__dirname, '../../..');
@@ -26,15 +29,60 @@ const API_YAML = resolve(REPO_ROOT, 'docs/api.yaml');
 const GO_SDK_ROOT = resolve(REPO_ROOT, 'sdk/go');
 const PKG_ROOT = resolve(REPO_ROOT, 'pkg');
 const GO_MODULE_PATH = 'github.com/layer-3/nitrolite';
-const GO_MODULE_VERSION = 'v1.2.0';
+const GO_MODULE_VERSION = 'v1.2.1';
+const SERVER_NAME = 'yellow-sdk-mcp';
+
+const SOURCE_ROOTS: Array<{ root: string; contentPrefix: string }> = [
+    { root: SDK_ROOT, contentPrefix: 'sdk/ts' },
+    { root: COMPAT_ROOT, contentPrefix: 'sdk/ts-compat' },
+    { root: PROTOCOL_DOCS, contentPrefix: 'docs/protocol' },
+    { root: GO_SDK_ROOT, contentPrefix: 'sdk/go' },
+    { root: PKG_ROOT, contentPrefix: 'pkg' },
+    { root: REPO_ROOT, contentPrefix: '' },
+];
+const MONOREPO_SOURCE_AVAILABLE = existsSync(resolve(SDK_ROOT, 'src/client.ts'));
 
 // ---------------------------------------------------------------------------
 // Helpers — read SDK sources at startup
 // ---------------------------------------------------------------------------
 
+function isWithin(root: string, path: string): boolean {
+    const rel = relative(root, path);
+    return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
+}
+
+function fallbackContentPath(path: string): string | undefined {
+    for (const { root, contentPrefix } of SOURCE_ROOTS) {
+        const rel = relative(root, path);
+        if (!isWithin(root, path)) continue;
+        if (rel === '') continue;
+        return resolve(CONTENT_ROOT, contentPrefix, rel);
+    }
+    return undefined;
+}
+
 function readFile(path: string): string {
-    if (!existsSync(path)) return '';
-    return readFileSync(path, 'utf-8');
+    if (existsSync(path) && (MONOREPO_SOURCE_AVAILABLE || isWithin(PACKAGE_ROOT, path))) {
+        return readFileSync(path, 'utf-8');
+    }
+
+    const packagedPath = fallbackContentPath(path);
+    if (packagedPath && existsSync(packagedPath)) {
+        return readFileSync(packagedPath, 'utf-8');
+    }
+
+    return '';
+}
+
+function readPackageVersion(path: string): string | undefined {
+    const content = readFile(path);
+    if (!content) return undefined;
+    try {
+        const parsed = JSON.parse(content) as { version?: unknown };
+        return typeof parsed.version === 'string' ? parsed.version : undefined;
+    } catch {
+        return undefined;
+    }
 }
 
 /** Extract named exports from a barrel file */
@@ -927,9 +975,13 @@ loadGoSdkMethods();
 // MCP Server
 // ---------------------------------------------------------------------------
 
+const serverVersion = readPackageVersion(resolve(PACKAGE_ROOT, 'package.json')) ?? '1.2.1';
+const sdkVersion = readPackageVersion(resolve(SDK_ROOT, 'package.json')) ?? 'unknown';
+const compatVersion = readPackageVersion(resolve(COMPAT_ROOT, 'package.json')) ?? 'unknown';
+
 const server = new McpServer({
-    name: 'nitrolite-sdk',
-    version: '0.1.0',
+    name: SERVER_NAME,
+    version: serverVersion,
 });
 
 // ========================== RESOURCES ======================================
@@ -1546,7 +1598,7 @@ main().catch(console.error);
 
 \`\`\`json
 {
-  "@yellow-org/sdk": "^1.2.0",
+  "@yellow-org/sdk": "^1.2.1",
   "decimal.js": "^10.4.0",
   "viem": "^2.46.0"
 }
@@ -1655,7 +1707,7 @@ main().catch(console.error);
 
 \`\`\`json
 {
-  "@yellow-org/sdk": "^1.2.0",
+  "@yellow-org/sdk": "^1.2.1",
   "viem": "^2.46.0",
   "decimal.js": "^10.6.0"
 }
@@ -1703,6 +1755,30 @@ server.resource('protocol-auth-flow', 'nitrolite://protocol/auth-flow', async ()
 
 
 // ========================== TOOLS ==========================================
+
+server.tool(
+    'server_info',
+    'Return Yellow SDK MCP package, SDK, compat, and indexed content version information for debugging and support.',
+    {},
+    async () => ({
+        content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+                name: SERVER_NAME,
+                version: serverVersion,
+                sdkPackage: '@yellow-org/sdk',
+                sdkVersion,
+                compatPackage: '@yellow-org/sdk-compat',
+                compatVersion,
+                goModule: GO_MODULE_PATH,
+                goModuleVersion: GO_MODULE_VERSION,
+                protocolVersion: 'v1',
+                transport: 'stdio',
+                contentMode: MONOREPO_SOURCE_AVAILABLE ? 'source-tree' : 'packaged-snapshot',
+            }, null, 2),
+        }],
+    }),
+);
 
 server.tool(
     'lookup_method',
@@ -2002,7 +2078,7 @@ server.tool(
             type: 'module',
             scripts: { start: 'npx tsx src/index.ts', build: 'tsc', typecheck: 'tsc --noEmit' },
             dependencies: {
-                '@yellow-org/sdk': '^1.2.0',
+                '@yellow-org/sdk': '^1.2.1',
                 'decimal.js': '^10.4.0',
                 viem: '^2.46.0',
             },
@@ -2314,7 +2390,7 @@ Use context.Context for timeouts. Use decimal.Decimal for amounts. Follow standa
 async function main() {
     const transport = new StdioServerTransport();
     await server.connect(transport);
-    console.error('Nitrolite SDK MCP server running on stdio');
+    console.error('Yellow SDK MCP server running on stdio');
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary

Packages `sdk/mcp` for public npm distribution as `@yellow-org/sdk-mcp`, so Claude, Codex, Cursor, VS Code, and other stdio MCP clients can run the Yellow SDK / Nitrolite protocol context server without cloning the Nitrolite monorepo.

## What changed

- Adds npm publish metadata for `sdk/mcp`: compiled `dist` entrypoint, executable `yellow-sdk-mcp` bin, public publish config, minimal package `files`, and `mcpName`.
- Adds a release-time `content/` snapshot builder so published installs can serve SDK/protocol docs from packaged files while local monorepo development still reads live source first.
- Adds `server_info` for package, SDK, compat, Go module, protocol, transport, and content-mode debugging.
- Adds MCP Registry metadata in `server.json` and a tag-triggered `mcp-v*` workflow that builds, packs, validates, smoke-tests, publishes to npm, then publishes registry metadata.
- Updates the README with install snippets for Claude Code, Claude Desktop, Codex, Cursor, VS Code, and local development.

## Release safety

The workflow now publishes the exact tarball it verifies. It asserts critical package paths, blocks source/test file leakage, installs the packed tarball into a temp app, and exercises packaged-snapshot mode through `server_info`, `lookup_method`, and `lookup_rpc_method` before publish.

`mcp-publisher` is pinned to `v1.7.6` with SHA256 verification instead of using a floating `latest` download.

## Validation run locally

- `npm run typecheck` from `sdk/mcp`
- `npm run build` from `sdk/mcp`
- package contents assertion against `npm pack --json`
- temp tarball install + MCP client smoke test for `server_info`, `lookup_method`, and `lookup_rpc_method`
- MCP Registry metadata validation
- `git diff --cached --check`

## Notes for reviewers

- Package version intentionally mirrors `@yellow-org/sdk` (`1.2.1`) so `@yellow-org/sdk-mcp@^1` tracks v1 SDK docs.
- Commit was created with `--no-gpg-sign` because the local 1Password SSH signing agent failed during commit creation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `server_info` tool providing server metadata and version information.
  * Enabled npm package distribution with automated MCP registry publishing.
  * Runtime now prefers local sources with fallback to packaged content snapshots.

* **Documentation**
  * Expanded README with setup guides for multiple MCP clients (Claude, Cursor, VS Code).
  * Added publishing documentation and version policy.

* **Chores**
  * Version bumped to 1.2.1.
  * Enhanced package validation and verification workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->