### PR TITLE
MF-M02: fix(rpc): release Serve wait group on processSink overflow

### DIFF
--- a/pkg/rpc/connection_test.go
+++ b/pkg/rpc/connection_test.go
@@ -229,6 +229,42 @@ func TestWebsocketConnection_RateLimitedFrame_ClosesConnection(t *testing.T) {
 	require.Equal(t, 2, limiter.calls, "limiter was consulted for both frames")
 }
 
+func TestWebsocketConnection_ServeQueueFullClosesCleanly(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	wsConnMock := newGorillaWsConnMock(ctx)
+
+	cfg := rpc.WebsocketConnectionConfig{
+		ConnectionID:      "conn1",
+		WebsocketConn:     wsConnMock,
+		ProcessBufferSize: 1,
+	}
+	conn, err := rpc.NewWebsocketConnection(cfg)
+	require.NoError(t, err)
+
+	closed := make(chan struct{})
+	conn.Serve(ctx, func(error) { close(closed) })
+
+	// First message fills processSink (no consumer reads RawRequests).
+	wsConnMock.addMessageToRead("msg1")
+	// Second message hits the queue-full branch. Without a handleClosure call,
+	// the internal wait group blocks forever and the parent closure never fires.
+	wsConnMock.addMessageToRead("msg2")
+
+	select {
+	case <-closed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("parent handleClosure not invoked after processSink overflow; goroutine leak")
+	}
+
+	require.Eventually(t, func() bool {
+		return wsConnMock.getCalledCloseCount() == 1
+	}, time.Second, 10*time.Millisecond, "underlying WebSocket Close() not called")
+}
+
 func TestWebsocketConnection_ConnectionID(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- `readMessages` returned without calling `handleClosure` when `processSink` was full, leaving the `Serve` wait group stuck at one outstanding `Done`. The parent closure callback never fired, the WebSocket was never closed, and the outer HTTP handler stayed blocked — `connHub.Remove` never ran. Unauthenticated clients could exhaust server resources by flooding messages faster than the queue drained.
- Call `handleClosure(nil)` before returning from the queue-full branch so the wait group invariant (every early return decrements exactly once) holds.
- Add a regression test that fills `processSink` without a consumer and asserts the parent closure fires and the underlying connection is closed.

## Notes
- Same fix already exists on `fix/nitronode-mf-c01` (part of broader frame-size + rate-limiter hardening). Three-way merge between this branch and c01 is clean — identical line addition, non-overlapping hunks.
- c01 also adds a parallel `frameRateLimiter.Admit` early-return path with the same `handleClosure(nil)` shape.

## Test plan
- [x] `go test ./pkg/rpc/... -count=1` passes
- [x] New test fails without the one-line fix (`parent handleClosure not invoked after processSink overflow; goroutine leak`)
- [x] `go vet ./pkg/rpc/...` clean
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)