### PR TITLE
chore(gomod): bump Go toolchain to 1.25.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/layer-3/nitrolite
 
-go 1.25.7
+go 1.25.9
 
 require (
 	cloud.google.com/go/kms v1.30.0

--- a/nitronode/Dockerfile
+++ b/nitronode/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS builder
+FROM golang:1.25.9-alpine AS builder
 
 WORKDIR /build
 ENV CGO_ENABLED=1


### PR DESCRIPTION
## Summary

- Bump `go.mod` from `go 1.25.7` → `go 1.25.9`
- Pin `nitronode/Dockerfile` builder from `golang:1.25-alpine` → `golang:1.25.9-alpine`

## Why

`govulncheck` flagged Go standard library issues fixed in `1.25.9` against the previous `1.25.7` pin. CI workflows (`main-pr.yml`, `main-push.yml`, `test-go.yml`) all resolve their toolchain via `go-version-file: go.mod`, so bumping `go.mod` propagates to CI automatically. The Dockerfile previously floated on `1.25-alpine`; pinning to `1.25.9-alpine` makes the production container deterministic and aligned with `go.mod`.

Follow-up to @ihsraham's note on #723 — kept out of that PR to keep the C-01 scope tight.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all packages pass
- [x] `govulncheck ./...` (v1.3.0, DB 2026-04-21) → "No vulnerabilities found."
- [x] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain to version 1.25.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->