### PR TITLE
MF-M01: backfill state user_sig from on-chain events

### DIFF
--- a/nitronode/event_handlers/service.go
+++ b/nitronode/event_handlers/service.go
@@ -64,6 +64,10 @@ func (s *EventHandlerService) HandleHomeChannelCreated(ctx context.Context, tx c
 		return err
 	}
 
+	if err := tx.UpdateStateUserSigIfMissing(event.ChannelID, event.StateVersion, event.UserSig); err != nil {
+		return err
+	}
+
 	logger.Info("handled HomeChannelCreated event", "channelId", event.ChannelID, "stateVersion", event.StateVersion, "userWallet", channel.UserWallet)
 	return nil
 }
@@ -107,6 +111,10 @@ func (s *EventHandlerService) HandleHomeChannelCheckpointed(ctx context.Context,
 	}
 
 	if err := tx.RefreshUserEnforcedBalance(channel.UserWallet, channel.Asset); err != nil {
+		return err
+	}
+
+	if err := tx.UpdateStateUserSigIfMissing(event.ChannelID, event.StateVersion, event.UserSig); err != nil {
 		return err
 	}
 
@@ -158,6 +166,10 @@ func (s *EventHandlerService) HandleHomeChannelChallenged(ctx context.Context, t
 		return err
 	}
 
+	if err := tx.UpdateStateUserSigIfMissing(event.ChannelID, event.StateVersion, event.UserSig); err != nil {
+		return err
+	}
+
 	logger.Warn("home channel challenged",
 		"channelId", chanID,
 		"userWallet", channel.UserWallet,
@@ -196,6 +208,10 @@ func (s *EventHandlerService) HandleHomeChannelClosed(ctx context.Context, tx co
 	}
 
 	if err := tx.RefreshUserEnforcedBalance(channel.UserWallet, channel.Asset); err != nil {
+		return err
+	}
+
+	if err := tx.UpdateStateUserSigIfMissing(event.ChannelID, event.StateVersion, event.UserSig); err != nil {
 		return err
 	}
 
@@ -239,6 +255,10 @@ func (s *EventHandlerService) HandleEscrowDepositInitiated(ctx context.Context, 
 		if err := tx.ScheduleInitiateEscrowDeposit(state.ID, state.HomeLedger.BlockchainID); err != nil {
 			return err
 		}
+	}
+
+	if err := tx.UpdateStateUserSigIfMissing(event.ChannelID, event.StateVersion, event.UserSig); err != nil {
+		return err
 	}
 
 	logger.Info("handled EscrowDepositInitiated event", "channelId", event.ChannelID, "stateVersion", event.StateVersion, "userWallet", channel.UserWallet)
@@ -298,6 +318,10 @@ func (s *EventHandlerService) HandleEscrowDepositChallenged(ctx context.Context,
 		}
 	}
 
+	if err := tx.UpdateStateUserSigIfMissing(event.ChannelID, event.StateVersion, event.UserSig); err != nil {
+		return err
+	}
+
 	logger.Info("handled EscrowDepositChallenged event", "channelId", event.ChannelID, "stateVersion", event.StateVersion, "userWallet", channel.UserWallet)
 	return nil
 }
@@ -328,6 +352,10 @@ func (s *EventHandlerService) HandleEscrowDepositFinalized(ctx context.Context, 
 		return err
 	}
 
+	if err := tx.UpdateStateUserSigIfMissing(event.ChannelID, event.StateVersion, event.UserSig); err != nil {
+		return err
+	}
+
 	logger.Info("handled EscrowDepositFinalized event", "channelId", event.ChannelID, "stateVersion", event.StateVersion, "userWallet", channel.UserWallet)
 	return nil
 }
@@ -355,6 +383,10 @@ func (s *EventHandlerService) HandleEscrowWithdrawalInitiated(ctx context.Contex
 	channel.Status = core.ChannelStatusOpen
 
 	if err := tx.UpdateChannel(*channel); err != nil {
+		return err
+	}
+
+	if err := tx.UpdateStateUserSigIfMissing(event.ChannelID, event.StateVersion, event.UserSig); err != nil {
 		return err
 	}
 
@@ -414,6 +446,10 @@ func (s *EventHandlerService) HandleEscrowWithdrawalChallenged(ctx context.Conte
 		}
 	}
 
+	if err := tx.UpdateStateUserSigIfMissing(event.ChannelID, event.StateVersion, event.UserSig); err != nil {
+		return err
+	}
+
 	logger.Info("handled EscrowWithdrawalChallenged event", "channelId", event.ChannelID, "stateVersion", event.StateVersion, "userWallet", channel.UserWallet)
 	return nil
 }
@@ -441,6 +477,10 @@ func (s *EventHandlerService) HandleEscrowWithdrawalFinalized(ctx context.Contex
 	channel.Status = core.ChannelStatusClosed
 
 	if err := tx.UpdateChannel(*channel); err != nil {
+		return err
+	}
+
+	if err := tx.UpdateStateUserSigIfMissing(event.ChannelID, event.StateVersion, event.UserSig); err != nil {
 		return err
 	}
 

--- a/nitronode/event_handlers/service_test.go
+++ b/nitronode/event_handlers/service_test.go
@@ -47,6 +47,7 @@ func TestHandleHomeChannelCreated_Success(t *testing.T) {
 			ch.StateVersion == 1
 	})).Return(nil)
 	mockStore.On("RefreshUserEnforcedBalance", userWallet, "usdc").Return(nil)
+	mockStore.On("UpdateStateUserSigIfMissing", channelID, uint64(1), "").Return(nil)
 
 	// Execute
 	err := service.HandleHomeChannelCreated(ctx, mockStore, event)
@@ -91,6 +92,7 @@ func TestHandleHomeChannelCheckpointed_Success(t *testing.T) {
 			ch.StateVersion == 5
 	})).Return(nil)
 	mockStore.On("RefreshUserEnforcedBalance", userWallet, "usdc").Return(nil)
+	mockStore.On("UpdateStateUserSigIfMissing", channelID, uint64(5), "").Return(nil)
 
 	// Execute
 	err := service.HandleHomeChannelCheckpointed(ctx, mockStore, event)
@@ -138,6 +140,7 @@ func TestHandleHomeChannelChallenged_PersistsChallenge(t *testing.T) {
 			ch.ChallengeExpiresAt.Unix() == int64(challengeExpiry)
 	})).Return(nil)
 	mockStore.On("RefreshUserEnforcedBalance", userWallet, "usdc").Return(nil)
+	mockStore.On("UpdateStateUserSigIfMissing", channelID, uint64(4), "").Return(nil)
 
 	err := service.HandleHomeChannelChallenged(ctx, mockStore, event)
 
@@ -266,6 +269,7 @@ func TestHandleHomeChannelClosed_Success(t *testing.T) {
 			ch.StateVersion == 10
 	})).Return(nil)
 	mockStore.On("RefreshUserEnforcedBalance", userWallet, "usdc").Return(nil)
+	mockStore.On("UpdateStateUserSigIfMissing", channelID, uint64(10), "").Return(nil)
 
 	// Execute
 	err := service.HandleHomeChannelClosed(ctx, mockStore, event)
@@ -320,6 +324,7 @@ func TestHandleEscrowDepositInitiated_Success(t *testing.T) {
 	})).Return(nil)
 	mockStore.On("GetStateByChannelIDAndVersion", channelID, uint64(1)).Return(state, nil)
 	mockStore.On("ScheduleInitiateEscrowDeposit", "state123", uint64(0)).Return(nil)
+	mockStore.On("UpdateStateUserSigIfMissing", channelID, uint64(1), "").Return(nil)
 
 	// Execute
 	err := service.HandleEscrowDepositInitiated(ctx, mockStore, event)
@@ -374,6 +379,7 @@ func TestHandleEscrowDepositChallenged_Success(t *testing.T) {
 	})).Return(nil)
 	mockStore.On("GetLastStateByChannelID", channelID, true).Return(state, nil)
 	mockStore.On("ScheduleFinalizeEscrowDeposit", "state123", uint64(2)).Return(nil)
+	mockStore.On("UpdateStateUserSigIfMissing", channelID, uint64(3), "").Return(nil)
 
 	// Execute
 	err := service.HandleEscrowDepositChallenged(ctx, mockStore, event)
@@ -415,6 +421,7 @@ func TestHandleEscrowDepositFinalized_Success(t *testing.T) {
 			ch.Status == core.ChannelStatusClosed &&
 			ch.StateVersion == 5
 	})).Return(nil)
+	mockStore.On("UpdateStateUserSigIfMissing", channelID, uint64(5), "").Return(nil)
 
 	// Execute
 	err := service.HandleEscrowDepositFinalized(ctx, mockStore, event)
@@ -456,6 +463,7 @@ func TestHandleEscrowWithdrawalInitiated_Success(t *testing.T) {
 			ch.Status == core.ChannelStatusOpen &&
 			ch.StateVersion == 1
 	})).Return(nil)
+	mockStore.On("UpdateStateUserSigIfMissing", channelID, uint64(1), "").Return(nil)
 
 	// Execute
 	err := service.HandleEscrowWithdrawalInitiated(ctx, mockStore, event)
@@ -510,6 +518,7 @@ func TestHandleEscrowWithdrawalChallenged_Success(t *testing.T) {
 	})).Return(nil)
 	mockStore.On("GetLastStateByChannelID", channelID, true).Return(state, nil)
 	mockStore.On("ScheduleFinalizeEscrowWithdrawal", "state123", uint64(2)).Return(nil)
+	mockStore.On("UpdateStateUserSigIfMissing", channelID, uint64(3), "").Return(nil)
 
 	// Execute
 	err := service.HandleEscrowWithdrawalChallenged(ctx, mockStore, event)
@@ -551,6 +560,7 @@ func TestHandleEscrowWithdrawalFinalized_Success(t *testing.T) {
 			ch.Status == core.ChannelStatusClosed &&
 			ch.StateVersion == 5
 	})).Return(nil)
+	mockStore.On("UpdateStateUserSigIfMissing", channelID, uint64(5), "").Return(nil)
 
 	// Execute
 	err := service.HandleEscrowWithdrawalFinalized(ctx, mockStore, event)
@@ -586,6 +596,88 @@ func TestHandleUserLockedBalanceUpdated_Success(t *testing.T) {
 
 	// Assert
 	require.NoError(t, err)
+	mockStore.AssertExpectations(t)
+}
+
+// TestHandleHomeChannelCheckpointed_BackfillsUserSig covers the recovery path for the wedge
+// scenario: a node-only state was checkpointed on chain (e.g. the receiver of a transfer signed
+// the receiver state and submitted it directly). The reactor extracts the user signature from the
+// event and the handler must forward it to the store so the local row matches what is enforced
+// on chain. Without this, EnsureNoOngoingStateTransitions stays blocked on the now-stale prior
+// bilateral state and the channel can only be unblocked via on-chain challenge.
+func TestHandleHomeChannelCheckpointed_BackfillsUserSig(t *testing.T) {
+	mockStore := new(MockStore)
+	ctx := log.SetContextLogger(context.Background(), log.NewNoopLogger())
+
+	service := &EventHandlerService{}
+
+	channelID := "0xHomeChannel123"
+	userWallet := "0x1234567890123456789012345678901234567890"
+	userSig := "0xabcdef0123456789"
+
+	channel := &core.Channel{
+		ChannelID:    channelID,
+		UserWallet:   userWallet,
+		Asset:        "usdc",
+		Type:         core.ChannelTypeHome,
+		Status:       core.ChannelStatusOpen,
+		StateVersion: 4,
+	}
+
+	event := &core.HomeChannelCheckpointedEvent{
+		ChannelID:    channelID,
+		StateVersion: 5,
+		UserSig:      userSig,
+	}
+
+	mockStore.On("GetChannelByID", channelID).Return(channel, nil)
+	mockStore.On("UpdateChannel", mock.MatchedBy(func(ch core.Channel) bool {
+		return ch.StateVersion == 5
+	})).Return(nil)
+	mockStore.On("RefreshUserEnforcedBalance", userWallet, "usdc").Return(nil)
+	mockStore.On("UpdateStateUserSigIfMissing", channelID, uint64(5), userSig).Return(nil)
+
+	err := service.HandleHomeChannelCheckpointed(ctx, mockStore, event)
+
+	require.NoError(t, err)
+	mockStore.AssertExpectations(t)
+}
+
+// TestHandleHomeChannelCheckpointed_BackfillError surfaces store errors from the backfill so
+// the surrounding event-processing transaction rolls back and the event can be retried.
+func TestHandleHomeChannelCheckpointed_BackfillError(t *testing.T) {
+	mockStore := new(MockStore)
+	ctx := log.SetContextLogger(context.Background(), log.NewNoopLogger())
+
+	service := &EventHandlerService{}
+
+	channelID := "0xHomeChannel123"
+	userWallet := "0x1234567890123456789012345678901234567890"
+
+	channel := &core.Channel{
+		ChannelID:    channelID,
+		UserWallet:   userWallet,
+		Asset:        "usdc",
+		Type:         core.ChannelTypeHome,
+		Status:       core.ChannelStatusOpen,
+		StateVersion: 4,
+	}
+
+	event := &core.HomeChannelCheckpointedEvent{
+		ChannelID:    channelID,
+		StateVersion: 5,
+		UserSig:      "0xdeadbeef",
+	}
+
+	mockStore.On("GetChannelByID", channelID).Return(channel, nil)
+	mockStore.On("UpdateChannel", mock.Anything).Return(nil)
+	mockStore.On("RefreshUserEnforcedBalance", userWallet, "usdc").Return(nil)
+	mockStore.On("UpdateStateUserSigIfMissing", channelID, uint64(5), "0xdeadbeef").Return(errors.New("db error"))
+
+	err := service.HandleHomeChannelCheckpointed(ctx, mockStore, event)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "db error")
 	mockStore.AssertExpectations(t)
 }
 

--- a/nitronode/event_handlers/testing.go
+++ b/nitronode/event_handlers/testing.go
@@ -86,3 +86,9 @@ func (m *MockStore) UpdateUserStaked(wallet string, blockchainID uint64, amount 
 	args := m.Called(wallet, blockchainID, amount)
 	return args.Error(0)
 }
+
+// UpdateStateUserSigIfMissing mocks backfilling a user signature for a stored state.
+func (m *MockStore) UpdateStateUserSigIfMissing(channelID string, version uint64, userSig string) error {
+	args := m.Called(channelID, version, userSig)
+	return args.Error(0)
+}

--- a/nitronode/store/database/db_store_test.go
+++ b/nitronode/store/database/db_store_test.go
@@ -646,3 +646,178 @@ func TestDBStore_EnsureNoOngoingStateTransitions(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestDBStore_UpdateStateUserSigIfMissing(t *testing.T) {
+	t.Run("Backfills user_sig when null and unblocks gate", func(t *testing.T) {
+		// This is the wedge-recovery path: a node-only state was checkpointed on chain
+		// (e.g. recipient submitted a transfer_receive state directly). After the event
+		// reactor backfills user_sig, EnsureNoOngoingStateTransitions must see a fully
+		// signed row at the on-chain version and pass.
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+
+		store := NewDBStore(db)
+
+		homeChannelID := "0xhomechannel123"
+		nodeSig := "0xnodesig"
+
+		channel := core.Channel{
+			ChannelID:         homeChannelID,
+			UserWallet:        "0xuser123",
+			Asset:             "usdc",
+			Type:              core.ChannelTypeHome,
+			BlockchainID:      1,
+			TokenAddress:      "0xtoken123",
+			ChallengeDuration: 86400,
+			Nonce:             1,
+			Status:            core.ChannelStatusOpen,
+			StateVersion:      2,
+		}
+		require.NoError(t, store.CreateChannel(channel))
+
+		// Node-only state at version 2; gate would normally skip this row and find
+		// nothing else, returning nil. To exercise the wedge, also seed an older
+		// bilateral state at version 1.
+		_, err := store.LockUserState("0xuser123", "USDC")
+		require.NoError(t, err)
+
+		bilateralUserSig := "0xprior"
+		bilateralNodeSig := "0xpriornode"
+		bilateral := core.State{
+			ID:            "state1",
+			Asset:         "USDC",
+			UserWallet:    "0xuser123",
+			Epoch:         1,
+			Version:       1,
+			HomeChannelID: &homeChannelID,
+			Transition: core.Transition{
+				Type: core.TransitionTypeHomeDeposit,
+			},
+			HomeLedger: core.Ledger{
+				UserBalance: decimal.NewFromInt(500),
+				UserNetFlow: decimal.Zero,
+				NodeBalance: decimal.Zero,
+				NodeNetFlow: decimal.Zero,
+			},
+			UserSig: &bilateralUserSig,
+			NodeSig: &bilateralNodeSig,
+		}
+		require.NoError(t, store.StoreUserState(bilateral, ""))
+
+		nodeOnly := core.State{
+			ID:            "state2",
+			Asset:         "USDC",
+			UserWallet:    "0xuser123",
+			Epoch:         1,
+			Version:       2,
+			HomeChannelID: &homeChannelID,
+			Transition: core.Transition{
+				Type: core.TransitionTypeTransferReceive,
+			},
+			HomeLedger: core.Ledger{
+				UserBalance: decimal.NewFromInt(750),
+				UserNetFlow: decimal.Zero,
+				NodeBalance: decimal.Zero,
+				NodeNetFlow: decimal.Zero,
+			},
+			NodeSig: &nodeSig,
+		}
+		require.NoError(t, store.StoreUserState(nodeOnly, ""))
+
+		// Pre-backfill: gate sees bilateral row at version 1, channel.state_version is 2 → mismatch.
+		err = store.EnsureNoOngoingStateTransitions("0xuser123", "USDC")
+		require.Error(t, err)
+
+		// Backfill the user signature recovered from the on-chain event.
+		recoveredSig := "0xrecovered"
+		require.NoError(t, store.UpdateStateUserSigIfMissing(homeChannelID, 2, recoveredSig))
+
+		got, err := store.GetStateByID("state2")
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		require.NotNil(t, got.UserSig)
+		assert.Equal(t, recoveredSig, *got.UserSig)
+
+		// Post-backfill: gate sees the now-bilateral row at version 2, matches channel state_version.
+		err = store.EnsureNoOngoingStateTransitions("0xuser123", "USDC")
+		require.NoError(t, err)
+	})
+
+	t.Run("Idempotent on replay - existing sig preserved", func(t *testing.T) {
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+
+		store := NewDBStore(db)
+
+		homeChannelID := "0xhomechannel123"
+		userSig := "0xexisting"
+		nodeSig := "0xnodesig"
+
+		channel := core.Channel{
+			ChannelID:         homeChannelID,
+			UserWallet:        "0xuser123",
+			Asset:             "usdc",
+			Type:              core.ChannelTypeHome,
+			BlockchainID:      1,
+			TokenAddress:      "0xtoken123",
+			ChallengeDuration: 86400,
+			Nonce:             1,
+			Status:            core.ChannelStatusOpen,
+			StateVersion:      1,
+		}
+		require.NoError(t, store.CreateChannel(channel))
+
+		_, err := store.LockUserState("0xuser123", "USDC")
+		require.NoError(t, err)
+
+		state := core.State{
+			ID:            "state1",
+			Asset:         "USDC",
+			UserWallet:    "0xuser123",
+			Epoch:         1,
+			Version:       1,
+			HomeChannelID: &homeChannelID,
+			Transition: core.Transition{
+				Type: core.TransitionTypeHomeDeposit,
+			},
+			HomeLedger: core.Ledger{
+				UserBalance: decimal.NewFromInt(1000),
+				UserNetFlow: decimal.Zero,
+				NodeBalance: decimal.Zero,
+				NodeNetFlow: decimal.Zero,
+			},
+			UserSig: &userSig,
+			NodeSig: &nodeSig,
+		}
+		require.NoError(t, store.StoreUserState(state, ""))
+
+		// Replayed event would carry a different (or any) sig; existing one must not be overwritten.
+		require.NoError(t, store.UpdateStateUserSigIfMissing(homeChannelID, 1, "0xshould-not-overwrite"))
+
+		got, err := store.GetStateByID("state1")
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		require.NotNil(t, got.UserSig)
+		assert.Equal(t, userSig, *got.UserSig)
+	})
+
+	t.Run("Empty sig is no-op", func(t *testing.T) {
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+
+		store := NewDBStore(db)
+
+		homeChannelID := "0xhomechannel123"
+		require.NoError(t, store.UpdateStateUserSigIfMissing(homeChannelID, 1, ""))
+	})
+
+	t.Run("Unknown version returns no error", func(t *testing.T) {
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+
+		store := NewDBStore(db)
+
+		homeChannelID := "0xhomechannel123"
+		require.NoError(t, store.UpdateStateUserSigIfMissing(homeChannelID, 99, "0xanything"))
+	})
+}

--- a/nitronode/store/database/interface.go
+++ b/nitronode/store/database/interface.go
@@ -80,6 +80,9 @@ type DatabaseStore interface {
 	// EnsureNoOngoingStateTransitions validates that no conflicting blockchain operations are pending.
 	EnsureNoOngoingStateTransitions(wallet, asset string) error
 
+	// UpdateStateUserSigIfMissing backfills the user signature for a stored state when it is currently NULL.
+	UpdateStateUserSigIfMissing(channelID string, version uint64, userSig string) error
+
 	// --- Blockchain Action Operations ---
 
 	// ScheduleInitiateEscrowWithdrawal queues a blockchain action to initiate withdrawal.

--- a/nitronode/store/database/state.go
+++ b/nitronode/store/database/state.go
@@ -221,6 +221,24 @@ func (s *DBStore) GetLastStateByChannelID(channelID string, signed bool) (*core.
 	return databaseStateToCore(&state)
 }
 
+// UpdateStateUserSigIfMissing backfills the user signature for a stored state when it is currently NULL.
+// Used by the on-chain event reactor to repair the local record once a state has been bilaterally
+// enforced on chain. The IS NULL guard makes the call idempotent on event replay and prevents
+// overwriting a signature already populated by the user-facing RPC path.
+func (s *DBStore) UpdateStateUserSigIfMissing(channelID string, version uint64, userSig string) error {
+	if userSig == "" {
+		return nil
+	}
+	cid := strings.ToLower(channelID)
+	res := s.db.Model(&State{}).
+		Where("(home_channel_id = ? OR escrow_channel_id = ?) AND version = ? AND user_sig IS NULL", cid, cid, version).
+		Update("user_sig", userSig)
+	if res.Error != nil {
+		return fmt.Errorf("failed to backfill user_sig: %w", res.Error)
+	}
+	return nil
+}
+
 // GetStateByChannelIDAndVersion retrieves a specific state version for a channel.
 // Uses UNION ALL of two indexed queries instead of OR for better performance.
 func (s *DBStore) GetStateByChannelIDAndVersion(channelID string, version uint64) (*core.State, error) {

--- a/pkg/blockchain/evm/channel_hub_reactor.go
+++ b/pkg/blockchain/evm/channel_hub_reactor.go
@@ -67,6 +67,9 @@ type ChannelHubReactorStore interface {
 	// RefreshUserEnforcedBalance recomputes the locked balance from the user's open home channel on-chain state.
 	RefreshUserEnforcedBalance(wallet, asset string) error
 
+	// UpdateStateUserSigIfMissing backfills the user signature for a stored state when it is currently NULL.
+	UpdateStateUserSigIfMissing(channelID string, version uint64, userSig string) error
+
 	// StoreContractEvent persists a blockchain event to the database.
 	StoreContractEvent(ev core.BlockchainEvent) error
 }
@@ -74,6 +77,14 @@ type ChannelHubReactorStore interface {
 var channelHubAbi *abi.ABI
 var channelHubFilterer *ChannelHubFilterer
 var channelHubEventMapping map[common.Hash]string
+
+// encodeSig hex-encodes a signature byte slice or returns an empty string when absent.
+func encodeSig(b []byte) string {
+	if len(b) == 0 {
+		return ""
+	}
+	return hexutil.Encode(b)
+}
 
 func initChannelHub() {
 	var err error
@@ -250,6 +261,7 @@ func (r *ChannelHubReactor) handleHomeChannelCreated(ctx context.Context, store 
 	ev := core.HomeChannelCreatedEvent{
 		ChannelID:    hexutil.Encode(event.ChannelId[:]),
 		StateVersion: event.InitialState.Version,
+		UserSig:      encodeSig(event.InitialState.UserSig),
 	}
 	return r.eventHandler.HandleHomeChannelCreated(ctx, store, &ev)
 }
@@ -263,6 +275,7 @@ func (r *ChannelHubReactor) handleHomeChannelMigrated(ctx context.Context, store
 	ev := core.HomeChannelMigratedEvent{
 		ChannelID:    hexutil.Encode(event.ChannelId[:]),
 		StateVersion: event.State.Version,
+		UserSig:      encodeSig(event.State.UserSig),
 	}
 	return r.eventHandler.HandleHomeChannelMigrated(ctx, store, &ev)
 }
@@ -276,6 +289,7 @@ func (r *ChannelHubReactor) handleHomeChannelCheckpointed(ctx context.Context, s
 	ev := core.HomeChannelCheckpointedEvent{
 		ChannelID:    hexutil.Encode(event.ChannelId[:]),
 		StateVersion: event.Candidate.Version,
+		UserSig:      encodeSig(event.Candidate.UserSig),
 	}
 	return r.eventHandler.HandleHomeChannelCheckpointed(ctx, store, &ev)
 }
@@ -289,6 +303,7 @@ func (r *ChannelHubReactor) handleChannelDeposited(ctx context.Context, store Ch
 	ev := core.HomeChannelCheckpointedEvent{
 		ChannelID:    hexutil.Encode(event.ChannelId[:]),
 		StateVersion: event.Candidate.Version,
+		UserSig:      encodeSig(event.Candidate.UserSig),
 	}
 	return r.eventHandler.HandleHomeChannelCheckpointed(ctx, store, &ev)
 }
@@ -302,6 +317,7 @@ func (r *ChannelHubReactor) handleChannelWithdrawn(ctx context.Context, store Ch
 	ev := core.HomeChannelCheckpointedEvent{
 		ChannelID:    hexutil.Encode(event.ChannelId[:]),
 		StateVersion: event.Candidate.Version,
+		UserSig:      encodeSig(event.Candidate.UserSig),
 	}
 	return r.eventHandler.HandleHomeChannelCheckpointed(ctx, store, &ev)
 }
@@ -316,6 +332,7 @@ func (r *ChannelHubReactor) handleHomeChannelChallenged(ctx context.Context, sto
 		ChannelID:       hexutil.Encode(event.ChannelId[:]),
 		StateVersion:    event.Candidate.Version,
 		ChallengeExpiry: event.ChallengeExpireAt,
+		UserSig:         encodeSig(event.Candidate.UserSig),
 	}
 	return r.eventHandler.HandleHomeChannelChallenged(ctx, store, &ev)
 }
@@ -329,6 +346,7 @@ func (r *ChannelHubReactor) handleHomeChannelClosed(ctx context.Context, store C
 	ev := core.HomeChannelClosedEvent{
 		ChannelID:    hexutil.Encode(event.ChannelId[:]),
 		StateVersion: event.FinalState.Version,
+		UserSig:      encodeSig(event.FinalState.UserSig),
 	}
 	return r.eventHandler.HandleHomeChannelClosed(ctx, store, &ev)
 }
@@ -342,6 +360,7 @@ func (r *ChannelHubReactor) handleEscrowDepositInitiated(ctx context.Context, st
 	ev := core.EscrowDepositInitiatedEvent{
 		ChannelID:    hexutil.Encode(event.EscrowId[:]),
 		StateVersion: event.State.Version,
+		UserSig:      encodeSig(event.State.UserSig),
 	}
 	return r.eventHandler.HandleEscrowDepositInitiated(ctx, store, &ev)
 }
@@ -356,6 +375,7 @@ func (r *ChannelHubReactor) handleEscrowDepositChallenged(ctx context.Context, s
 		ChannelID:       hexutil.Encode(event.EscrowId[:]),
 		StateVersion:    event.State.Version,
 		ChallengeExpiry: event.ChallengeExpireAt,
+		UserSig:         encodeSig(event.State.UserSig),
 	}
 	return r.eventHandler.HandleEscrowDepositChallenged(ctx, store, &ev)
 }
@@ -369,6 +389,7 @@ func (r *ChannelHubReactor) handleEscrowDepositFinalized(ctx context.Context, st
 	ev := core.EscrowDepositFinalizedEvent{
 		ChannelID:    hexutil.Encode(event.EscrowId[:]),
 		StateVersion: event.State.Version,
+		UserSig:      encodeSig(event.State.UserSig),
 	}
 	return r.eventHandler.HandleEscrowDepositFinalized(ctx, store, &ev)
 }
@@ -382,6 +403,7 @@ func (r *ChannelHubReactor) handleEscrowWithdrawalInitiated(ctx context.Context,
 	ev := core.EscrowWithdrawalInitiatedEvent{
 		ChannelID:    hexutil.Encode(event.EscrowId[:]),
 		StateVersion: event.State.Version,
+		UserSig:      encodeSig(event.State.UserSig),
 	}
 	return r.eventHandler.HandleEscrowWithdrawalInitiated(ctx, store, &ev)
 }
@@ -396,6 +418,7 @@ func (r *ChannelHubReactor) handleEscrowWithdrawalChallenged(ctx context.Context
 		ChannelID:       hexutil.Encode(event.EscrowId[:]),
 		StateVersion:    event.State.Version,
 		ChallengeExpiry: event.ChallengeExpireAt,
+		UserSig:         encodeSig(event.State.UserSig),
 	}
 	return r.eventHandler.HandleEscrowWithdrawalChallenged(ctx, store, &ev)
 }
@@ -409,6 +432,7 @@ func (r *ChannelHubReactor) handleEscrowWithdrawalFinalized(ctx context.Context,
 	ev := core.EscrowWithdrawalFinalizedEvent{
 		ChannelID:    hexutil.Encode(event.EscrowId[:]),
 		StateVersion: event.State.Version,
+		UserSig:      encodeSig(event.State.UserSig),
 	}
 	return r.eventHandler.HandleEscrowWithdrawalFinalized(ctx, store, &ev)
 }
@@ -422,6 +446,7 @@ func (r *ChannelHubReactor) handleEscrowDepositInitiatedOnHome(ctx context.Conte
 	ev := core.HomeChannelCheckpointedEvent{
 		ChannelID:    hexutil.Encode(event.ChannelId[:]),
 		StateVersion: event.State.Version,
+		UserSig:      encodeSig(event.State.UserSig),
 	}
 	return r.eventHandler.HandleHomeChannelCheckpointed(ctx, store, &ev)
 }
@@ -435,6 +460,7 @@ func (r *ChannelHubReactor) handleEscrowDepositFinalizedOnHome(ctx context.Conte
 	ev := core.HomeChannelCheckpointedEvent{
 		ChannelID:    hexutil.Encode(event.ChannelId[:]),
 		StateVersion: event.State.Version,
+		UserSig:      encodeSig(event.State.UserSig),
 	}
 	return r.eventHandler.HandleHomeChannelCheckpointed(ctx, store, &ev)
 }
@@ -448,6 +474,7 @@ func (r *ChannelHubReactor) handleEscrowWithdrawalInitiatedOnHome(ctx context.Co
 	ev := core.HomeChannelCheckpointedEvent{
 		ChannelID:    hexutil.Encode(event.ChannelId[:]),
 		StateVersion: event.State.Version,
+		UserSig:      encodeSig(event.State.UserSig),
 	}
 	return r.eventHandler.HandleHomeChannelCheckpointed(ctx, store, &ev)
 }
@@ -461,6 +488,7 @@ func (r *ChannelHubReactor) handleEscrowWithdrawalFinalizedOnHome(ctx context.Co
 	ev := core.HomeChannelCheckpointedEvent{
 		ChannelID:    hexutil.Encode(event.ChannelId[:]),
 		StateVersion: event.State.Version,
+		UserSig:      encodeSig(event.State.UserSig),
 	}
 	return r.eventHandler.HandleHomeChannelCheckpointed(ctx, store, &ev)
 }

--- a/pkg/blockchain/evm/channel_hub_reactor_test.go
+++ b/pkg/blockchain/evm/channel_hub_reactor_test.go
@@ -85,6 +85,11 @@ func (m *mockChannelHubStore) StoreContractEvent(ev core.BlockchainEvent) error 
 	return args.Error(0)
 }
 
+func (m *mockChannelHubStore) UpdateStateUserSigIfMissing(channelID string, version uint64, userSig string) error {
+	args := m.Called(channelID, version, userSig)
+	return args.Error(0)
+}
+
 // mockChannelHubEventHandler captures events dispatched by the reactor.
 type mockChannelHubEventHandler struct {
 	mock.Mock
@@ -363,6 +368,46 @@ func TestChannelHubReactor_HandleHomeChannelCheckpointed(t *testing.T) {
 	})).Return(nil)
 
 	expectStoreContractEvent(store, "ChannelCheckpointed", 400, blockchainID)
+
+	reactor := newReactor(blockchainID, nodeAddr, handler, assetStore, store)
+	err := reactor.HandleEvent(context.Background(), logEntry)
+	require.NoError(t, err)
+	handler.AssertExpectations(t)
+	store.AssertExpectations(t)
+}
+
+// TestChannelHubReactor_HandleHomeChannelCheckpointed_ForwardsUserSig confirms the reactor
+// hex-encodes Candidate.UserSig from the parsed event payload and surfaces it to the handler.
+// Without this the wedge-recovery backfill in HandleHomeChannelCheckpointed has nothing to write.
+func TestChannelHubReactor_HandleHomeChannelCheckpointed_ForwardsUserSig(t *testing.T) {
+	blockchainID := uint64(1)
+	nodeAddr := "0x1111111111111111111111111111111111111111"
+	channelID := common.HexToHash("0xcc02ff")
+
+	state := makeState(7)
+	state.UserSig = []byte{0xde, 0xad, 0xbe, 0xef}
+	data := packNonIndexed(t, "ChannelCheckpointed", state)
+
+	logEntry := types.Log{
+		Topics: []common.Hash{
+			channelHubAbi.Events["ChannelCheckpointed"].ID,
+			channelID,
+		},
+		Data:        data,
+		BlockNumber: 401,
+		TxHash:      common.HexToHash("0x112"),
+		Index:       0,
+	}
+
+	store := new(mockChannelHubStore)
+	handler := new(mockChannelHubEventHandler)
+	assetStore := new(MockAssetStore)
+
+	handler.On("HandleHomeChannelCheckpointed", mock.Anything, mock.Anything, mock.MatchedBy(func(ev *core.HomeChannelCheckpointedEvent) bool {
+		return ev.UserSig == hexutil.Encode([]byte{0xde, 0xad, 0xbe, 0xef})
+	})).Return(nil)
+
+	expectStoreContractEvent(store, "ChannelCheckpointed", 401, blockchainID)
 
 	reactor := newReactor(blockchainID, nodeAddr, handler, assetStore, store)
 	err := reactor.HandleEvent(context.Background(), logEntry)

--- a/pkg/core/event.go
+++ b/pkg/core/event.go
@@ -47,12 +47,17 @@ type EscrowWithdrawalFinalizedEvent channelEvent
 type channelEvent struct {
 	ChannelID    string `json:"channel_id"`
 	StateVersion uint64 `json:"state_version"`
+	// UserSig is the hex-encoded user signature recovered from the on-chain state payload.
+	// Empty when the parsed event carries no user signature (e.g. unilateral node-only state).
+	UserSig string `json:"user_sig,omitempty"`
 }
 
 type channelChallengedEvent struct {
 	ChannelID       string `json:"channel_id"`
 	StateVersion    uint64 `json:"state_version"`
 	ChallengeExpiry uint64 `json:"challenge_expiry"`
+	// UserSig is the hex-encoded user signature recovered from the on-chain state payload.
+	UserSig string `json:"user_sig,omitempty"`
 }
 
 type UserLockedBalanceUpdatedEvent struct {

--- a/pkg/core/interface.go
+++ b/pkg/core/interface.go
@@ -139,6 +139,11 @@ type ChannelHubEventHandlerStore interface {
 
 	// RefreshUserEnforcedBalance recomputes the locked balance from the user's open home channel on-chain state.
 	RefreshUserEnforcedBalance(wallet, asset string) error
+
+	// UpdateStateUserSigIfMissing backfills the user signature for a stored state when it is currently NULL.
+	// Used to repair the local record after an on-chain event proves the state was bilaterally enforced.
+	// No-op when userSig is empty or no row matches; existing user_sig is never overwritten.
+	UpdateStateUserSigIfMissing(channelID string, version uint64, userSig string) error
 }
 
 type LockingContractEventHandler interface {


### PR DESCRIPTION
## Summary
- Plumb the on-chain user signature from the parsed `State` payload through the reactor into `channelEvent` / `channelChallengedEvent`, then forward it to the matching `EventHandlerService` handlers.
- New `ChannelHubEventHandlerStore.UpdateStateUserSigIfMissing` populates `channel_states.user_sig` when NULL; idempotent on replay via `user_sig IS NULL` guard.
- Closes the wedge where a unilateral on-chain checkpoint of a node-only state (e.g. recipient submits the `TransferReceive` state directly) leaves the local row partially signed, causing `EnsureNoOngoingStateTransitions` to permanently mismatch versions and block the channel until an on-chain challenge.

## Threat addressed
Recipient signs the node-issued `TransferReceive` state and submits it on chain. `HomeChannelCheckpointed` bumps `channels.state_version` to N+1, but `channel_states` row at N+1 still has `user_sig = NULL`. The gate query in `EnsureNoOngoingStateTransitions` filters on both signatures, picks the prior bilateral row at N, and reports a version mismatch on every subsequent state transition. Channel wedged offchain; recovery requires on-chain challenge — costly griefing vector with a one-tx attack surface.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] New unit tests:
  - `nitronode/event_handlers/service_test.go` — `BackfillsUserSig`, `BackfillError`; existing handler tests updated to expect the backfill mock call (empty sig).
  - `nitronode/store/database/db_store_test.go` — wedge-resolution end-to-end (gate fails → backfill → gate passes), idempotent replay (existing sig preserved), empty-sig no-op, unknown-version no-op.
  - `pkg/blockchain/evm/channel_hub_reactor_test.go` — reactor hex-encodes `Candidate.UserSig` into the event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)