### PR TITLE
YNU-779: feat(nitronode/metrics): saturation + DB latency + label hygiene

### DIFF
--- a/nitronode/api/rpc_router.go
+++ b/nitronode/api/rpc_router.go
@@ -160,6 +160,9 @@ func (r *RPCRouter) ObservabilityMiddleware(c *rpc.Context) {
 	startTime := time.Now()
 	methodPath := getMethodPath(c)
 
+	r.runtimeMetrics.IncRPCInflight(c.Request.Method)
+	defer r.runtimeMetrics.DecRPCInflight(c.Request.Method)
+
 	c.Next()
 
 	reqDuration := time.Since(startTime)

--- a/nitronode/metrics/exporter.go
+++ b/nitronode/metrics/exporter.go
@@ -154,6 +154,7 @@ type runtimeMetricExporter struct {
 	rpcRequestsTotal          *prometheus.CounterVec
 	rpcRequestDurationSeconds *prometheus.HistogramVec
 	rpcConnectionsTotal       *prometheus.GaugeVec
+	rpcInflight               *prometheus.GaugeVec
 
 	// api/app_session_v1
 	appStateUpdates                     *prometheus.CounterVec
@@ -168,6 +169,9 @@ type runtimeMetricExporter struct {
 	// Metric Worker
 	channelSessionKeysTotal prometheus.Counter
 	appSessionKeysTotal     prometheus.Counter
+
+	// store/database (instrumented via gorm callbacks)
+	dbQueryDurationSeconds *prometheus.HistogramVec
 }
 
 // RuntimeMetricExporter exposes metrics related to runtime operations, such as API requests, channel state validations, and blockchain interactions.
@@ -234,6 +238,13 @@ func NewRuntimeMetricExporter(reg prometheus.Registerer) (RuntimeMetricExporter,
 			Name:      "rpc_connections_active",
 			Help:      "Current number of active RPC connections",
 		}, []string{"region", "origin"}),
+		rpcInflight: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: MetricNamespace,
+			Name:      "rpc_inflight",
+			Help: "Currently in-flight RPC requests, labelled by method. Incremented at " +
+				"middleware entry and decremented on exit. Saturation signal — pair with " +
+				"rpc_request_duration_seconds for queueing-style diagnosis.",
+		}, []string{"method"}),
 
 		// api/app_session_v1
 		appStateUpdates: prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -260,6 +271,21 @@ func NewRuntimeMetricExporter(reg prometheus.Registerer) (RuntimeMetricExporter,
 			Name:      "blockchain_events_total",
 			Help:      "Total number of blockchain events processed",
 		}, []string{"blockchain_id", "process_result"}),
+
+		// store/database
+		dbQueryDurationSeconds: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: MetricNamespace,
+			Name:      "db_query_duration_seconds",
+			Help: "Application-side database query duration. Observed via gorm " +
+				"callbacks, so the value is round-trip time from the app to the DB " +
+				"through pgbouncer (when used). Pair with go_sql_wait_duration_" +
+				"seconds_total / go_sql_wait_count_total (emitted by the DB-stats " +
+				"collector registered alongside) to separate pool-acquire latency " +
+				"from in-DB execution.\n\n" +
+				"  query_kind  — gorm operation: create, query, update, delete, " +
+				"row, raw.",
+			Buckets: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5},
+		}, []string{"query_kind"}),
 	}
 
 	if reg != nil {
@@ -272,12 +298,14 @@ func NewRuntimeMetricExporter(reg prometheus.Registerer) (RuntimeMetricExporter,
 			m.rpcRequestsTotal,
 			m.rpcRequestDurationSeconds,
 			m.rpcConnectionsTotal,
+			m.rpcInflight,
 			m.appStateUpdates,
 			m.appSessionUpdateSigValidationsTotal,
 			m.blockchainActionsTotal,
 			m.blockchainEventsTotal,
 			m.channelSessionKeysTotal,
 			m.appSessionKeysTotal,
+			m.dbQueryDurationSeconds,
 		)
 	} else {
 		return nil, fmt.Errorf("prometheus registerer not provided")
@@ -321,6 +349,19 @@ func (m *runtimeMetricExporter) ObserveRPCDuration(method, path string, success 
 
 func (m *runtimeMetricExporter) SetRPCConnections(region, origin string, count uint32) {
 	m.rpcConnectionsTotal.WithLabelValues(region, origin).Set(float64(count))
+}
+
+func (m *runtimeMetricExporter) IncRPCInflight(method string) {
+	m.rpcInflight.WithLabelValues(method).Inc()
+}
+
+func (m *runtimeMetricExporter) DecRPCInflight(method string) {
+	m.rpcInflight.WithLabelValues(method).Dec()
+}
+
+// store/database
+func (m *runtimeMetricExporter) ObserveDBQueryDuration(queryKind string, duration time.Duration) {
+	m.dbQueryDurationSeconds.WithLabelValues(queryKind).Observe(duration.Seconds())
 }
 
 // api/app_session_v1

--- a/nitronode/metrics/exporter.go
+++ b/nitronode/metrics/exporter.go
@@ -42,47 +42,71 @@ func NewStoreMetricExporter(reg prometheus.Registerer) (StoreMetricExporter, err
 		appSessionsTotal: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: MetricNamespace,
 			Name:      "app_sessions_total",
-			Help:      "Current total number of app sessions",
+			Help: "Current count of app sessions, refreshed by the periodic store " +
+				"ticker (~1 min). Labels: application_id (self-declared by clients, " +
+				"empty becomes \"_DEFAULT\"), status ∈ {\"\" (void), open, closed}. " +
+				"Note: void renders as empty-string label value — sum by (status) " +
+				"will produce a series with status=\"\".",
 		}, []string{"application_id", "status"}),
 		channelsTotal: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: MetricNamespace,
 			Name:      "channels_total",
-			Help:      "Current total number of channels",
+			Help: "Current count of payment channels, refreshed by the periodic store " +
+				"ticker (~1 min). Labels: asset (e.g. usdc, eth), " +
+				"status ∈ {void, open, challenged, closed}.",
 		}, []string{"asset", "status"}),
 		usersActive: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: MetricNamespace,
 			Name:      "users_active",
-			Help:      "Current total active users",
+			Help: "Active users per asset over a rolling time window. Labels: asset, " +
+				"timespan ∈ {day, week, month}. Each window is computed independently " +
+				"from the store; values are not strictly nested (a user active in the " +
+				"day window also counts in week + month).",
 		}, []string{"asset", "timespan"}),
 		appSessionsActive: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: MetricNamespace,
 			Name:      "app_sessions_active",
-			Help:      "Current total active app sessions",
+			Help: "Active app sessions per application over a rolling time window. " +
+				"Labels: application_id, timespan ∈ {day, week, month}.",
 		}, []string{"application_id", "timespan"}),
 		totalValueLocked: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: MetricNamespace,
 			Name:      "total_value_locked",
-			Help:      "Total value locked by domain and asset",
+			Help: "Total value locked across all channels and app-sessions, in the " +
+				"asset's native units. Labels: domain (business unit), asset. Sum " +
+				"across assets is meaningless without a price feed.",
 		}, []string{"domain", "asset"}),
 		nodeBalance: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: MetricNamespace,
 			Name:      "node_balance",
-			Help:      "Node's available on-chain balance by blockchain and asset",
+			Help: "Operator's on-chain balance per (blockchain, asset). This is the " +
+				"liquidity pool the node owns directly — separate from channel " +
+				"balances held by users (see user_balance_total). Native asset units.",
 		}, []string{"blockchain_id", "asset"}),
 		userBalanceTotal: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: MetricNamespace,
 			Name:      "user_balance_total",
-			Help:      "Total user balance obligations by blockchain and asset",
+			Help: "Sum of user channel balances per (blockchain, asset). These funds " +
+				"live off-chain in user channels — they are NOT a subset of " +
+				"node_balance, the two are parallel pools. Native asset units.",
 		}, []string{"blockchain_id", "asset"}),
 		userBalanceUnderfunded: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: MetricNamespace,
 			Name:      "user_balance_underfunded",
-			Help:      "User balance exceeding on-chain locked amount by blockchain and asset",
+			Help: "Worst-case potential outflow from node_balance per (blockchain, " +
+				"asset): if every underfunded channel checkpointed simultaneously " +
+				"with its latest state, this much would move from on-chain (node) to " +
+				"user channels. Liquidity health: compare against node_balance per " +
+				"pool — sustained underfunded > node_balance is paging-grade. Native " +
+				"asset units.",
 		}, []string{"blockchain_id", "asset"}),
 		userBalanceReleasable: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: MetricNamespace,
 			Name:      "user_balance_releasable",
-			Help:      "On-chain locked amount exceeding user balance by blockchain and asset",
+			Help: "Worst-case potential inflow to node_balance per (blockchain, " +
+				"asset): if every releasable channel checkpointed simultaneously, " +
+				"this much would move from user channels back into on-chain. " +
+				"Native asset units.",
 		}, []string{"blockchain_id", "asset"}),
 	}
 
@@ -188,32 +212,53 @@ func NewRuntimeMetricExporter(reg prometheus.Registerer) (RuntimeMetricExporter,
 		userStatesTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: MetricNamespace,
 			Name:      "user_states_total",
-			Help:      "Total number of user states",
+			Help: "Total state transitions recorded for users. Labels: asset, " +
+				"home_blockchain_id (uint64 stringified), transition (state " +
+				"transition kind, see core.TransitionType — void / acknowledgement " +
+				"/ transfer_send / transfer_receive / commit / release / " +
+				"home_deposit / home_withdrawal / mutual_lock / escrow_deposit / " +
+				"escrow_lock / escrow_withdraw / migrate / finalize), " +
+				"application_id (\"_DEFAULT\" when client did not supply one).",
 		}, []string{"asset", "home_blockchain_id", "transition", "application_id"}),
 		transactionsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: MetricNamespace,
 			Name:      "transactions_total",
-			Help:      "Total number of transactions",
+			Help: "Total transactions recorded. Labels: asset, tx_type (see " +
+				"core.TransactionType — transfer / release / commit / home_deposit " +
+				"/ home_withdrawal / mutual_lock / escrow_deposit / escrow_lock / " +
+				"escrow_withdraw / migrate / rebalance / finalize), application_id. " +
+				"Pair with transactions_amount_total for value-weighted views.",
 		}, []string{"asset", "tx_type", "application_id"}),
 		transactionsAmountTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: MetricNamespace,
 			Name:      "transactions_amount_total",
-			Help:      "Total amount of transactions processed",
+			Help: "Cumulative transaction amounts in native asset units. Same labels " +
+				"as transactions_total. Note: amounts are aggregated via " +
+				"decimal.Decimal.InexactFloat64() — for very large or very precise " +
+				"values this is lossy. For accounting accuracy query the database " +
+				"directly; this metric is for dashboards and alerts only.",
 		}, []string{"asset", "tx_type", "application_id"}),
 		channelSessionKeysTotal: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: MetricNamespace,
 			Name:      "channel_session_keys_total",
-			Help:      "Total number of channel session keys issued",
+			Help: "Total channel session keys issued by the node. Unlabelled. Use " +
+				"rate(channel_session_keys_total[5m]) for issuance rate.",
 		}),
 		appSessionKeysTotal: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: MetricNamespace,
 			Name:      "app_session_keys_total",
-			Help:      "Total number of app session keys issued",
+			Help: "Total app session keys issued by the node. Unlabelled. Use " +
+				"rate(app_session_keys_total[5m]) for issuance rate.",
 		}),
 		channelStateSigValidationsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: MetricNamespace,
 			Name:      "channel_state_sig_validations_total",
-			Help:      "Total number of channel state signature validations",
+			Help: "Channel-state signature validations attempted. Labels: " +
+				"sig_type ∈ {default (wallet-signed), session_key}, " +
+				"result ∈ {success, failed}. " +
+				"For error rate compute " +
+				"rate(...{result=\"failed\"}[5m]) / rate(...[5m]); failed includes " +
+				"both forgery attempts and operational bugs.",
 		}, []string{"sig_type", "result"}),
 
 		// api/rpc_router
@@ -225,18 +270,29 @@ func NewRuntimeMetricExporter(reg prometheus.Registerer) (RuntimeMetricExporter,
 		rpcRequestsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: MetricNamespace,
 			Name:      "rpc_requests_total",
-			Help:      "Total number of RPC requests",
+			Help: "Total top-level RPC requests handled. Increments once per " +
+				"method invocation (not per WebSocket message). Labels: " +
+				"method (RPC method name), path (request path / group), " +
+				"result ∈ {success, failed}. " +
+				"\"success\" = response message type is Resp; everything else " +
+				"(RespErr, Event, no response) maps to failed.",
 		}, []string{"method", "path", "result"}),
 		rpcRequestDurationSeconds: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: MetricNamespace,
 			Name:      "rpc_request_duration_seconds",
-			Help:      "Duration of RPC requests in seconds",
-			Buckets:   []float64{0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+			Help: "RPC request duration in seconds. Same labels as " +
+				"rpc_requests_total. Use histogram_quantile for P50/P95/P99 " +
+				"latency; pair with rpc_inflight to distinguish slow handlers " +
+				"from queued contention.",
+			Buckets: []float64{0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
 		}, []string{"method", "path", "result"}),
 		rpcConnectionsTotal: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: MetricNamespace,
 			Name:      "rpc_connections_active",
-			Help:      "Current number of active RPC connections",
+			Help: "Active RPC (WebSocket) connections. Labels: region, origin " +
+				"(both sourced from request headers / client metadata at connect " +
+				"time). Operator-decided values — bounded only by the set of " +
+				"connecting clients.",
 		}, []string{"region", "origin"}),
 		rpcInflight: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: MetricNamespace,
@@ -250,26 +306,35 @@ func NewRuntimeMetricExporter(reg prometheus.Registerer) (RuntimeMetricExporter,
 		appStateUpdates: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: MetricNamespace,
 			Name:      "app_state_updates_total",
-			Help:      "Total number of app state updates",
+			Help: "Total app-session state updates accepted. Label: " +
+				"application_id (\"_DEFAULT\" when client did not supply one).",
 		}, []string{"application_id"}),
 		appSessionUpdateSigValidationsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: MetricNamespace,
 			Name:      "app_session_update_sig_validations_total",
-			Help:      "Total number of app session update signature validations",
+			Help: "App-session update signature validations attempted. Labels: " +
+				"application_id, sig_type ∈ {wallet, session_key}, " +
+				"result ∈ {success, failed}.",
 		}, []string{"application_id", "sig_type", "result"}),
 
 		// Blockchain Worker
 		blockchainActionsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: MetricNamespace,
 			Name:      "blockchain_actions_total",
-			Help:      "Total number of blockchain actions",
+			Help: "Blockchain actions dispatched by the node (deposits, withdrawals, " +
+				"escrow ops, etc.). Labels: asset, blockchain_id (uint64 stringified), " +
+				"action_type (uses core.TransitionType.String()), " +
+				"result ∈ {success, failed}.",
 		}, []string{"asset", "blockchain_id", "action_type", "result"}),
 
 		// Event Listener
 		blockchainEventsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: MetricNamespace,
 			Name:      "blockchain_events_total",
-			Help:      "Total number of blockchain events processed",
+			Help: "On-chain events received and processed by the listener. Labels: " +
+				"blockchain_id (uint64 stringified), result ∈ {success, failed}. " +
+				"A flat / zero rate per chain may indicate a stalled chain " +
+				"connection — pair with chain-side liveness checks.",
 		}, []string{"blockchain_id", "result"}),
 
 		// store/database

--- a/nitronode/metrics/exporter.go
+++ b/nitronode/metrics/exporter.go
@@ -43,7 +43,7 @@ func NewStoreMetricExporter(reg prometheus.Registerer) (StoreMetricExporter, err
 			Namespace: MetricNamespace,
 			Name:      "app_sessions_total",
 			Help:      "Current total number of app sessions",
-		}, []string{"application", "status"}),
+		}, []string{"application_id", "status"}),
 		channelsTotal: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: MetricNamespace,
 			Name:      "channels_total",
@@ -58,7 +58,7 @@ func NewStoreMetricExporter(reg prometheus.Registerer) (StoreMetricExporter, err
 			Namespace: MetricNamespace,
 			Name:      "app_sessions_active",
 			Help:      "Current total active app sessions",
-		}, []string{"application", "timespan"}),
+		}, []string{"application_id", "timespan"}),
 		totalValueLocked: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: MetricNamespace,
 			Name:      "total_value_locked",
@@ -106,7 +106,7 @@ func NewStoreMetricExporter(reg prometheus.Registerer) (StoreMetricExporter, err
 }
 
 func (m *storeMetricExporter) SetAppSessions(applicationID string, status app.AppSessionStatus, count uint64) {
-	m.appSessionsTotal.WithLabelValues(applicationID, status.String()).Set(float64(count))
+	m.appSessionsTotal.WithLabelValues(getApplicationIDLabelValue(applicationID), status.String()).Set(float64(count))
 }
 
 func (m *storeMetricExporter) SetChannels(asset string, status core.ChannelStatus, count uint64) {
@@ -118,7 +118,7 @@ func (m *storeMetricExporter) SetActiveUsers(asset, timeSpanLabel string, count 
 }
 
 func (m *storeMetricExporter) SetActiveAppSessions(applicationID, timeSpanLabel string, count uint64) {
-	m.appSessionsActive.WithLabelValues(applicationID, timeSpanLabel).Set(float64(count))
+	m.appSessionsActive.WithLabelValues(getApplicationIDLabelValue(applicationID), timeSpanLabel).Set(float64(count))
 }
 
 func (m *storeMetricExporter) SetTotalValueLocked(domain, asset string, value float64) {
@@ -219,20 +219,20 @@ func NewRuntimeMetricExporter(reg prometheus.Registerer) (RuntimeMetricExporter,
 		// api/rpc_router
 		rpcMessagesTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: MetricNamespace,
-			Name:      "rpc_messages_total",
-			Help:      "Total number of RPC messages",
+			Name:      "rpc_messages_emitted_total",
+			Help:      "Total number of RPC messages emitted (request + response). Counter increments twice per request — once for the request msg and once for the response — so rate(...) over this is roughly 2× the QPS. For real RPC throughput use rpc_requests_total.",
 		}, []string{"msg_type", "method"}),
 		rpcRequestsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: MetricNamespace,
 			Name:      "rpc_requests_total",
 			Help:      "Total number of RPC requests",
-		}, []string{"method", "path", "status"}),
+		}, []string{"method", "path", "result"}),
 		rpcRequestDurationSeconds: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: MetricNamespace,
 			Name:      "rpc_request_duration_seconds",
 			Help:      "Duration of RPC requests in seconds",
 			Buckets:   []float64{0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
-		}, []string{"method", "path", "status"}),
+		}, []string{"method", "path", "result"}),
 		rpcConnectionsTotal: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: MetricNamespace,
 			Name:      "rpc_connections_active",
@@ -251,12 +251,12 @@ func NewRuntimeMetricExporter(reg prometheus.Registerer) (RuntimeMetricExporter,
 			Namespace: MetricNamespace,
 			Name:      "app_state_updates_total",
 			Help:      "Total number of app state updates",
-		}, []string{"application"}),
+		}, []string{"application_id"}),
 		appSessionUpdateSigValidationsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: MetricNamespace,
 			Name:      "app_session_update_sig_validations_total",
 			Help:      "Total number of app session update signature validations",
-		}, []string{"application", "sig_type", "result"}),
+		}, []string{"application_id", "sig_type", "result"}),
 
 		// Blockchain Worker
 		blockchainActionsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -270,7 +270,7 @@ func NewRuntimeMetricExporter(reg prometheus.Registerer) (RuntimeMetricExporter,
 			Namespace: MetricNamespace,
 			Name:      "blockchain_events_total",
 			Help:      "Total number of blockchain events processed",
-		}, []string{"blockchain_id", "process_result"}),
+		}, []string{"blockchain_id", "result"}),
 
 		// store/database
 		dbQueryDurationSeconds: prometheus.NewHistogramVec(prometheus.HistogramOpts{
@@ -366,7 +366,7 @@ func (m *runtimeMetricExporter) ObserveDBQueryDuration(queryKind string, duratio
 
 // api/app_session_v1
 func (m *runtimeMetricExporter) IncAppStateUpdate(applicationID string) {
-	m.appStateUpdates.WithLabelValues(applicationID).Inc()
+	m.appStateUpdates.WithLabelValues(getApplicationIDLabelValue(applicationID)).Inc()
 }
 
 func (m *runtimeMetricExporter) IncAppSessionUpdateSigValidation(applicationID string, signerType app.AppSessionSignerTypeV1, result bool) {
@@ -374,7 +374,7 @@ func (m *runtimeMetricExporter) IncAppSessionUpdateSigValidation(applicationID s
 	if result {
 		res = ActionResultSuccess
 	}
-	m.appSessionUpdateSigValidationsTotal.WithLabelValues(applicationID, signerType.String(), res.String()).Inc()
+	m.appSessionUpdateSigValidationsTotal.WithLabelValues(getApplicationIDLabelValue(applicationID), signerType.String(), res.String()).Inc()
 }
 
 func (m *runtimeMetricExporter) IncChannelStateSigValidation(sigType core.ChannelSignerType, result bool) {

--- a/nitronode/metrics/interface.go
+++ b/nitronode/metrics/interface.go
@@ -38,6 +38,8 @@ type RuntimeMetricExporter interface {
 	IncRPCRequest(method, path string, success bool)
 	ObserveRPCDuration(method, path string, success bool, duration time.Duration)
 	SetRPCConnections(region, origin string, count uint32)
+	IncRPCInflight(method string)
+	DecRPCInflight(method string)
 
 	// api/app_session_v1
 	IncAppStateUpdate(applicationID string)
@@ -48,6 +50,9 @@ type RuntimeMetricExporter interface {
 
 	// Event Listener
 	IncBlockchainEvent(blockchainID uint64, handledSuccessfully bool)
+
+	// store/database (instrumented via gorm callbacks; see metrics.RegisterDBCallbacks)
+	ObserveDBQueryDuration(queryKind string, duration time.Duration)
 }
 
 // noopRuntimeMetricExporter is a no-op implementation for use in tests.
@@ -69,7 +74,10 @@ func (noopRuntimeMetricExporter) IncAppSessionUpdateSigValidation(string, app.Ap
 }
 func (noopRuntimeMetricExporter) IncBlockchainAction(string, uint64, string, bool) {
 }
-func (noopRuntimeMetricExporter) IncBlockchainEvent(uint64, bool) {}
+func (noopRuntimeMetricExporter) IncBlockchainEvent(uint64, bool)            {}
+func (noopRuntimeMetricExporter) IncRPCInflight(string)                      {}
+func (noopRuntimeMetricExporter) DecRPCInflight(string)                      {}
+func (noopRuntimeMetricExporter) ObserveDBQueryDuration(string, time.Duration) {}
 
 // StoreMetricExporter defines the interface for setting metrics that are stored and updated by a separate metric worker.
 type StoreMetricExporter interface {

--- a/nitronode/runtime.go
+++ b/nitronode/runtime.go
@@ -181,6 +181,16 @@ func InitBackbone() *Backbone {
 		logger.Fatal("failed to initialize store metric exporter", "error", err)
 	}
 
+	// Wire DB instrumentation now that both gorm.DB and the runtime exporter
+	// exist: per-query histograms via gorm callbacks, plus the standard
+	// go_sql_* pool-stats collector.
+	if err := database.RegisterMetricsCallbacks(db, runtimeMetrics); err != nil {
+		logger.Fatal("failed to register database metric callbacks", "error", err)
+	}
+	if err := database.RegisterDBStatsCollector(db, prometheus.DefaultRegisterer); err != nil {
+		logger.Fatal("failed to register database stats collector", "error", err)
+	}
+
 	// ------------------------------------------------
 	// RPC Node
 	// ------------------------------------------------

--- a/nitronode/store/database/metrics.go
+++ b/nitronode/store/database/metrics.go
@@ -1,0 +1,112 @@
+package database
+
+import (
+	"errors"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+	"gorm.io/gorm"
+)
+
+// QueryDurationObserver records the time a single gorm DB operation took.
+// Implemented by the runtime metric exporter to avoid an import cycle
+// (the metrics package depends on pkg/{app,core,rpc}, store/database does not).
+type QueryDurationObserver interface {
+	ObserveDBQueryDuration(queryKind string, duration time.Duration)
+}
+
+// metricsStartKey is the gorm.DB context key the before-callback uses to stash
+// the operation start timestamp for the after-callback to read.
+const metricsStartKey = "nitronode:metrics:start"
+
+// callbackName is registered on every gorm callback chain we instrument; if
+// you change it remember to keep the before/after pair in sync.
+const callbackName = "nitronode:metrics"
+
+// queryKinds is the set of gorm callback chains we hook. Order matches the
+// gorm callback registry; "raw" covers Raw / Exec catch-all on the gorm v2
+// callback chain "raw".
+var queryKinds = []string{"create", "query", "update", "delete", "row", "raw"}
+
+// RegisterMetricsCallbacks installs gorm callbacks that observe wall-clock
+// duration of each Create / Query / Update / Delete / Row / Raw operation
+// onto obs. Pass nil to skip registration (test / sqlite-in-memory cases).
+//
+// The callbacks add no per-call allocation beyond a single time.Time stashed
+// in the gorm context dict.
+func RegisterMetricsCallbacks(db *gorm.DB, obs QueryDurationObserver) error {
+	if db == nil {
+		return errors.New("database: nil gorm.DB")
+	}
+	if obs == nil {
+		return nil
+	}
+
+	for _, kind := range queryKinds {
+		kind := kind // pin for closures
+		chain := db.Callback().Query()
+		switch kind {
+		case "create":
+			chain = db.Callback().Create()
+		case "update":
+			chain = db.Callback().Update()
+		case "delete":
+			chain = db.Callback().Delete()
+		case "row":
+			chain = db.Callback().Row()
+		case "raw":
+			chain = db.Callback().Raw()
+		}
+
+		if err := chain.Before("*").Register(callbackName+":before:"+kind, func(tx *gorm.DB) {
+			tx.Set(metricsStartKey, time.Now())
+		}); err != nil {
+			return err
+		}
+		if err := chain.After("*").Register(callbackName+":after:"+kind, func(tx *gorm.DB) {
+			v, ok := tx.Get(metricsStartKey)
+			if !ok {
+				return
+			}
+			start, ok := v.(time.Time)
+			if !ok {
+				return
+			}
+			obs.ObserveDBQueryDuration(kind, time.Since(start))
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RegisterDBStatsCollector registers the standard go_sql_* collector on reg
+// for the underlying *sql.DB, so pool-state gauges and wait counters become
+// scrapable. Returns an error if the gorm DB doesn't expose a *sql.DB
+// (sqlite-in-memory variants normally do; misconfigured pools don't).
+//
+// Emits, under "nitronode" db name:
+//
+//	go_sql_max_open_connections
+//	go_sql_open_connections
+//	go_sql_in_use_connections
+//	go_sql_idle_connections
+//	go_sql_wait_count_total
+//	go_sql_wait_duration_seconds_total
+//	go_sql_max_idle_closed_total
+//	go_sql_max_idle_time_closed_total
+//	go_sql_max_lifetime_closed_total
+func RegisterDBStatsCollector(db *gorm.DB, reg prometheus.Registerer) error {
+	if db == nil {
+		return errors.New("database: nil gorm.DB")
+	}
+	if reg == nil {
+		return errors.New("database: nil prometheus registerer")
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		return err
+	}
+	return reg.Register(collectors.NewDBStatsCollector(sqlDB, "nitronode"))
+}

--- a/nitronode/store/database/metrics.go
+++ b/nitronode/store/database/metrics.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -45,10 +46,17 @@ func RegisterMetricsCallbacks(db *gorm.DB, obs QueryDurationObserver) error {
 
 	for _, kind := range queryKinds {
 		kind := kind // pin for closures
+		// Explicit case per kind + default that errors out, so adding a new
+		// entry to queryKinds without an arm here trips at runtime instead
+		// of silently hooking the wrong gorm processor. (Type of `chain` is
+		// gorm's unexported *callbacks.processor; inferred from the dummy
+		// init so the compile-time variable type lines up.)
 		chain := db.Callback().Query()
 		switch kind {
 		case "create":
 			chain = db.Callback().Create()
+		case "query":
+			chain = db.Callback().Query()
 		case "update":
 			chain = db.Callback().Update()
 		case "delete":
@@ -57,14 +65,20 @@ func RegisterMetricsCallbacks(db *gorm.DB, obs QueryDurationObserver) error {
 			chain = db.Callback().Row()
 		case "raw":
 			chain = db.Callback().Raw()
+		default:
+			return fmt.Errorf("database: unknown query kind %q", kind)
 		}
 
-		if err := chain.Before("*").Register(callbackName+":before:"+kind, func(tx *gorm.DB) {
+		// Use Replace, not Register: Replace is idempotent on the callback
+		// name, so calling RegisterMetricsCallbacks twice on the same gorm.DB
+		// (test helpers, DI restart) doesn't double-fire the after callback
+		// and double-count duration into the histogram.
+		if err := chain.Before("*").Replace(callbackName+":before:"+kind, func(tx *gorm.DB) {
 			tx.Set(metricsStartKey, time.Now())
 		}); err != nil {
 			return err
 		}
-		if err := chain.After("*").Register(callbackName+":after:"+kind, func(tx *gorm.DB) {
+		if err := chain.After("*").Replace(callbackName+":after:"+kind, func(tx *gorm.DB) {
 			v, ok := tx.Get(metricsStartKey)
 			if !ok {
 				return


### PR DESCRIPTION
## Summary

Extends nitronode's emitted metric set and standardizes its label naming so dashboards and alerts can be authored against a coherent surface. Three commits, each independently reviewable:

1. **`2aba0e3d` feat(nitronode/metrics): add saturation + DB latency observability** — three new emission paths:
   - `nitronode_rpc_inflight{method}` — gauge incremented at the `ObservabilityMiddleware` entry and decremented on exit. Saturation signal that pairs with `rpc_request_duration_seconds` to distinguish "slow handler" from "queued behind contention".
   - `nitronode_db_query_duration_seconds{query_kind}` — histogram observed via gorm callbacks (Create / Query / Update / Delete / Row / Raw). Captures app-side round-trip including pgbouncer hop.
   - `go_sql_*` — standard `collectors.NewDBStatsCollector` registered with db name `nitronode`. Pool gauges + wait counters (`go_sql_wait_duration_seconds_total`, `go_sql_wait_count_total`, etc.) for the underlying `*sql.DB`.

   New `store/database/metrics.go` owns the gorm-callback registration and dbstats collector helpers, exposing a tiny `QueryDurationObserver` interface so the package doesn't depend on `nitronode/metrics` (which would induce a cycle through `pkg/{app,core,rpc}`).

2. **`921a00b0` refactor(nitronode/metrics): standardize label naming + scrub appID** — coordinated **breaking** label renames:
   - `application` → `application_id` on `nitronode_app_sessions_total`, `nitronode_app_sessions_active`, `nitronode_app_state_updates_total`, `nitronode_app_session_update_sig_validations_total` (the holdouts; `user_states_total` / `transactions_total` already used `application_id`).
   - `status` → `result` on `nitronode_rpc_requests_total` and `nitronode_rpc_request_duration_seconds`; `process_result` → `result` on `nitronode_blockchain_events_total`. Settles on `result ∈ {success, failed}` everywhere.
   - `IncAppStateUpdate`, `IncAppSessionUpdateSigValidation`, `SetAppSessions`, `SetActiveAppSessions` now wrap `applicationID` with `getApplicationIDLabelValue` so empty becomes `_DEFAULT` (matches `IncUserState` / `RecordTransaction`).
   - `nitronode_rpc_messages_total` → `nitronode_rpc_messages_emitted_total`. The metric counts both the request and the response message of every RPC; the new name and Help spell out the doubled emission so downstream consumers don't compute QPS at 2× the real rate.

3. **`196190ca` docs(nitronode/metrics): expand Help texts to encode label semantics** — Help string rewrite covering trigger conditions, label semantics with enum value sets, and aggregation guidance for every metric. Notable:
   - `user_balance_underfunded` / `user_balance_releasable` now explain the channel-checkpoint semantics: each is the worst-case potential outflow / inflow from `node_balance` if every underfunded / releasable channel checkpointed simultaneously.
   - `transactions_amount_total` documents the `decimal.Decimal.InexactFloat64` precision loss explicitly.

## Verified

- `go build ./nitronode/...` clean.
- `go test ./nitronode/...` clean (existing test suite — no behaviour-affecting changes; rename-only refactors covered by package-level builds).
- DB instrumentation does not introduce per-call allocation beyond a single `time.Time` stashed in the gorm context dict.

## Migration

Breaking — every dashboard / alert / recording rule that referenced the old label names or `nitronode_rpc_messages_total` must update in lockstep with the deploy. The ops-side changes (dashboard YAML, alert rules) follow on `feat/metrics-extensions` in `layer-3/ops`.

## Deferred

- `D N7` (PodMonitoring `metricRelabeling` guard against `application_id` cardinality blow-up) is captured in `docs/nitronode-env-metrics.md` §7 / §9 in the ops repo — postponed until cardinality becomes a real ingest cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-flight RPC request tracking added to monitor concurrent requests per RPC method
  * Database query duration metrics and DB pool stats collection registered for deeper DB performance insights

* **Chores**
  * Standardized application metric label name to application_id
  * Renamed and clarified RPC metric names and result semantics for improved observability
<!-- end of auto-generated comment: release notes by coderabbit.ai -->