### PR TITLE
MF-L01: fix(contracts/ChannelHub): cap ERC20 transfer returndata copy to 32 bytes

### DIFF
--- a/contracts/src/ChannelHub.sol
+++ b/contracts/src/ChannelHub.sol
@@ -1425,16 +1425,27 @@ contract ChannelHub is ReentrancyGuard {
     /// - explicit return value: decoded as uint256, non-zero treated as success.
     ///   Decoding as uint256 (not bool) avoids an abi.decode revert on non-canonical bool encodings
     ///   (e.g. a token returning 2), which would otherwise break _nonRevertingPushFunds' no-revert guarantee.
+    /// Uses assembly with retLen=32 so the EVM only expands caller memory by 32 bytes regardless of actual
+    /// returndata size, preventing memory-expansion OOG from tokens that return oversized data.
+    /// The high-level `(bool, bytes memory) = addr.call(...)` form copies ALL returndata into caller memory
+    /// at caller-gas expense — a malicious token returning 1 MB would exhaust gas before we reach the length check.
     function _trySafeTransfer(address token, address to, uint256 amount) internal returns (bool) {
-        (bool success, bytes memory returnData) =
-            address(token).call{gas: TRANSFER_GAS_LIMIT}(abi.encodeCall(IERC20.transfer, (to, amount)));
+        bytes memory callData = abi.encodeCall(IERC20.transfer, (to, amount));
+        bool success;
+        uint256 rdsize;
+        uint256 retval;
+
+        assembly ("memory-safe") {
+            // retLen=32 caps caller-side memory expansion to 32 bytes; returndatasize() still reflects actual length.
+            // Output written to scratch space (0x00-0x1f), reserved by Solidity's memory layout for transient use.
+            success := call(TRANSFER_GAS_LIMIT, token, 0, add(callData, 0x20), mload(callData), 0x00, 0x20)
+            rdsize := returndatasize()
+            retval := mload(0x00)
+        }
 
         if (!success) return false;
-        if (returnData.length == 0) return address(token).code.length > 0;
-        // Solidity 0.8's ABI decoder validates canonical bool encoding (only 0 or 1 are valid).
-        // A token returning any other non-zero value (e.g. 2, 0xff...ff) would cause abi.decode(..., (bool)) to revert
-        // — propagating out of _nonRevertingPushFunds and breaking its invariant
-        if (returnData.length >= 32) return abi.decode(returnData, (uint256)) != 0;
-        return false;
+        if (rdsize == 0) return address(token).code.length > 0;
+        if (rdsize < 32) return false;
+        return retval != 0;
     }
 }

--- a/contracts/src/ChannelHub.sol
+++ b/contracts/src/ChannelHub.sol
@@ -1425,8 +1425,9 @@ contract ChannelHub is ReentrancyGuard {
     /// - explicit return value: decoded as uint256, non-zero treated as success.
     ///   Decoding as uint256 (not bool) avoids an abi.decode revert on non-canonical bool encodings
     ///   (e.g. a token returning 2), which would otherwise break _nonRevertingPushFunds' no-revert guarantee.
-    /// Uses assembly with retLen=32 so the EVM only expands caller memory by 32 bytes regardless of actual
-    /// returndata size, preventing memory-expansion OOG from tokens that return oversized data.
+    /// Uses assembly to write the call output directly to scratch space (0x00-0x1f).
+    /// That range is already within the memory expanded by the preceding abi.encodeCall(), so no
+    /// additional memory expansion occurs regardless of actual returndata size.
     /// The high-level `(bool, bytes memory) = addr.call(...)` form copies ALL returndata into caller memory
     /// at caller-gas expense — a malicious token returning 1 MB would exhaust gas before we reach the length check.
     function _trySafeTransfer(address token, address to, uint256 amount) internal returns (bool) {
@@ -1436,8 +1437,7 @@ contract ChannelHub is ReentrancyGuard {
         uint256 retval;
 
         assembly ("memory-safe") {
-            // retLen=32 caps caller-side memory expansion to 32 bytes; returndatasize() still reflects actual length.
-            // Output written to scratch space (0x00-0x1f), reserved by Solidity's memory layout for transient use.
+            // Output to scratch space (0x00-0x1f); returndatasize() still reflects the full returndata length.
             success := call(TRANSFER_GAS_LIMIT, token, 0, add(callData, 0x20), mload(callData), 0x00, 0x20)
             rdsize := returndatasize()
             retval := mload(0x00)

--- a/contracts/test/ChannelHub_nonRevertingPushFunds.t.sol
+++ b/contracts/test/ChannelHub_nonRevertingPushFunds.t.sol
@@ -204,6 +204,33 @@ contract ChannelHubTest_nonRevertingPushFunds is Test {
         _verifyBalancesNotChanged(recipient, address(oversizedToken), TRANSFER_AMOUNT);
     }
 
+    // Covers the rdsize ∈ [1, 31] branch of _trySafeTransfer.
+    // Any response shorter than 32 bytes is rejected as failure regardless of content —
+    // a valid ERC20 bool is always a full 32-byte ABI word.
+    function test_accumulatesReclaims_whenERC20ReturnsShortData() public {
+        OversizedReturnERC20 shortToken = new OversizedReturnERC20(16, 0);
+        shortToken.mint(address(cHub), BALANCE_AMOUNT);
+
+        vm.expectEmit(true, true, false, true);
+        emit ChannelHub.TransferFailed(recipient, address(shortToken), TRANSFER_AMOUNT);
+
+        cHub.exposed_nonRevertingPushFunds(recipient, address(shortToken), TRANSFER_AMOUNT);
+
+        _verifyBalancesNotChanged(recipient, address(shortToken), TRANSFER_AMOUNT);
+    }
+
+    // Covers rdsize == 32 with a non-canonical bool value (2).
+    // abi.decode(..., (bool)) reverts on value 2 — Solidity 0.8 only accepts 0 or 1.
+    // Decoding as uint256 and checking != 0 handles this correctly without reverting.
+    function test_succeeds_whenERC20ReturnsNonCanonicalBoolValue() public {
+        OversizedReturnERC20 nonCanonicalToken = new OversizedReturnERC20(32, 2);
+        nonCanonicalToken.mint(address(cHub), BALANCE_AMOUNT);
+
+        cHub.exposed_nonRevertingPushFunds(recipient, address(nonCanonicalToken), TRANSFER_AMOUNT);
+
+        _verifyTransferSuccess(recipient, address(nonCanonicalToken), TRANSFER_AMOUNT);
+    }
+
     // ========== ERC777 Donation-Back Tests ==========
 
     function test_succeeds_whenERC777DonatesBack() public {

--- a/contracts/test/ChannelHub_nonRevertingPushFunds.t.sol
+++ b/contracts/test/ChannelHub_nonRevertingPushFunds.t.sol
@@ -176,6 +176,33 @@ contract ChannelHubTest_nonRevertingPushFunds is Test {
 
     // ========== Oversized Return Data ERC20 Tests ==========
 
+    // Regression pin for the SC-L01 audit finding.
+    // The existing oversized-data tests verify behavioural correctness but still pass if the old
+    // high-level `(bool, bytes memory) = addr.call(...)` form is restored, because Foundry's default
+    // gas budget is far too large to trigger OOG.  This test calls with a tight external gas cap so
+    // that the old copy path runs out of gas while the assembly fix passes comfortably.
+    //
+    // Budget breakdown (Berlin EVM, 80 000 gas forwarded to exposed_nonRevertingPushFunds):
+    //   function overhead + nonReentrant SSTORE + abi.encodeCall : ~11 000 gas
+    //   63/64 rule → forwarded to token                           : 67 922 gas
+    //   token execution (100 KB memory expansion, no SSTORE)      : ~28 500 gas (returned: 39 422)
+    //   caller gas after CALL (kept 1/64 + returned)              : ~40 500 gas
+    //   ── new code post-call (cold reclaim SSTORE + emit)         : ~26 250 → 14 250 spare → PASSES
+    //   ── old code extra (memory expand + RETURNDATACOPY 100 KB)  : ~38 072 → needs 64 322 → OOGs
+    function test_doesNotOOG_withTightGas_whenERC20ReturnsLargeData() public {
+        OversizedReturnERC20 largeToken = new OversizedReturnERC20(100_000, 0);
+        largeToken.mint(address(cHub), BALANCE_AMOUNT);
+
+        (bool ok,) = address(cHub).call{gas: 80_000}(
+            abi.encodeCall(
+                TestChannelHub.exposed_nonRevertingPushFunds, (recipient, address(largeToken), TRANSFER_AMOUNT)
+            )
+        );
+
+        assertTrue(ok, "assembly path must not OOG: old high-level copy costs ~38k extra gas");
+        assertEq(cHub.getReclaimBalance(recipient, address(largeToken)), TRANSFER_AMOUNT, "reclaim must be written");
+    }
+
     // Covers the rdsize > 32, retval != 0 branch of _trySafeTransfer.
     // With the old high-level (bool, bytes memory) call form, a token returning a large buffer
     // would exhaust caller gas during returndata copy before we could inspect the length.

--- a/contracts/test/ChannelHub_nonRevertingPushFunds.t.sol
+++ b/contracts/test/ChannelHub_nonRevertingPushFunds.t.sol
@@ -10,6 +10,7 @@ import {RevertingERC20} from "./mocks/RevertingERC20.sol";
 import {GasConsumingERC20} from "./mocks/GasConsumingERC20.sol";
 import {MalformedReturningERC20} from "./mocks/MalformedReturningERC20.sol";
 import {DonatingERC20} from "./mocks/DonatingERC20.sol";
+import {OversizedReturnERC20} from "./mocks/OversizedReturnERC20.sol";
 import {RevertingEthReceiver} from "./mocks/RevertingEthReceiver.sol";
 import {GasConsumingEthReceiver} from "./mocks/GasConsumingEthReceiver.sol";
 
@@ -171,6 +172,36 @@ contract ChannelHubTest_nonRevertingPushFunds is Test {
         cHub.exposed_nonRevertingPushFunds(recipient, address(malformedToken), TRANSFER_AMOUNT);
 
         _verifyBalancesNotChanged(recipient, address(malformedToken), TRANSFER_AMOUNT);
+    }
+
+    // ========== Oversized Return Data ERC20 Tests ==========
+
+    // Covers the rdsize > 32, retval != 0 branch of _trySafeTransfer.
+    // With the old high-level (bool, bytes memory) call form, a token returning a large buffer
+    // would exhaust caller gas during returndata copy before we could inspect the length.
+    // The assembly fix caps the copy to 32 bytes, so the first word is read and the transfer succeeds.
+    function test_succeeds_whenERC20ReturnsOversizedDataWithNonzeroValue() public {
+        OversizedReturnERC20 oversizedToken = new OversizedReturnERC20(10_240, 1);
+        oversizedToken.mint(address(cHub), BALANCE_AMOUNT);
+
+        cHub.exposed_nonRevertingPushFunds(recipient, address(oversizedToken), TRANSFER_AMOUNT);
+
+        _verifyTransferSuccess(recipient, address(oversizedToken), TRANSFER_AMOUNT);
+    }
+
+    // Covers the rdsize > 32, retval == 0 branch of _trySafeTransfer.
+    // Oversized returndata with a zero first word must be treated as failure and accumulate reclaims,
+    // not revert.
+    function test_accumulatesReclaims_whenERC20ReturnsOversizedDataWithZeroValue() public {
+        OversizedReturnERC20 oversizedToken = new OversizedReturnERC20(10_240, 0);
+        oversizedToken.mint(address(cHub), BALANCE_AMOUNT);
+
+        vm.expectEmit(true, true, false, true);
+        emit ChannelHub.TransferFailed(recipient, address(oversizedToken), TRANSFER_AMOUNT);
+
+        cHub.exposed_nonRevertingPushFunds(recipient, address(oversizedToken), TRANSFER_AMOUNT);
+
+        _verifyBalancesNotChanged(recipient, address(oversizedToken), TRANSFER_AMOUNT);
     }
 
     // ========== ERC777 Donation-Back Tests ==========

--- a/contracts/test/mocks/MalformedReturningERC20.sol
+++ b/contracts/test/mocks/MalformedReturningERC20.sol
@@ -17,7 +17,11 @@ contract MalformedReturningERC20 is ERC20 {
         // Return only 1 byte instead of 32 (malformed) WITHOUT actually transferring
         // This simulates a malicious/buggy token that returns invalid data
         assembly {
-            mstore(0, 1)
+            // mstore8 writes a single byte (0x01) to address 0.
+            // mstore(0, 1) would write the value 1 as a 32-byte big-endian word,
+            // placing 0x01 at address 31 and 0x00 at address 0 — so return(0, 1)
+            // would yield 0x00, not 0x01. mstore8 avoids this by writing exactly one byte.
+            mstore8(0, 1)
             return(0, 1)
         }
     }
@@ -26,7 +30,11 @@ contract MalformedReturningERC20 is ERC20 {
         // Return only 1 byte instead of 32 (malformed) WITHOUT actually transferring
         // This simulates a malicious/buggy token that returns invalid data
         assembly {
-            mstore(0, 1)
+            // mstore8 writes a single byte (0x01) to address 0.
+            // mstore(0, 1) would write the value 1 as a 32-byte big-endian word,
+            // placing 0x01 at address 31 and 0x00 at address 0 — so return(0, 1)
+            // would yield 0x00, not 0x01. mstore8 avoids this by writing exactly one byte.
+            mstore8(0, 1)
             return(0, 1)
         }
     }

--- a/contracts/test/mocks/OversizedReturnERC20.sol
+++ b/contracts/test/mocks/OversizedReturnERC20.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.30;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/**
+ * @title OversizedReturnERC20
+ * @notice Mock ERC20 whose transfer() returns `returnDataSize` bytes with `firstWord` as the first word.
+ * @dev Used to verify that _trySafeTransfer caps returndata copy to 32 bytes, preventing
+ *      memory-expansion OOG when a token returns an oversized buffer.
+ *      The actual transfer is performed only when firstWord != 0, matching normal token semantics
+ *      (a zero return value signals failure without a state change).
+ */
+contract OversizedReturnERC20 is ERC20 {
+    uint256 private immutable RETURN_DATA_SIZE;
+    uint256 private immutable FIRST_WORD;
+
+    constructor(uint256 returnDataSize, uint256 firstWord) ERC20("Oversized Token", "OVR") {
+        RETURN_DATA_SIZE = returnDataSize;
+        FIRST_WORD = firstWord;
+    }
+
+    function transfer(address to, uint256 amount) public override returns (bool) {
+        if (FIRST_WORD != 0) {
+            _transfer(msg.sender, to, amount);
+        }
+
+        uint256 size = RETURN_DATA_SIZE;
+        uint256 word = FIRST_WORD;
+        assembly {
+            let ptr := mload(0x40)
+            mstore(ptr, word)
+            // EVM zero-initialises newly expanded memory, so bytes [32, size) are 0x00.
+            return(ptr, size)
+        }
+    }
+
+    function mint(address to, uint256 amount) public {
+        _mint(to, amount);
+    }
+}


### PR DESCRIPTION
## Security audit finding

**Severity:** Low  
**Location:** `ChannelHub._trySafeTransfer`

The original implementation used the high-level Solidity call form:

```solidity
(bool success, bytes memory returnData) =
    address(token).call{gas: TRANSFER_GAS_LIMIT}(abi.encodeCall(IERC20.transfer, (to, amount)));
```

`TRANSFER_GAS_LIMIT` correctly caps the gas forwarded to the callee, but the returndata copy happens in the **caller's** context after the call returns. Solidity compiles the `bytes memory returnData` capture into three steps — `RETURNDATASIZE`, memory allocation of `returndata_size + 32` bytes, and `RETURNDATACOPY` over the full buffer — all paid from the caller's (ChannelHub's) remaining gas, not from the capped budget.

A malicious or non-compliant token can return an arbitrarily large buffer from `transfer()`. This triggers quadratic memory expansion in ChannelHub before `returnData.length` is ever checked, causing `_trySafeTransfer` to OOG and revert rather than return `false`. The revert propagates through `_nonRevertingPushFunds`, breaking its non-reverting guarantee and blocking channel settlement paths (close, challenge response, escrow finalization).

## Fix

Replaced the high-level call with an assembly block that writes at most 32 bytes of output to Solidity scratch space (`0x00–0x1f`):

```solidity
bytes memory callData = abi.encodeCall(IERC20.transfer, (to, amount));

assembly ("memory-safe") {
    // Output to scratch space (0x00-0x1f); returndatasize() still reflects the full returndata length.
    success := call(TRANSFER_GAS_LIMIT, token, 0, add(callData, 0x20), mload(callData), 0x00, 0x20)
    rdsize := returndatasize()
    retval := mload(0x00)
}
```

Key properties:
- `retLen = 0x20` in the `call` opcode limits the output buffer to 32 bytes; EVM memory expansion is bounded by `retOffset + retLen = 0x20`, not by actual returndata size.
- `returndatasize()` still reflects the full length of the token's response, used to distinguish no-return-value tokens (`rdsize == 0`) from truncated responses (`rdsize < 32`).
- The scratch space range `0x00–0x1f` is already within the memory expanded by the preceding `abi.encodeCall()`, so no additional expansion occurs.
- `abi.encodeCall` is used for calldata encoding (type-checked selector, no hardcoded magic constant).

## Tests added

Two new tests cover the previously untested branches, plus two regression pins:

| Test | Branch |
|---|---|
| `test_succeeds_whenERC20ReturnsOversizedDataWithNonzeroValue` | `rdsize > 32`, nonzero first word → success |
| `test_accumulatesReclaims_whenERC20ReturnsOversizedDataWithZeroValue` | `rdsize > 32`, zero first word → reclaim |
| `test_accumulatesReclaims_whenERC20ReturnsShortData` | `rdsize ∈ [1, 31]` → failure regardless of content |
| `test_succeeds_whenERC20ReturnsNonCanonicalBoolValue` | `rdsize == 32`, value `2` → treated as success (not ABI decode revert) |

Also fixed a pre-existing bug in `MalformedReturningERC20`: `mstore(0, 1); return(0, 1)` was returning byte `0x00` (the MSB of the big-endian word) instead of `0x01`. Replaced with `mstore8(0, 1)`.