### PR TITLE
M3-L01: fix(nitronode): persist home channel challenge state

### DIFF
--- a/nitronode/event_handlers/service.go
+++ b/nitronode/event_handlers/service.go
@@ -115,11 +115,13 @@ func (s *EventHandlerService) HandleHomeChannelCheckpointed(ctx context.Context,
 }
 
 // HandleHomeChannelChallenged processes the HomeChannelChallenged event emitted when a potentially
-// stale state is submitted on-chain. Automatic challenge response is intentionally disabled: the
-// latest signed state may carry an intent (e.g. CLOSE, escrow initiate/finalize, migration) that
-// cannot be resolved via ScheduleCheckpoint, and silently queueing an impossible transaction
-// risks letting the challenge expire on a stale state. Instead, this handler emits a warning so
-// operators are alerted and can submit the appropriate on-chain action manually before expiry.
+// stale state is submitted on-chain. It marks the channel as Challenged and persists the challenge
+// expiry so subsequent state-submission paths (CheckOpenChannel, RefreshUserEnforcedBalance) stop
+// treating the channel as open. Automatic challenge response is intentionally disabled: the latest
+// signed state may carry an intent (e.g. CLOSE, escrow initiate/finalize, migration) that cannot
+// be resolved via ScheduleCheckpoint, and silently queueing an impossible transaction risks
+// letting the challenge expire on a stale state. A warning is emitted so operators submit the
+// appropriate on-chain action manually before expiry.
 func (s *EventHandlerService) HandleHomeChannelChallenged(ctx context.Context, tx core.ChannelHubEventHandlerStore, event *core.HomeChannelChallengedEvent) error {
 	logger := log.FromContext(ctx)
 	chanID := event.ChannelID
@@ -136,13 +138,33 @@ func (s *EventHandlerService) HandleHomeChannelChallenged(ctx context.Context, t
 		return nil
 	}
 
+	if event.StateVersion < channel.StateVersion {
+		// Per protocol the challenged version cannot be lower than the last known on-chain version.
+		// Treat as an anomaly (replay, indexer mis-order, contract bug): warn and skip persistence.
+		logger.Warn("challenged state version is less than current channel state version, ignoring", "channelId", chanID, "currentStateVersion", channel.StateVersion, "challengedStateVersion", event.StateVersion)
+		return nil
+	}
+
+	channel.StateVersion = event.StateVersion
+	channel.Status = core.ChannelStatusChallenged
+	expirationTime := time.Unix(int64(event.ChallengeExpiry), 0)
+	channel.ChallengeExpiresAt = &expirationTime
+
+	if err := tx.UpdateChannel(*channel); err != nil {
+		return err
+	}
+
+	if err := tx.RefreshUserEnforcedBalance(channel.UserWallet, channel.Asset); err != nil {
+		return err
+	}
+
 	logger.Warn("home channel challenged",
 		"channelId", chanID,
 		"userWallet", channel.UserWallet,
 		"blockchainID", channel.BlockchainID,
 		"asset", channel.Asset,
 		"challengedStateVersion", event.StateVersion,
-		"challengeExpiry", time.Unix(int64(event.ChallengeExpiry), 0),
+		"challengeExpiry", expirationTime,
 	)
 	return nil
 }

--- a/nitronode/event_handlers/service_test.go
+++ b/nitronode/event_handlers/service_test.go
@@ -100,11 +100,11 @@ func TestHandleHomeChannelCheckpointed_Success(t *testing.T) {
 	mockStore.AssertExpectations(t)
 }
 
-func TestHandleHomeChannelChallenged_LogsOnly(t *testing.T) {
-	// Automatic challenge response was removed because non-checkpointable intents (CLOSE,
-	// escrow initiate/finalize, migration) cannot be resolved via ScheduleCheckpoint. The
-	// handler must only fetch the channel for context and emit a warning — no state mutation,
-	// no scheduled action, no enforced-balance refresh.
+func TestHandleHomeChannelChallenged_PersistsChallenge(t *testing.T) {
+	// Channel must be marked Challenged with the challenge expiry so CheckOpenChannel and
+	// RefreshUserEnforcedBalance stop treating it as open. Auto-checkpoint stays disabled:
+	// non-checkpointable intents (CLOSE, escrow initiate/finalize, migration) cannot be
+	// resolved via ScheduleCheckpoint, so operator action is required.
 	mockStore := new(MockStore)
 	ctx := log.SetContextLogger(context.Background(), log.NewNoopLogger())
 
@@ -130,14 +130,56 @@ func TestHandleHomeChannelChallenged_LogsOnly(t *testing.T) {
 	}
 
 	mockStore.On("GetChannelByID", channelID).Return(channel, nil)
+	mockStore.On("UpdateChannel", mock.MatchedBy(func(ch core.Channel) bool {
+		return ch.ChannelID == channelID &&
+			ch.Status == core.ChannelStatusChallenged &&
+			ch.StateVersion == 4 &&
+			ch.ChallengeExpiresAt != nil &&
+			ch.ChallengeExpiresAt.Unix() == int64(challengeExpiry)
+	})).Return(nil)
+	mockStore.On("RefreshUserEnforcedBalance", userWallet, "usdc").Return(nil)
+
+	err := service.HandleHomeChannelChallenged(ctx, mockStore, event)
+
+	require.NoError(t, err)
+	mockStore.AssertExpectations(t)
+	mockStore.AssertNotCalled(t, "GetLastStateByChannelID", mock.Anything, mock.Anything)
+	mockStore.AssertNotCalled(t, "ScheduleCheckpoint", mock.Anything, mock.Anything)
+}
+
+func TestHandleHomeChannelChallenged_StaleVersionIgnored(t *testing.T) {
+	// Per protocol the challenged version cannot be lower than the last known on-chain version.
+	// Anomalies (replay, indexer mis-order) must not regress channel state.
+	mockStore := new(MockStore)
+	ctx := log.SetContextLogger(context.Background(), log.NewNoopLogger())
+
+	service := &EventHandlerService{}
+
+	channelID := "0xHomeChannel123"
+	userWallet := "0x1234567890123456789012345678901234567890"
+
+	channel := &core.Channel{
+		ChannelID:    channelID,
+		UserWallet:   userWallet,
+		Asset:        "usdc",
+		Type:         core.ChannelTypeHome,
+		Status:       core.ChannelStatusOpen,
+		StateVersion: 5,
+	}
+
+	event := &core.HomeChannelChallengedEvent{
+		ChannelID:       channelID,
+		StateVersion:    3,
+		ChallengeExpiry: uint64(time.Now().Add(time.Hour).Unix()),
+	}
+
+	mockStore.On("GetChannelByID", channelID).Return(channel, nil)
 
 	err := service.HandleHomeChannelChallenged(ctx, mockStore, event)
 
 	require.NoError(t, err)
 	mockStore.AssertExpectations(t)
 	mockStore.AssertNotCalled(t, "UpdateChannel", mock.Anything)
-	mockStore.AssertNotCalled(t, "GetLastStateByChannelID", mock.Anything, mock.Anything)
-	mockStore.AssertNotCalled(t, "ScheduleCheckpoint", mock.Anything, mock.Anything)
 	mockStore.AssertNotCalled(t, "RefreshUserEnforcedBalance", mock.Anything, mock.Anything)
 }
 


### PR DESCRIPTION
## Summary
- Restore persistence of `Status=Challenged`, `ChallengeExpiresAt`, and `StateVersion` in `HandleHomeChannelChallenged`, and refresh the user's enforced balance.
- Without persistence, `CheckOpenChannel` (filters `status <= Open`) kept passing for a disputed channel, so the node could keep accepting and signing states while the contract was in `DISPUTED`. This addresses the round-2 audit finding flagged after #713 (M2-M01).
- Auto-checkpoint stays disabled per M2-M01: non-checkpointable intents (CLOSE, escrow initiate/finalize, migration) cannot be resolved via `ScheduleCheckpoint`, so operator action is still required and a warning is emitted.
- Stale events where `event.StateVersion < channel.StateVersion` are ignored with a warning — per protocol the challenged version cannot regress below the last known on-chain version.

## Test plan
- [x] `go test ./nitronode/event_handlers/...`
- [x] `go vet ./nitronode/event_handlers/...`
- [x] New tests:
  - `TestHandleHomeChannelChallenged_PersistsChallenge` — asserts `UpdateChannel` (Status=Challenged, expiry set, version bumped) and `RefreshUserEnforcedBalance`, asserts no auto-checkpoint scheduled.
  - `TestHandleHomeChannelChallenged_StaleVersionIgnored` — asserts no persistence when challenged version < current.
- [x] Existing `_ChannelNotFound` and `_TypeMismatch` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced channel challenge event handling with state version validation to prevent processing outdated challenge events
  * Improved persistence of challenge state information and expiration tracking
  * User balance refresh now occurs automatically when channel challenges are detected

<!-- end of auto-generated comment: release notes by coderabbit.ai -->