### PR TITLE
MF-I01-I02: fix(contracts): address security audit findings I-01 and I-02

### DIFF
--- a/contracts/src/ChannelHub.sol
+++ b/contracts/src/ChannelHub.sol
@@ -337,7 +337,7 @@ contract ChannelHub is ReentrancyGuard {
     function withdrawFromNode(address to, address token, uint256 amount) external {
         require(to != address(0), InvalidAddress());
         require(amount > 0, IncorrectAmount());
-        require(msg.sender == NODE, IncorrectNode());
+        require(msg.sender == NODE, IncorrectMsgSender());
 
         uint256 currentBalance = _nodeBalances[token];
         require(currentBalance >= amount, InsufficientBalance());
@@ -477,8 +477,10 @@ contract ChannelHub is ReentrancyGuard {
     /**
      * @notice Register a signature validator for NODE using signature-based authorization
      * @dev Anyone can submit this transaction with a valid NODE signature, enabling relayer-friendly registration.
-     *      NODE's private key only signs the registration data, never sends transactions directly.
-     *      This allows NODE to use cold storage or HSMs without exposing keys to transaction submission.
+     *      For this function only, NODE's private key only signs the registration data and does not need to send
+     *      the transaction directly, allowing cold storage or HSM usage without exposing keys to transaction submission.
+     *      Other NODE-gated operations (withdrawFromNode, home-chain initiateEscrowDeposit, challengeChannel with
+     *      INITIATE_ESCROW_DEPOSIT) still require NODE to be msg.sender and are not relayer-compatible.
      *      The signature includes block.chainid and address(this) to prevent cross-chain and cross-deployment replay attacks.
      * @param validatorId The validator ID (0x01-0xFF, 0x00 reserved for DEFAULT)
      * @param validator The validator contract address

--- a/contracts/src/ChannelHub.sol
+++ b/contracts/src/ChannelHub.sol
@@ -479,8 +479,10 @@ contract ChannelHub is ReentrancyGuard {
      * @dev Anyone can submit this transaction with a valid NODE signature, enabling relayer-friendly registration.
      *      For this function only, NODE's private key only signs the registration data and does not need to send
      *      the transaction directly, allowing cold storage or HSM usage without exposing keys to transaction submission.
-     *      Other NODE-gated operations (withdrawFromNode, home-chain initiateEscrowDeposit, challengeChannel with
-     *      INITIATE_ESCROW_DEPOSIT) still require NODE to be msg.sender and are not relayer-compatible.
+     *      Other NODE-gated operations (withdrawFromNode, home-chain initiateEscrowDeposit, and submitting
+     *      a new INITIATE_ESCROW_DEPOSIT state via challengeChannel) still require NODE to be msg.sender
+     *      and are not relayer-compatible. Note: challenging with the same-version INITIATE_ESCROW_DEPOSIT
+     *      state (already-processed path) is open to any caller, as it only sets the DISPUTED flag.
      *      The signature includes block.chainid and address(this) to prevent cross-chain and cross-deployment replay attacks.
      * @param validatorId The validator ID (0x01-0xFF, 0x00 reserved for DEFAULT)
      * @param validator The validator contract address

--- a/contracts/src/Utils.sol
+++ b/contracts/src/Utils.sol
@@ -33,9 +33,12 @@ library Utils {
     function getEscrowId(bytes32 channelId, uint64 version) internal pure returns (bytes32 escrowId) {
         // "channelId, (state-)version" pair is unique as long as participants do not reuse versions
         // Uses the 64-byte scratch space (0x00–0x3f) to avoid a heap allocation.
+        // Mask version to 64 bits: mstore writes the full 256-bit stack word, and Solidity does
+        // not guarantee that internal call arguments are cleaned for sub-256-bit types. Without
+        // the mask, dirty high bits would produce a hash that diverges from abi.encode(channelId, version).
         assembly ("memory-safe") {
             mstore(0x00, channelId)
-            mstore(0x20, version)
+            mstore(0x20, and(version, 0xffffffffffffffff))
             escrowId := keccak256(0x00, 0x40)
         }
     }

--- a/contracts/src/Utils.sol
+++ b/contracts/src/Utils.sol
@@ -17,11 +17,12 @@ library Utils {
     error FailedToFetchDecimals();
 
     function getChannelId(ChannelDefinition memory def, uint8 version) internal pure returns (bytes32 channelId) {
-        bytes32 baseId = keccak256(abi.encode(def));
-
         assembly ("memory-safe") {
+            // ChannelDefinition has 6 static fields × 32 bytes = 192 (0xC0) bytes in memory.
+            // Memory layout is identical to abi.encode for structs with only value types, so we
+            // hash the struct pointer directly, avoiding the abi.encode allocation.
+            let baseId := keccak256(def, 0xC0)
             // Store the version in the first byte (most significant byte) of the channelId
-            // Clear the first byte of baseId, then set it to version
             channelId := or(
                 and(baseId, 0x00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff),
                 shl(248, version)
@@ -29,9 +30,14 @@ library Utils {
         }
     }
 
-    function getEscrowId(bytes32 channelId, uint64 version) internal pure returns (bytes32) {
+    function getEscrowId(bytes32 channelId, uint64 version) internal pure returns (bytes32 escrowId) {
         // "channelId, (state-)version" pair is unique as long as participants do not reuse versions
-        return keccak256(abi.encode(channelId, version));
+        // Uses the 64-byte scratch space (0x00–0x3f) to avoid a heap allocation.
+        assembly ("memory-safe") {
+            mstore(0x00, channelId)
+            mstore(0x20, version)
+            escrowId := keccak256(0x00, 0x40)
+        }
     }
 
     function getValidatorRegistrationMessage(address channelHub, uint8 validatorId, address validator)

--- a/contracts/src/interfaces/Types.sol
+++ b/contracts/src/interfaces/Types.sol
@@ -8,6 +8,9 @@ enum ParticipantIndex {
     NODE
 }
 
+// INVARIANT: Utils.getChannelId hashes the raw memory layout of this struct using the
+// hardcoded size 0xC0 (6 fields × 32 bytes). Adding or removing fields requires updating
+// that constant; failing to do so silently produces wrong channelIds.
 struct ChannelDefinition {
     uint32 challengeDuration;
     address user;

--- a/contracts/test/ChannelHub_Node.t.sol
+++ b/contracts/test/ChannelHub_Node.t.sol
@@ -24,6 +24,12 @@ contract ChannelHubTest_withdrawFromNode is ChannelHubTest_Base {
 
     // ========== Input Validation ==========
 
+    function test_reverts_whenCallerIsNotNode() public {
+        vm.prank(alice);
+        vm.expectRevert(ChannelHub.IncorrectMsgSender.selector);
+        cHub.withdrawFromNode(recipient, address(token), DEPOSIT_AMOUNT);
+    }
+
     function test_reverts_whenToIsZeroAddress() public {
         vm.prank(node);
         vm.expectRevert(ChannelHub.InvalidAddress.selector);

--- a/contracts/test/ChannelHub_challenge/ChannelHub_challengeSessionKeyValidator.t.sol
+++ b/contracts/test/ChannelHub_challenge/ChannelHub_challengeSessionKeyValidator.t.sol
@@ -25,6 +25,7 @@ abstract contract ChannelHubTest_Challenge_SkApproved_Base is ChannelHubTest_Cha
             user: alice,
             node: node,
             nonce: NONCE,
+            // forge-lint: disable-next-line(incorrect-shift) -- intentional bitmask: 1 << N sets bit N
             approvedSignatureValidators: 1 << SESSION_KEY_VALIDATOR_ID,
             metadata: bytes32(0)
         });

--- a/contracts/test/ChannelHub_lifecycle/ChannelHub_singlechain.lifecycle.t.sol
+++ b/contracts/test/ChannelHub_lifecycle/ChannelHub_singlechain.lifecycle.t.sol
@@ -11,6 +11,7 @@ import {TestUtils, SESSION_KEY_VALIDATOR_ID} from "../TestUtils.sol";
 contract ChannelHubTest_SingleChain_Lifecycle is ChannelHubTest_Base {
     function test_happyPath() public {
         // Approve SessionKeyValidator (ID 1) for user signatures by setting bit 1
+        // forge-lint: disable-next-line(incorrect-shift) -- intentional bitmask: 1 << N sets bit N
         uint256 approvedValidators = 1 << SESSION_KEY_VALIDATOR_ID; // Bit 1 = 1
 
         ChannelDefinition memory def = ChannelDefinition({

--- a/contracts/test/ChannelHub_sigValidator.t.sol
+++ b/contracts/test/ChannelHub_sigValidator.t.sol
@@ -102,6 +102,7 @@ contract ChannelHubTest_RegisterNodeValidator is ChannelHubTest_SigValidator_Bas
 contract ChannelHubTest_ExtractValidator is ChannelHubTest_SigValidator_Base {
     /// @dev approvedSignatureValidators bitmask with bit `id` set.
     function _approved(uint8 id) internal pure returns (uint256) {
+        // forge-lint: disable-next-line(incorrect-shift) -- intentional bitmask: 1 << N sets bit N
         return 1 << id;
     }
 

--- a/contracts/test/Utils.t.sol
+++ b/contracts/test/Utils.t.sol
@@ -154,6 +154,27 @@ contract UtilsTest is Test {
         console.logBytes32(channelId);
     }
 
+    function test_getChannelId_matchesAbiEncodePath() public pure {
+        ChannelDefinition memory def = ChannelDefinition({
+            challengeDuration: 86400,
+            user: 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045,
+            node: 0x435d4B6b68e1083Cc0835D1F971C4739204C1d2a,
+            nonce: 42,
+            approvedSignatureValidators: 24042,
+            metadata: 0x13730b0d8e1bdbdc000000000000000000000000000000000000000000000000
+        });
+        uint8 version = 1;
+
+        // Reproduce the pre-assembly path: keccak256(abi.encode(def)) + version in first byte
+        bytes32 baseId = keccak256(abi.encode(def));
+        bytes32 expected = bytes32(
+            (uint256(baseId) & 0x00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
+                | (uint256(version) << 248)
+        );
+
+        assertEq(Utils.getChannelId(def, version), expected);
+    }
+
     function test_log_calculateEscrowId() public pure {
         bytes32 channelId = 0xeac2bed767671a8ab77527e1e2fff00bb2e62de5467d9ba3a4105dad5c6e3d66;
         uint64 version = 42;


### PR DESCRIPTION
## Security audit findings

### I-01 — Wrong error selector in `withdrawFromNode`

`withdrawFromNode()` guarded `msg.sender == NODE` with `IncorrectNode()`. The contract's convention is:

- `IncorrectNode()` — data validation: `def.node != NODE` in `_requireValidDefinition`
- `IncorrectMsgSender()` — caller auth: `msg.sender != NODE`

Using the wrong selector made the revert misleading to integrators doing error-based retry logic or monitoring, and was inconsistent with all other `msg.sender` guards in the contract (`challengeChannel`, `initiateEscrowDeposit`).

**Fix:** `IncorrectNode()` → `IncorrectMsgSender()` in `withdrawFromNode()`.
**Test added:** `test_reverts_whenCallerIsNotNode` asserts the correct selector.

---

### I-02 — Misleading NatSpec on `registerNodeValidator`

The `@dev` comment stated *"NODE's private key only signs the registration data, never sends transactions directly"* — a property true only for `registerNodeValidator` (relayer-friendly via off-chain signature), but not for the protocol as a whole. Three other functions require `NODE` as `msg.sender`:

- `withdrawFromNode`
- home-chain path of `initiateEscrowDeposit`
- new-version path of `challengeChannel` with `INITIATE_ESCROW_DEPOSIT`

Reading the comment as a protocol-wide guarantee produced a wrong trust model for integrators building relayer infrastructure.

**Fix:** Narrowed the NatSpec to scope the relayer-friendly claim to `registerNodeValidator` only; listed the three NODE-gated operations explicitly; clarified that the `challengeChannel` guard applies only to the new-version (state-advancing) path, not the same-version (already-processed) path.

---

## Additional changes

- **`perf`** `Utils.sol`: replaced `keccak256(abi.encode(...))` with inline assembly in `getChannelId` and `getEscrowId`, eliminating heap allocations. ~350–580 gas saved avg on `createChannel`, `initiateEscrow*`, `initiateMigration`; −170 bytes deployed bytecode. Added `INVARIANT` warning at `ChannelDefinition` in `Types.sol`: the hardcoded struct size `0xC0` must be updated if fields are added or removed.
- **`fix`** Suppressed three `forge-lint incorrect-shift` false positives in test files (bitmask construction `1 << N` is intentional; linter cannot infer semantic intent).
- **`fix`** Resolved `/review` findings: struct-size invariant comment, NatSpec same-version-path clarification, `test_reverts_whenCallerIsNotNode` test.

## Test plan

- [x] `forge test` — 269/269 pass
- [x] `forge lint` — zero warnings, zero notes
- [x] `withdrawFromNode` non-NODE caller reverts with `IncorrectMsgSender` (new test)