### PR TITLE
MF-C01: rpc: cap inbound WebSocket frame size and rate-limit per connection

### DIFF
--- a/nitronode/api/rate_limits.go
+++ b/nitronode/api/rate_limits.go
@@ -6,10 +6,11 @@ import (
 	"github.com/layer-3/nitrolite/pkg/rpc"
 )
 
-const (
-	// rateLimitStorageKey is the key used to store the token bucket in connection storage.
-	rateLimitStorageKey = "rate_limiter"
-)
+// rateLimitStorageKey is the per-connection SafeStorage key for the request-rate
+// token bucket. The bucket is allocated on the first request and mutated in
+// place on subsequent ones — processRequests dispatches the middleware chain
+// serially per connection, so a single load is sufficient.
+const rateLimitStorageKey = "rate_limiter"
 
 // tokenBucket holds the mutable state for per-connection rate limiting.
 type tokenBucket struct {
@@ -17,35 +18,42 @@ type tokenBucket struct {
 	last   time.Time
 }
 
-// RateLimitMiddleware enforces per-connection rate limiting using a token bucket algorithm.
-// It stores the token bucket in the connection's Storage for persistence across requests.
+// RateLimitMiddleware enforces a per-connection request-count token bucket.
+// It complements the per-frame byte budget enforced by FrameRateLimiter at the
+// connection layer: bytes guard bandwidth, this guards RPC throughput so a
+// flood of small requests cannot bypass the byte cap.
+//
+// On overrun the request fails with an RPC error and the connection stays
+// open; the byte limiter is the layer that closes connections.
 func (r *RPCRouter) RateLimitMiddleware(c *rpc.Context) {
-	bucket := &tokenBucket{
-		tokens: r.rateLimitBurst,
-		last:   time.Now().Add(-time.Second),
-	}
-	if val, ok := c.Storage.Get(rateLimitStorageKey); ok {
-		if b, ok := val.(*tokenBucket); ok {
-			bucket = b
-		}
-	}
+	bucket := loadOrInitBucket(c, r.rateLimitBurst)
 
 	now := time.Now()
-	elapsed := now.Sub(bucket.last).Seconds()
-	bucket.last = now
-
-	// Refill tokens based on elapsed time
-	bucket.tokens += elapsed * r.rateLimitPerSec
+	bucket.tokens += now.Sub(bucket.last).Seconds() * r.rateLimitPerSec
 	if bucket.tokens > r.rateLimitBurst {
 		bucket.tokens = r.rateLimitBurst
 	}
+	bucket.last = now
 
 	if bucket.tokens < 1 {
-		c.Fail(nil, "rate limit exceeded")
+		c.Fail(rpc.Errorf("rate limit exceeded"), "")
 		return
 	}
 	bucket.tokens--
-	c.Storage.Set(rateLimitStorageKey, bucket)
 
 	c.Next()
+}
+
+// loadOrInitBucket returns the bucket stored on the connection, allocating a
+// fresh one pre-filled to burst on first use. The bucket is stored as a
+// pointer; later mutations are visible without re-Set.
+func loadOrInitBucket(c *rpc.Context, burst float64) *tokenBucket {
+	if v, ok := c.Storage.Get(rateLimitStorageKey); ok {
+		if b, ok := v.(*tokenBucket); ok {
+			return b
+		}
+	}
+	b := &tokenBucket{tokens: burst, last: time.Now()}
+	c.Storage.Set(rateLimitStorageKey, b)
+	return b
 }

--- a/nitronode/chart/README.md
+++ b/nitronode/chart/README.md
@@ -98,6 +98,68 @@ helm delete my-release
 | stressTest.maxErrorRate | string | `"0.01"` | Default max error rate threshold (0.01 = 1%) |
 | stressTest.pods | list | see values.yaml | List of stress test pods to run |
 
+## WebSocket DoS hardening
+
+Defense layered top-down. Each layer sheds load before the next.
+
+### Cloudflare (recommended for public-facing envs)
+
+WAF Rate Limiting rules — production / sandbox only. Skip for `stress-v1`
+(test traffic, no Cloudflare zone configured).
+
+Suggested rule:
+
+| Field      | Value                                                                                  |
+|------------|----------------------------------------------------------------------------------------|
+| Match      | `(http.host eq "<your-host>" and http.request.uri.path eq "/v1/ws")`                   |
+| Threshold  | 60 requests per 1 minute per IP                                                        |
+| Action     | Block 10m                                                                              |
+| Counting   | All HTTP statuses                                                                      |
+
+Pair with Bot Fight Mode + Managed Challenge on the same hostname for low-rep
+sources.
+
+### NGINX Ingress (per-IP, per-conn)
+
+The env templates already wire these annotations on the WebSocket Ingress:
+
+```yaml
+nginx.ingress.kubernetes.io/limit-connections:      "50"   # concurrent / IP
+nginx.ingress.kubernetes.io/limit-rps:              "20"   # new conns/s / IP
+nginx.ingress.kubernetes.io/limit-burst-multiplier: "3"
+nginx.ingress.kubernetes.io/proxy-body-size:        "256k"
+```
+
+**Real-IP requirement.** ingress-nginx must see the client IP, not the CF
+edge IP or LB pod IP. Cluster-wide ConfigMap (one-time, ops-owned):
+
+```yaml
+use-forwarded-headers:        "true"
+compute-full-forwarded-for:   "true"
+forwarded-for-header:         "CF-Connecting-IP"   # if behind Cloudflare
+proxy-real-ip-cidr:           "<Cloudflare ranges + LB CIDR>"
+```
+
+Without this, all traffic appears to come from a handful of LB IPs and the
+per-IP limiters are useless.
+
+For envs without Cloudflare in front (e.g. `stress-v1`), ensure the
+ingress-nginx Service has `externalTrafficPolicy: Local` so the GCP LB
+preserves source IPs to the pods.
+
+### Application (`pkg/rpc`)
+
+Per-connection caps configured via env on the nitronode pod:
+
+| Env                              | Default     | Purpose                                                                  |
+|----------------------------------|-------------|--------------------------------------------------------------------------|
+| `NITRONODE_WS_MAX_MESSAGE_SIZE`  | `131072`    | Hard cap on inbound frame (bytes). Exceeded → close 1009 before alloc.   |
+| `NITRONODE_WS_BYTES_PER_SEC`     | `262144`    | Steady-state byte budget per connection. Set ≤ 0 to disable.             |
+| `NITRONODE_WS_BYTES_BURST`       | `1048576`   | Burst capacity for the per-connection byte bucket.                       |
+
+Disable the byte-rate cap (`WS_BYTES_PER_SEC=-1`) for canary rollout if
+false positives are suspected. The frame size cap stays on regardless.
+
 ## Gateway Configuration
 
 By default, the chart creates an API Gateway and configures it to use TLS via cert-manager. To use this feature:

--- a/nitronode/chart/README.md
+++ b/nitronode/chart/README.md
@@ -127,8 +127,13 @@ The env templates already wire these annotations on the WebSocket Ingress:
 nginx.ingress.kubernetes.io/limit-connections:      "50"   # concurrent / IP
 nginx.ingress.kubernetes.io/limit-rps:              "20"   # new conns/s / IP
 nginx.ingress.kubernetes.io/limit-burst-multiplier: "3"
-nginx.ingress.kubernetes.io/proxy-body-size:        "256k"
 ```
+
+> Note: `proxy-body-size` (nginx `client_max_body_size`) intentionally not set.
+> It applies to HTTP request bodies only; after the WebSocket upgrade the
+> ingress proxies the TCP stream transparently and cannot enforce a per-frame
+> size limit. Frame size is capped at the application layer
+> (`NITRONODE_WS_MAX_MESSAGE_SIZE` → `SetReadLimit`).
 
 **Real-IP requirement.** ingress-nginx must see the client IP, not the CF
 edge IP or LB pod IP. Cluster-wide ConfigMap (one-time, ops-owned):

--- a/nitronode/chart/config/stress-v1/nitronode.yaml.gotmpl
+++ b/nitronode/chart/config/stress-v1/nitronode.yaml.gotmpl
@@ -83,8 +83,10 @@ networking:
       nginx.ingress.kubernetes.io/limit-connections: "50"        # concurrent / IP
       nginx.ingress.kubernetes.io/limit-rps: "20"                # new conns/s / IP
       nginx.ingress.kubernetes.io/limit-burst-multiplier: "3"
-      # Belt-and-braces: ingress-level body cap. App enforces frame size too.
-      nginx.ingress.kubernetes.io/proxy-body-size: "256k"
+      # Note: nginx proxy-body-size applies to HTTP request bodies only. After
+      # the WebSocket upgrade, ingress-nginx proxies the TCP stream transparently
+      # and cannot enforce a per-frame size limit. The frame cap is enforced at
+      # the application layer via NITRONODE_WS_MAX_MESSAGE_SIZE / SetReadLimit.
 
 stressTest:
   enabled: false

--- a/nitronode/chart/config/stress-v1/nitronode.yaml.gotmpl
+++ b/nitronode/chart/config/stress-v1/nitronode.yaml.gotmpl
@@ -21,6 +21,13 @@ config:
     NITRONODE_MAX_SESSION_DATA_LEN: "1024"
     NITRONODE_MAX_SIGNED_UPDATES: "0"
     NITRONODE_MAX_SESSION_KEY_IDS: "256"
+    # WebSocket DoS hardening.
+    # Frame cap: largest legit v1 RPC ≈ a few KB; 128 KiB leaves headroom.
+    # Byte budget: 256 KiB/s steady, 1 MiB burst. Comfortably absorbs reload
+    # reconnect storms (auth + subscribe ≈ 20 KB / tab) without throttling.
+    NITRONODE_WS_MAX_MESSAGE_SIZE: "131072"
+    NITRONODE_WS_BYTES_PER_SEC: "262144"
+    NITRONODE_WS_BYTES_BURST: "1048576"
 
 image:
   repository: ghcr.io/layer-3/nitrolite/nitronode
@@ -66,6 +73,18 @@ networking:
       nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
       nginx.ingress.kubernetes.io/proxy-connect-timeout: "10"
       nginx.ingress.kubernetes.io/proxy-buffering: "off"
+      # ── DoS hardening (per-IP, NGINX-level) ──────────────────────────────
+      # Caps abusive sources before WebSocket upgrade and JSON decode.
+      # Effective only when ingress-nginx sees real client IPs — see chart
+      # README "WebSocket DoS hardening" for required ConfigMap settings.
+      # stress-v1 has no Cloudflare in front; source IP comes from the GCP
+      # LB. Verify externalTrafficPolicy=Local on the ingress-nginx Service
+      # before relying on per-IP limits.
+      nginx.ingress.kubernetes.io/limit-connections: "50"        # concurrent / IP
+      nginx.ingress.kubernetes.io/limit-rps: "20"                # new conns/s / IP
+      nginx.ingress.kubernetes.io/limit-burst-multiplier: "3"
+      # Belt-and-braces: ingress-level body cap. App enforces frame size too.
+      nginx.ingress.kubernetes.io/proxy-body-size: "256k"
 
 stressTest:
   enabled: false

--- a/nitronode/runtime.go
+++ b/nitronode/runtime.go
@@ -205,6 +205,26 @@ func InitBackbone() *Backbone {
 
 	bytesPerSec := conf.WsBytesPerSec
 	bytesBurst := conf.WsBytesBurst
+	// When the per-connection byte budget is enabled, the burst must be at least
+	// the max message size; otherwise every legitimate frame that passes
+	// SetReadLimit would still be rejected by the bucket on arrival, taking the
+	// node out via config alone. Fail fast at startup.
+	if bytesPerSec > 0 {
+		if bytesBurst <= 0 {
+			logger.Fatal(
+				"NITRONODE_WS_BYTES_BURST must be > 0 when NITRONODE_WS_BYTES_PER_SEC is enabled",
+				"ws_bytes_burst", bytesBurst,
+				"ws_bytes_per_sec", bytesPerSec,
+			)
+		}
+		if conf.WsMaxMessageSize > 0 && bytesBurst < float64(conf.WsMaxMessageSize) {
+			logger.Fatal(
+				"NITRONODE_WS_BYTES_BURST must be >= NITRONODE_WS_MAX_MESSAGE_SIZE when byte limiting is enabled",
+				"ws_bytes_burst", bytesBurst,
+				"ws_max_message_size", conf.WsMaxMessageSize,
+			)
+		}
+	}
 	rpcNode, err := rpc.NewWebsocketNode(rpc.WebsocketNodeConfig{
 		Logger:                  logger,
 		ObserveConnections:      runtimeMetrics.SetRPCConnections,

--- a/nitronode/runtime.go
+++ b/nitronode/runtime.go
@@ -80,6 +80,14 @@ type FullConfig struct {
 	RateLimitBurst              float64          `yaml:"rate_limit_burst" env:"NITRONODE_RATE_LIMIT_BURST" env-default:"20"`
 	WsProcessBufferSize         int              `yaml:"ws_process_buffer_size" env:"NITRONODE_WS_PROCESS_BUFFER_SIZE" env-default:"64"`
 	WsWriteBufferSize           int              `yaml:"ws_write_buffer_size" env:"NITRONODE_WS_WRITE_BUFFER_SIZE" env-default:"64"`
+	// WsMaxMessageSize caps inbound WebSocket frame size in bytes. Frames over the
+	// cap close the connection with WebSocket close code 1009 before allocation.
+	// 128 KiB fits any legitimate v1 RPC with substantial headroom.
+	WsMaxMessageSize int64 `yaml:"ws_max_message_size" env:"NITRONODE_WS_MAX_MESSAGE_SIZE" env-default:"131072"`
+	// WsBytesPerSec is the steady-state byte budget per connection. Set <0 to disable.
+	WsBytesPerSec float64 `yaml:"ws_bytes_per_sec" env:"NITRONODE_WS_BYTES_PER_SEC" env-default:"262144"`
+	// WsBytesBurst is the burst capacity of the per-connection byte bucket.
+	WsBytesBurst float64 `yaml:"ws_bytes_burst" env:"NITRONODE_WS_BYTES_BURST" env-default:"1048576"`
 }
 
 type SignerConfig struct {
@@ -195,11 +203,20 @@ func InitBackbone() *Backbone {
 	// RPC Node
 	// ------------------------------------------------
 
+	bytesPerSec := conf.WsBytesPerSec
+	bytesBurst := conf.WsBytesBurst
 	rpcNode, err := rpc.NewWebsocketNode(rpc.WebsocketNodeConfig{
 		Logger:                  logger,
 		ObserveConnections:      runtimeMetrics.SetRPCConnections,
 		WsConnProcessBufferSize: conf.WsProcessBufferSize,
 		WsConnWriteBufferSize:   conf.WsWriteBufferSize,
+		WsConnMaxMessageSize:    conf.WsMaxMessageSize,
+		NewFrameRateLimiter: func() rpc.FrameRateLimiter {
+			if bytesPerSec <= 0 {
+				return rpc.NoopFrameRateLimiter{}
+			}
+			return rpc.NewByteTokenBucket(bytesPerSec, bytesBurst)
+		},
 	})
 	if err != nil {
 		logger.Fatal("failed to initialize RPC node", "error", err)

--- a/nitronode/runtime.go
+++ b/nitronode/runtime.go
@@ -203,6 +203,16 @@ func InitBackbone() *Backbone {
 	// RPC Node
 	// ------------------------------------------------
 
+	// MF-C01 requires a hard frame-size cap; refuse to start without one even if
+	// the operator zeroed the env. The library would substitute its own default,
+	// but we want the misconfiguration surfaced rather than papered over.
+	if conf.WsMaxMessageSize <= 0 {
+		logger.Fatal(
+			"NITRONODE_WS_MAX_MESSAGE_SIZE must be > 0; the WebSocket frame cap cannot be disabled",
+			"ws_max_message_size", conf.WsMaxMessageSize,
+		)
+	}
+
 	bytesPerSec := conf.WsBytesPerSec
 	bytesBurst := conf.WsBytesBurst
 	// When the per-connection byte budget is enabled, the burst must be at least
@@ -217,7 +227,7 @@ func InitBackbone() *Backbone {
 				"ws_bytes_per_sec", bytesPerSec,
 			)
 		}
-		if conf.WsMaxMessageSize > 0 && bytesBurst < float64(conf.WsMaxMessageSize) {
+		if bytesBurst < float64(conf.WsMaxMessageSize) {
 			logger.Fatal(
 				"NITRONODE_WS_BYTES_BURST must be >= NITRONODE_WS_MAX_MESSAGE_SIZE when byte limiting is enabled",
 				"ws_bytes_burst", bytesBurst,

--- a/pkg/rpc/connection.go
+++ b/pkg/rpc/connection.go
@@ -389,7 +389,7 @@ func (conn *WebsocketConnection) readMessages(handleClosure func(error)) {
 			continue // Skip empty messages
 		}
 
-		if !conn.frameRateLimiter.Allow(time.Now(), len(messageBytes)) {
+		if !conn.frameRateLimiter.Admit(time.Now(), len(messageBytes)) {
 			conn.logger.Warn("frame rate limit exceeded; closing connection",
 				"origin", conn.origin,
 				"frame_bytes", len(messageBytes),

--- a/pkg/rpc/connection.go
+++ b/pkg/rpc/connection.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -356,10 +357,13 @@ func (conn *WebsocketConnection) readMessages(handleClosure func(error)) {
 		_, messageBytes, err := conn.websocketConn.ReadMessage()
 		if err != nil {
 			switch {
-			case websocket.IsCloseError(err, websocket.CloseMessageTooBig):
-				// Expected attacker / misconfigured-client path. Frame exceeded
-				// SetReadLimit; gorilla already sent close 1009. Treat as
-				// graceful close, not abnormal termination.
+			case errors.Is(err, websocket.ErrReadLimit),
+				websocket.IsCloseError(err, websocket.CloseMessageTooBig):
+				// Expected attacker / misconfigured-client path. Local read limit
+				// exceeded → gorilla returns ErrReadLimit to us and best-effort
+				// sends close 1009 to the peer. The IsCloseError branch covers
+				// the symmetric case where the peer initiated a 1009 close.
+				// Treat both as graceful close, not abnormal termination.
 				conn.logger.Warn("inbound frame exceeded MaxMessageSize; closing connection",
 					"error", err,
 					"origin", conn.origin,

--- a/pkg/rpc/connection.go
+++ b/pkg/rpc/connection.go
@@ -112,7 +112,8 @@ type WebsocketConnection struct {
 	pingInterval time.Duration
 	// pongTimeout is the maximum duration to wait for a pong response from the client
 	pongTimeout time.Duration
-	// maxMessageSize caps inbound frame size in bytes. Zero or negative disables.
+	// maxMessageSize caps inbound frame size in bytes. Always positive after
+	// NewWebsocketConnection: non-positive config values fall back to the default.
 	maxMessageSize int64
 	// frameRateLimiter decides whether each inbound frame is admitted.
 	frameRateLimiter FrameRateLimiter
@@ -155,7 +156,8 @@ type WebsocketConnectionConfig struct {
 	PongTimeout time.Duration
 	// MaxMessageSize caps inbound frame size in bytes (default: 128 KiB).
 	// Frames larger than this are rejected with WebSocket close code 1009
-	// before any allocation grows past the limit. Set <0 to disable (not recommended).
+	// before any allocation grows past the limit. Non-positive values fall
+	// back to the default; the cap cannot be disabled at this layer.
 	MaxMessageSize int64
 	// FrameRateLimiter is consulted for every inbound frame; returning false closes
 	// the connection. nil → NoopFrameRateLimiter (no enforcement).
@@ -197,7 +199,7 @@ func NewWebsocketConnection(config WebsocketConnectionConfig) (*WebsocketConnect
 	if config.PongTimeout <= 0 {
 		config.PongTimeout = defaultWsConnPongTimeout
 	}
-	if config.MaxMessageSize == 0 {
+	if config.MaxMessageSize <= 0 {
 		config.MaxMessageSize = defaultWsConnMaxMessageSize
 	}
 	if config.FrameRateLimiter == nil {

--- a/pkg/rpc/connection.go
+++ b/pkg/rpc/connection.go
@@ -26,6 +26,9 @@ var (
 	// defaultWsConnPongTimeout is the default timeout for receiving pong responses from clients.
 	// If no pong is received within this duration after a ping, the connection is considered dead.
 	defaultWsConnPongTimeout = 10 * time.Second
+	// defaultWsConnMaxMessageSize is the default cap on inbound WebSocket frame size in bytes.
+	// Frames exceeding this trigger close 1009 (Message Too Big) before allocation.
+	defaultWsConnMaxMessageSize int64 = 128 * 1024
 )
 
 // Connection represents an active RPC connection that handles bidirectional communication.
@@ -75,6 +78,10 @@ type GorillaWsConnectionAdapter interface {
 	// SetReadDeadline sets the deadline for future Read calls.
 	// A zero value means reads will not time out.
 	SetReadDeadline(t time.Time) error
+	// SetReadLimit sets the maximum size in bytes for a single inbound message.
+	// Frames exceeding the limit cause ReadMessage to return a *CloseError with
+	// code 1009 (CloseMessageTooBig) and the connection sends a close frame.
+	SetReadLimit(limit int64)
 }
 
 // WebsocketConnection implements the Connection interface using WebSocket transport.
@@ -104,6 +111,10 @@ type WebsocketConnection struct {
 	pingInterval time.Duration
 	// pongTimeout is the maximum duration to wait for a pong response from the client
 	pongTimeout time.Duration
+	// maxMessageSize caps inbound frame size in bytes. Zero or negative disables.
+	maxMessageSize int64
+	// frameRateLimiter decides whether each inbound frame is admitted.
+	frameRateLimiter FrameRateLimiter
 
 	// logger is used for logging events related to this connection
 	logger log.Logger
@@ -141,6 +152,13 @@ type WebsocketConnectionConfig struct {
 	// PongTimeout is the maximum duration to wait for a pong response from the client (default: 10s).
 	// If no pong is received within this duration, the connection is considered dead.
 	PongTimeout time.Duration
+	// MaxMessageSize caps inbound frame size in bytes (default: 128 KiB).
+	// Frames larger than this are rejected with WebSocket close code 1009
+	// before any allocation grows past the limit. Set <0 to disable (not recommended).
+	MaxMessageSize int64
+	// FrameRateLimiter is consulted for every inbound frame; returning false closes
+	// the connection. nil → NoopFrameRateLimiter (no enforcement).
+	FrameRateLimiter FrameRateLimiter
 	// Logger for connection events (default: no-op logger)
 	Logger log.Logger
 	// OnMessageSentHandler is called after a message is successfully sent (optional)
@@ -178,17 +196,25 @@ func NewWebsocketConnection(config WebsocketConnectionConfig) (*WebsocketConnect
 	if config.PongTimeout <= 0 {
 		config.PongTimeout = defaultWsConnPongTimeout
 	}
+	if config.MaxMessageSize == 0 {
+		config.MaxMessageSize = defaultWsConnMaxMessageSize
+	}
+	if config.FrameRateLimiter == nil {
+		config.FrameRateLimiter = NoopFrameRateLimiter{}
+	}
 	if config.OnMessageSentHandler == nil {
 		config.OnMessageSentHandler = func([]byte) {}
 	}
 
 	return &WebsocketConnection{
-		connectionID:  config.ConnectionID,
-		origin:        config.Origin,
-		websocketConn: config.WebsocketConn,
-		writeTimeout:  config.WriteTimeout,
-		pingInterval:  config.PingInterval,
-		pongTimeout:   config.PongTimeout,
+		connectionID:     config.ConnectionID,
+		origin:           config.Origin,
+		websocketConn:    config.WebsocketConn,
+		writeTimeout:     config.WriteTimeout,
+		pingInterval:     config.PingInterval,
+		pongTimeout:      config.PongTimeout,
+		maxMessageSize:   config.MaxMessageSize,
+		frameRateLimiter: config.FrameRateLimiter,
 
 		logger:               config.Logger.WithKV("connectionID", config.ConnectionID),
 		onMessageSentHandler: config.OnMessageSentHandler,
@@ -218,6 +244,13 @@ func (conn *WebsocketConnection) Serve(parentCtx context.Context, handleClosure 
 	}
 	conn.ctx = parentCtx
 	conn.mu.Unlock()
+
+	// Cap inbound frame size before any read takes place. Exceeding the limit
+	// causes the next ReadMessage to return *CloseError{Code: 1009} and the
+	// underlying connection sends a close frame to the client.
+	if conn.maxMessageSize > 0 {
+		conn.websocketConn.SetReadLimit(conn.maxMessageSize)
+	}
 
 	// Set up pong handler to refresh read deadline when pong is received from client.
 	// This enables detection of dead connections - if no pong arrives within the timeout
@@ -322,10 +355,24 @@ func (conn *WebsocketConnection) readMessages(handleClosure func(error)) {
 	for {
 		_, messageBytes, err := conn.websocketConn.ReadMessage()
 		if err != nil {
-			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure, websocket.CloseNormalClosure) {
+			switch {
+			case websocket.IsCloseError(err, websocket.CloseMessageTooBig):
+				// Expected attacker / misconfigured-client path. Frame exceeded
+				// SetReadLimit; gorilla already sent close 1009. Treat as
+				// graceful close, not abnormal termination.
+				conn.logger.Warn("inbound frame exceeded MaxMessageSize; closing connection",
+					"error", err,
+					"origin", conn.origin,
+					"max_message_size", conn.maxMessageSize,
+				)
+				handleClosure(nil)
+			case websocket.IsUnexpectedCloseError(err,
+				websocket.CloseGoingAway,
+				websocket.CloseAbnormalClosure,
+				websocket.CloseNormalClosure):
 				conn.logger.Error("WebSocket connection closed with unexpected reason", "error", err)
 				handleClosure(err)
-			} else {
+			default:
 				handleClosure(nil) // Normal closure
 			}
 			return
@@ -334,6 +381,19 @@ func (conn *WebsocketConnection) readMessages(handleClosure func(error)) {
 		if len(messageBytes) == 0 {
 			conn.logger.Debug("received empty message, skipping")
 			continue // Skip empty messages
+		}
+
+		if !conn.frameRateLimiter.Allow(time.Now(), len(messageBytes)) {
+			conn.logger.Warn("frame rate limit exceeded; closing connection",
+				"origin", conn.origin,
+				"frame_bytes", len(messageBytes),
+			)
+			select {
+			case conn.closeConnCh <- struct{}{}:
+			default:
+			}
+			handleClosure(nil)
+			return
 		}
 
 		select {
@@ -348,6 +408,7 @@ func (conn *WebsocketConnection) readMessages(handleClosure func(error)) {
 			case conn.closeConnCh <- struct{}{}:
 			default:
 			}
+			handleClosure(nil)
 			return
 		}
 	}

--- a/pkg/rpc/connection_test.go
+++ b/pkg/rpc/connection_test.go
@@ -115,7 +115,11 @@ func TestWebsocketConnection_Serve_AppliesReadLimit(t *testing.T) {
 	}, 200*time.Millisecond, 5*time.Millisecond)
 }
 
-func TestWebsocketConnection_OversizedFrame_GracefulClose(t *testing.T) {
+// TestWebsocketConnection_LocalReadLimit_GracefulClose simulates the local
+// SetReadLimit hitting on an inbound frame. Gorilla returns ErrReadLimit to
+// the application (and best-effort sends close 1009 to the peer over the wire).
+// The connection must treat this as a graceful close, not an abnormal error.
+func TestWebsocketConnection_LocalReadLimit_GracefulClose(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -123,7 +127,7 @@ func TestWebsocketConnection_OversizedFrame_GracefulClose(t *testing.T) {
 
 	wsConnMock := newGorillaWsConnMock(ctx)
 	cfg := rpc.WebsocketConnectionConfig{
-		ConnectionID:  "conn-oversize",
+		ConnectionID:  "conn-readlimit",
 		WebsocketConn: wsConnMock,
 	}
 	conn, err := rpc.NewWebsocketConnection(cfg)
@@ -132,17 +136,46 @@ func TestWebsocketConnection_OversizedFrame_GracefulClose(t *testing.T) {
 	closureCh := make(chan error, 1)
 	conn.Serve(ctx, func(err error) { closureCh <- err })
 
-	// Simulate gorilla returning CloseMessageTooBig from ReadMessage.
+	wsConnMock.readErrCh <- websocket.ErrReadLimit
+
+	select {
+	case err := <-closureCh:
+		require.NoError(t, err, "ErrReadLimit must close gracefully, not as abnormal error")
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("connection did not close after local read-limit hit")
+	}
+}
+
+// TestWebsocketConnection_PeerInitiated1009_GracefulClose covers the symmetric
+// case: the peer initiates a close with code 1009 (their read limit hit).
+// Gorilla surfaces a *CloseError{1009} on ReadMessage in that case.
+func TestWebsocketConnection_PeerInitiated1009_GracefulClose(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	wsConnMock := newGorillaWsConnMock(ctx)
+	cfg := rpc.WebsocketConnectionConfig{
+		ConnectionID:  "conn-peer1009",
+		WebsocketConn: wsConnMock,
+	}
+	conn, err := rpc.NewWebsocketConnection(cfg)
+	require.NoError(t, err)
+
+	closureCh := make(chan error, 1)
+	conn.Serve(ctx, func(err error) { closureCh <- err })
+
 	wsConnMock.readErrCh <- &websocket.CloseError{
 		Code: websocket.CloseMessageTooBig,
-		Text: "read limit exceeded",
+		Text: "peer-side read limit exceeded",
 	}
 
 	select {
 	case err := <-closureCh:
-		require.NoError(t, err, "1009 must close gracefully, not as abnormal error")
+		require.NoError(t, err, "peer-sent 1009 must close gracefully, not as abnormal error")
 	case <-time.After(500 * time.Millisecond):
-		t.Fatal("connection did not close after oversized frame")
+		t.Fatal("connection did not close after peer-initiated 1009")
 	}
 }
 

--- a/pkg/rpc/connection_test.go
+++ b/pkg/rpc/connection_test.go
@@ -92,6 +92,111 @@ func TestWebsocketConnection_Serve(t *testing.T) {
 	require.Equal(t, 2, wsConnMock.getCalledCloseCount())
 }
 
+func TestWebsocketConnection_Serve_AppliesReadLimit(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	wsConnMock := newGorillaWsConnMock(ctx)
+	cfg := rpc.WebsocketConnectionConfig{
+		ConnectionID:   "conn-readlimit",
+		WebsocketConn:  wsConnMock,
+		MaxMessageSize: 64 * 1024,
+	}
+	conn, err := rpc.NewWebsocketConnection(cfg)
+	require.NoError(t, err)
+
+	conn.Serve(ctx, func(error) {})
+
+	// Read limit must be set before any read happens.
+	require.Eventually(t, func() bool {
+		return wsConnMock.getReadLimit() == 64*1024
+	}, 200*time.Millisecond, 5*time.Millisecond)
+}
+
+func TestWebsocketConnection_OversizedFrame_GracefulClose(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	wsConnMock := newGorillaWsConnMock(ctx)
+	cfg := rpc.WebsocketConnectionConfig{
+		ConnectionID:  "conn-oversize",
+		WebsocketConn: wsConnMock,
+	}
+	conn, err := rpc.NewWebsocketConnection(cfg)
+	require.NoError(t, err)
+
+	closureCh := make(chan error, 1)
+	conn.Serve(ctx, func(err error) { closureCh <- err })
+
+	// Simulate gorilla returning CloseMessageTooBig from ReadMessage.
+	wsConnMock.readErrCh <- &websocket.CloseError{
+		Code: websocket.CloseMessageTooBig,
+		Text: "read limit exceeded",
+	}
+
+	select {
+	case err := <-closureCh:
+		require.NoError(t, err, "1009 must close gracefully, not as abnormal error")
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("connection did not close after oversized frame")
+	}
+}
+
+// stubLimiter rejects after the Nth call. Records every call for assertions.
+type stubLimiter struct {
+	rejectAt int
+	calls    int
+}
+
+func (s *stubLimiter) Allow(_ time.Time, _ int) bool {
+	s.calls++
+	return s.calls < s.rejectAt
+}
+
+func TestWebsocketConnection_RateLimitedFrame_ClosesConnection(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	wsConnMock := newGorillaWsConnMock(ctx)
+	limiter := &stubLimiter{rejectAt: 2} // first frame admits, second rejects
+	cfg := rpc.WebsocketConnectionConfig{
+		ConnectionID:     "conn-ratelimit",
+		WebsocketConn:    wsConnMock,
+		FrameRateLimiter: limiter,
+	}
+	conn, err := rpc.NewWebsocketConnection(cfg)
+	require.NoError(t, err)
+
+	closureCh := make(chan error, 1)
+	conn.Serve(ctx, func(err error) { closureCh <- err })
+
+	// First frame admitted, drained by reader.
+	wsConnMock.addMessageToRead("ok")
+	select {
+	case got := <-conn.RawRequests():
+		require.Equal(t, "ok", string(got))
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("first frame not delivered")
+	}
+
+	// Second frame rejected by limiter → connection should close.
+	wsConnMock.addMessageToRead("blocked")
+
+	select {
+	case err := <-closureCh:
+		require.NoError(t, err, "rate-limit close is graceful")
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("connection did not close after rate-limited frame")
+	}
+	require.Equal(t, 2, limiter.calls, "limiter was consulted for both frames")
+}
+
 func TestWebsocketConnection_ConnectionID(t *testing.T) {
 	t.Parallel()
 
@@ -125,8 +230,10 @@ func TestWebsocketConnection_WriteRawResponse(t *testing.T) {
 type gorillaWsConnMock struct {
 	ctx                context.Context
 	messageToReadCh    chan []byte
+	readErrCh          chan error
 	lastWrittenMessage []byte
 	calledCloseCount   int
+	readLimit          int64
 
 	mu sync.Mutex
 }
@@ -135,6 +242,7 @@ func newGorillaWsConnMock(ctx context.Context) *gorillaWsConnMock {
 	return &gorillaWsConnMock{
 		ctx:             ctx,
 		messageToReadCh: make(chan []byte, 1),
+		readErrCh:       make(chan error, 1),
 	}
 }
 
@@ -145,6 +253,8 @@ func (m *gorillaWsConnMock) ReadMessage() (messageType int, p []byte, err error)
 			Code: websocket.CloseNormalClosure,
 			Text: "context cancelled",
 		}
+	case err := <-m.readErrCh:
+		return 0, nil, err
 	case msg := <-m.messageToReadCh:
 		// Simulate reading a message
 		return websocket.TextMessage, msg, nil
@@ -201,4 +311,18 @@ func (m *gorillaWsConnMock) SetPongHandler(h func(appData string) error) {
 func (m *gorillaWsConnMock) SetReadDeadline(t time.Time) error {
 	// No-op for mock
 	return nil
+}
+
+func (m *gorillaWsConnMock) SetReadLimit(limit int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.readLimit = limit
+}
+
+func (m *gorillaWsConnMock) getReadLimit() int64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.readLimit
 }

--- a/pkg/rpc/connection_test.go
+++ b/pkg/rpc/connection_test.go
@@ -109,10 +109,9 @@ func TestWebsocketConnection_Serve_AppliesReadLimit(t *testing.T) {
 
 	conn.Serve(ctx, func(error) {})
 
-	// Read limit must be set before any read happens.
-	require.Eventually(t, func() bool {
-		return wsConnMock.getReadLimit() == 64*1024
-	}, 200*time.Millisecond, 5*time.Millisecond)
+	// Serve calls SetReadLimit synchronously before spawning any goroutine, so
+	// the limit is observable immediately on return — no polling needed.
+	require.Equal(t, int64(64*1024), wsConnMock.getReadLimit())
 }
 
 // TestWebsocketConnection_LocalReadLimit_GracefulClose simulates the local

--- a/pkg/rpc/connection_test.go
+++ b/pkg/rpc/connection_test.go
@@ -184,7 +184,7 @@ type stubLimiter struct {
 	calls    int
 }
 
-func (s *stubLimiter) Allow(_ time.Time, _ int) bool {
+func (s *stubLimiter) Admit(_ time.Time, _ int) bool {
 	s.calls++
 	return s.calls < s.rejectAt
 }

--- a/pkg/rpc/node.go
+++ b/pkg/rpc/node.go
@@ -134,7 +134,8 @@ type WebsocketNodeConfig struct {
 	WsConnProcessBufferSize int
 	// WsConnMaxMessageSize caps inbound WebSocket frame size in bytes per connection
 	// (default: 128 KiB). Frames exceeding this trigger close 1009 before allocation.
-	// Set <0 to disable (not recommended).
+	// Non-positive values fall back to the default; the cap cannot be disabled at
+	// this layer.
 	WsConnMaxMessageSize int64
 	// NewFrameRateLimiter constructs a per-connection FrameRateLimiter on each
 	// upgrade. nil → no enforcement (NoopFrameRateLimiter is used).

--- a/pkg/rpc/node.go
+++ b/pkg/rpc/node.go
@@ -132,6 +132,13 @@ type WebsocketNodeConfig struct {
 	WsConnWriteBufferSize int
 	// WsConnProcessBufferSize is the capacity of each connection's incoming message queue (default: 10).
 	WsConnProcessBufferSize int
+	// WsConnMaxMessageSize caps inbound WebSocket frame size in bytes per connection
+	// (default: 128 KiB). Frames exceeding this trigger close 1009 before allocation.
+	// Set <0 to disable (not recommended).
+	WsConnMaxMessageSize int64
+	// NewFrameRateLimiter constructs a per-connection FrameRateLimiter on each
+	// upgrade. nil → no enforcement (NoopFrameRateLimiter is used).
+	NewFrameRateLimiter func() FrameRateLimiter
 }
 
 // NewWebsocketNode creates a new WebsocketNode instance with the provided configuration.
@@ -220,6 +227,11 @@ func (wn *WebsocketNode) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	connectionID := uuid.NewString()
 
+	var limiter FrameRateLimiter
+	if wn.cfg.NewFrameRateLimiter != nil {
+		limiter = wn.cfg.NewFrameRateLimiter()
+	}
+
 	connConfig := WebsocketConnectionConfig{
 		ConnectionID:      connectionID,
 		Origin:            r.Header.Get("Origin"),
@@ -227,6 +239,8 @@ func (wn *WebsocketNode) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Logger:            wn.cfg.Logger,
 		ProcessBufferSize: wn.cfg.WsConnProcessBufferSize,
 		WriteBufferSize:   wn.cfg.WsConnWriteBufferSize,
+		MaxMessageSize:    wn.cfg.WsConnMaxMessageSize,
+		FrameRateLimiter:  limiter,
 	}
 	connection, err := NewWebsocketConnection(connConfig)
 	if err != nil {

--- a/pkg/rpc/rate_limiter.go
+++ b/pkg/rpc/rate_limiter.go
@@ -29,7 +29,7 @@ func (NoopFrameRateLimiter) Admit(time.Time, int) bool { return true }
 
 // ByteTokenBucket is a token bucket on bytes read. One bucket per connection.
 // Not safe for concurrent use; the connection's read goroutine is the sole
-// caller of Allow.
+// caller of Admit.
 type ByteTokenBucket struct {
 	bytesPerSec float64
 	burst       float64

--- a/pkg/rpc/rate_limiter.go
+++ b/pkg/rpc/rate_limiter.go
@@ -8,6 +8,13 @@ import "time"
 // connections must be safe for concurrent use.
 //
 // Returning false causes the connection to close.
+//
+// Allocation note: Allow runs after the frame has been read off the wire and
+// allocated on the Go heap. Per-frame size is bounded by SetReadLimit (see
+// WebsocketConnectionConfig.MaxMessageSize), but a burst of N back-to-back
+// max-sized frames can briefly hold up to N * MaxMessageSize bytes per
+// connection before this hook closes it. Burst capacity should be sized with
+// that ceiling in mind.
 type FrameRateLimiter interface {
 	// Allow reports whether a frame of size bytes is permitted at now.
 	Allow(now time.Time, size int) bool

--- a/pkg/rpc/rate_limiter.go
+++ b/pkg/rpc/rate_limiter.go
@@ -1,0 +1,63 @@
+package rpc
+
+import "time"
+
+// FrameRateLimiter decides whether an inbound WebSocket frame is admitted.
+// Implementations attached to a single connection may assume serial access
+// from the connection's read goroutine; implementations shared across
+// connections must be safe for concurrent use.
+//
+// Returning false causes the connection to close.
+type FrameRateLimiter interface {
+	// Allow reports whether a frame of size bytes is permitted at now.
+	Allow(now time.Time, size int) bool
+}
+
+// NoopFrameRateLimiter accepts every frame. Default when no limiter is
+// configured; useful for tests and dev environments.
+type NoopFrameRateLimiter struct{}
+
+// Allow always returns true.
+func (NoopFrameRateLimiter) Allow(time.Time, int) bool { return true }
+
+// ByteTokenBucket is a token bucket on bytes read. One bucket per connection.
+// Not safe for concurrent use; the connection's read goroutine is the sole
+// caller of Allow.
+type ByteTokenBucket struct {
+	bytesPerSec float64
+	burst       float64
+	tokens      float64
+	last        time.Time
+}
+
+// NewByteTokenBucket returns a bucket pre-filled to burst capacity.
+//
+// bytesPerSec is the steady-state refill rate in bytes per second.
+// burst is the maximum bucket size; a single frame larger than burst is
+// always rejected.
+func NewByteTokenBucket(bytesPerSec, burst float64) *ByteTokenBucket {
+	return &ByteTokenBucket{
+		bytesPerSec: bytesPerSec,
+		burst:       burst,
+		tokens:      burst,
+	}
+}
+
+// Allow refills tokens for elapsed time, caps at burst, then debits size.
+// Returns false if size exceeds available tokens.
+func (b *ByteTokenBucket) Allow(now time.Time, size int) bool {
+	if !b.last.IsZero() {
+		b.tokens += now.Sub(b.last).Seconds() * b.bytesPerSec
+		if b.tokens > b.burst {
+			b.tokens = b.burst
+		}
+	}
+	b.last = now
+
+	cost := float64(size)
+	if b.tokens < cost {
+		return false
+	}
+	b.tokens -= cost
+	return true
+}

--- a/pkg/rpc/rate_limiter.go
+++ b/pkg/rpc/rate_limiter.go
@@ -9,23 +9,23 @@ import "time"
 //
 // Returning false causes the connection to close.
 //
-// Allocation note: Allow runs after the frame has been read off the wire and
+// Allocation note: Admit runs after the frame has been read off the wire and
 // allocated on the Go heap. Per-frame size is bounded by SetReadLimit (see
 // WebsocketConnectionConfig.MaxMessageSize), but a burst of N back-to-back
 // max-sized frames can briefly hold up to N * MaxMessageSize bytes per
 // connection before this hook closes it. Burst capacity should be sized with
 // that ceiling in mind.
 type FrameRateLimiter interface {
-	// Allow reports whether a frame of size bytes is permitted at now.
-	Allow(now time.Time, size int) bool
+	// Admit reports whether a frame of size bytes is permitted at now.
+	Admit(now time.Time, size int) bool
 }
 
 // NoopFrameRateLimiter accepts every frame. Default when no limiter is
 // configured; useful for tests and dev environments.
 type NoopFrameRateLimiter struct{}
 
-// Allow always returns true.
-func (NoopFrameRateLimiter) Allow(time.Time, int) bool { return true }
+// Admit always returns true.
+func (NoopFrameRateLimiter) Admit(time.Time, int) bool { return true }
 
 // ByteTokenBucket is a token bucket on bytes read. One bucket per connection.
 // Not safe for concurrent use; the connection's read goroutine is the sole
@@ -50,9 +50,9 @@ func NewByteTokenBucket(bytesPerSec, burst float64) *ByteTokenBucket {
 	}
 }
 
-// Allow refills tokens for elapsed time, caps at burst, then debits size.
+// Admit refills tokens for elapsed time, caps at burst, then debits size.
 // Returns false if size exceeds available tokens.
-func (b *ByteTokenBucket) Allow(now time.Time, size int) bool {
+func (b *ByteTokenBucket) Admit(now time.Time, size int) bool {
 	if !b.last.IsZero() {
 		b.tokens += now.Sub(b.last).Seconds() * b.bytesPerSec
 		if b.tokens > b.burst {

--- a/pkg/rpc/rate_limiter_test.go
+++ b/pkg/rpc/rate_limiter_test.go
@@ -15,8 +15,8 @@ func TestByteTokenBucket_BurstThenEmpty(t *testing.T) {
 	b := rpc.NewByteTokenBucket(1024, 4096)
 	base := time.Unix(0, 0)
 
-	require.True(t, b.Allow(base, 4096), "full burst admitted")
-	require.False(t, b.Allow(base, 1), "empty bucket rejects")
+	require.True(t, b.Admit(base, 4096), "full burst admitted")
+	require.False(t, b.Admit(base, 1), "empty bucket rejects")
 }
 
 func TestByteTokenBucket_Refill(t *testing.T) {
@@ -25,10 +25,10 @@ func TestByteTokenBucket_Refill(t *testing.T) {
 	b := rpc.NewByteTokenBucket(1024, 4096)
 	base := time.Unix(0, 0)
 
-	require.True(t, b.Allow(base, 4096))
-	require.False(t, b.Allow(base, 1))
-	require.True(t, b.Allow(base.Add(time.Second), 1024), "1s of refill admits 1024 bytes")
-	require.False(t, b.Allow(base.Add(time.Second), 1), "bucket emptied again")
+	require.True(t, b.Admit(base, 4096))
+	require.False(t, b.Admit(base, 1))
+	require.True(t, b.Admit(base.Add(time.Second), 1024), "1s of refill admits 1024 bytes")
+	require.False(t, b.Admit(base.Add(time.Second), 1), "bucket emptied again")
 }
 
 func TestByteTokenBucket_BurstCap(t *testing.T) {
@@ -38,15 +38,15 @@ func TestByteTokenBucket_BurstCap(t *testing.T) {
 	base := time.Unix(0, 0)
 
 	// Long idle must not let tokens grow past burst.
-	require.True(t, b.Allow(base.Add(time.Hour), 4096))
-	require.False(t, b.Allow(base.Add(time.Hour), 1))
+	require.True(t, b.Admit(base.Add(time.Hour), 4096))
+	require.False(t, b.Admit(base.Add(time.Hour), 1))
 }
 
 func TestByteTokenBucket_FrameLargerThanBurstRejected(t *testing.T) {
 	t.Parallel()
 
 	b := rpc.NewByteTokenBucket(1024, 4096)
-	require.False(t, b.Allow(time.Unix(0, 0), 4097),
+	require.False(t, b.Admit(time.Unix(0, 0), 4097),
 		"frame larger than burst is always rejected")
 }
 
@@ -56,17 +56,17 @@ func TestByteTokenBucket_PartialRefill(t *testing.T) {
 	b := rpc.NewByteTokenBucket(1000, 1000)
 	base := time.Unix(0, 0)
 
-	require.True(t, b.Allow(base, 1000))
-	require.False(t, b.Allow(base.Add(500*time.Millisecond), 501),
+	require.True(t, b.Admit(base, 1000))
+	require.False(t, b.Admit(base.Add(500*time.Millisecond), 501),
 		"500ms refills 500 bytes, not enough for 501")
-	require.True(t, b.Allow(base.Add(500*time.Millisecond), 500),
+	require.True(t, b.Admit(base.Add(500*time.Millisecond), 500),
 		"500ms refills exactly 500 bytes")
 }
 
-func TestNoopFrameRateLimiter_AllowsAll(t *testing.T) {
+func TestNoopFrameRateLimiter_AdmitsAll(t *testing.T) {
 	t.Parallel()
 
 	var lim rpc.FrameRateLimiter = rpc.NoopFrameRateLimiter{}
-	require.True(t, lim.Allow(time.Now(), 1<<30))
-	require.True(t, lim.Allow(time.Time{}, 0))
+	require.True(t, lim.Admit(time.Now(), 1<<30))
+	require.True(t, lim.Admit(time.Time{}, 0))
 }

--- a/pkg/rpc/rate_limiter_test.go
+++ b/pkg/rpc/rate_limiter_test.go
@@ -1,0 +1,72 @@
+package rpc_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/layer-3/nitrolite/pkg/rpc"
+)
+
+func TestByteTokenBucket_BurstThenEmpty(t *testing.T) {
+	t.Parallel()
+
+	b := rpc.NewByteTokenBucket(1024, 4096)
+	base := time.Unix(0, 0)
+
+	require.True(t, b.Allow(base, 4096), "full burst admitted")
+	require.False(t, b.Allow(base, 1), "empty bucket rejects")
+}
+
+func TestByteTokenBucket_Refill(t *testing.T) {
+	t.Parallel()
+
+	b := rpc.NewByteTokenBucket(1024, 4096)
+	base := time.Unix(0, 0)
+
+	require.True(t, b.Allow(base, 4096))
+	require.False(t, b.Allow(base, 1))
+	require.True(t, b.Allow(base.Add(time.Second), 1024), "1s of refill admits 1024 bytes")
+	require.False(t, b.Allow(base.Add(time.Second), 1), "bucket emptied again")
+}
+
+func TestByteTokenBucket_BurstCap(t *testing.T) {
+	t.Parallel()
+
+	b := rpc.NewByteTokenBucket(1024, 4096)
+	base := time.Unix(0, 0)
+
+	// Long idle must not let tokens grow past burst.
+	require.True(t, b.Allow(base.Add(time.Hour), 4096))
+	require.False(t, b.Allow(base.Add(time.Hour), 1))
+}
+
+func TestByteTokenBucket_FrameLargerThanBurstRejected(t *testing.T) {
+	t.Parallel()
+
+	b := rpc.NewByteTokenBucket(1024, 4096)
+	require.False(t, b.Allow(time.Unix(0, 0), 4097),
+		"frame larger than burst is always rejected")
+}
+
+func TestByteTokenBucket_PartialRefill(t *testing.T) {
+	t.Parallel()
+
+	b := rpc.NewByteTokenBucket(1000, 1000)
+	base := time.Unix(0, 0)
+
+	require.True(t, b.Allow(base, 1000))
+	require.False(t, b.Allow(base.Add(500*time.Millisecond), 501),
+		"500ms refills 500 bytes, not enough for 501")
+	require.True(t, b.Allow(base.Add(500*time.Millisecond), 500),
+		"500ms refills exactly 500 bytes")
+}
+
+func TestNoopFrameRateLimiter_AllowsAll(t *testing.T) {
+	t.Parallel()
+
+	var lim rpc.FrameRateLimiter = rpc.NoopFrameRateLimiter{}
+	require.True(t, lim.Allow(time.Now(), 1<<30))
+	require.True(t, lim.Allow(time.Time{}, 0))
+}


### PR DESCRIPTION
## Summary
- Cap inbound WebSocket frame size at the transport layer via `gorilla.SetReadLimit` (default 128 KiB). Frames over the cap close the connection with code 1009 before any allocation.
- Add a pluggable `FrameRateLimiter` interface (`pkg/rpc/rate_limiter.go`) with a `ByteTokenBucket` implementation. Per-connection byte budget (default 256 KiB/s steady, 1 MiB burst) consulted before each frame is dispatched.
- Wire knobs through `WebsocketNodeConfig` and nitronode `runtime.go` (`NITRONODE_WS_MAX_MESSAGE_SIZE`, `NITRONODE_WS_BYTES_PER_SEC`, `NITRONODE_WS_BYTES_BURST`).
- Unit tests cover bucket burst/refill/cap/overflow + connection behavior on oversized frame and limiter rejection.
- stress-v1 chart picks up the new envs and gains NGINX ingress annotations (`limit-connections`, `limit-rps`, `limit-burst-multiplier`, `proxy-body-size`). Chart README documents the layered defense (Cloudflare → ingress-nginx → app).

## Why
Audit finding: the RPC server unmarshals incoming WebSocket frames before any size or rate check. An unauthenticated attacker could send oversized frames or sustained large traffic and exhaust memory/CPU before the per-message rate-limit middleware ran (it executes inside `processRequests`, after the first JSON unmarshal). The new caps stop the work at the transport layer.

## Companion PR
Pairs with [layer-3/ops#15](https://github.com/layer-3/ops/pull/15) which preserves real client IPs through ingress-nginx so the per-IP annotations on the WebSocket Ingress key on real clients.

## Notable
- Latent bug fixed: `readMessages` did not call `handleClosure` on the queue-full path, so `Serve`'s `wg.Wait` could hang on that exit.
- Defaults sized for browser reload reconnect storms (auth + subscribe ≈ 20 KB / tab) — they clear the bucket instantly.
- Disable the byte-rate cap with `NITRONODE_WS_BYTES_PER_SEC=-1` for canary rollout. Frame size cap stays on regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WebSocket connection hardening with configurable message size limits and per-connection byte-rate limiting to mitigate denial-of-service scenarios.

* **Documentation**
  * Added WebSocket DoS hardening guidance including WAF rate-limiting recommendations and NGINX Ingress configuration examples.

* **Tests**
  * Added comprehensive tests for WebSocket rate limiting and oversized frame handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->