### PR TITLE
MF-M07: Unblock receiver states after finalized escrow operations

### DIFF
--- a/nitronode/api/app_session_v1/handler.go
+++ b/nitronode/api/app_session_v1/handler.go
@@ -159,15 +159,8 @@ func (h *Handler) issueReleaseReceiverState(ctx context.Context, tx Store, recei
 		return rpc.Errorf("failed to apply release transition: %v", err)
 	}
 
-	// Check if we need to sign the state (skip signing if last signed state was a lock)
-	lastSignedState, err := tx.GetLastUserState(receiverWallet, asset, true)
-	if err != nil {
-		return rpc.Errorf("failed to get last signed state: %v", err)
-	}
-
-	// TODO: move to DB query
-	if lastSignedState != nil && lastSignedState.EscrowChannelID != nil {
-		return rpc.Errorf("cannot issue release receiver state: last signed state is a lock with escrow channel %s", *lastSignedState.EscrowChannelID)
+	if err := tx.EnsureNoOngoingEscrowOperation(receiverWallet, asset); err != nil {
+		return rpc.Errorf("cannot issue release receiver state: %v", err)
 	}
 
 	if newState.HomeChannelID != nil {

--- a/nitronode/api/app_session_v1/interface.go
+++ b/nitronode/api/app_session_v1/interface.go
@@ -43,6 +43,11 @@ type Store interface {
 	StoreUserState(state core.State, applicationID string) error
 	EnsureNoOngoingStateTransitions(wallet, asset string) error
 
+	// EnsureNoOngoingEscrowOperation validates that the user has no in-flight escrow
+	// operation (escrow_lock, mutual_lock, or unfinalized escrow_deposit/escrow_withdraw)
+	// that would prevent issuing a receiver-side state.
+	EnsureNoOngoingEscrowOperation(wallet, asset string) error
+
 	// App Session key state operations
 	LockSessionKeyState(userAddress, sessionKey string, kind database.SessionKeyKind) (uint64, error)
 	CountSessionKeysForUser(userAddress string) (uint32, error)

--- a/nitronode/api/app_session_v1/submit_app_state_test.go
+++ b/nitronode/api/app_session_v1/submit_app_state_test.go
@@ -3,6 +3,7 @@ package app_session_v1
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -350,7 +351,7 @@ func TestSubmitAppState_WithdrawIntent_Success(t *testing.T) {
 	}
 	mockStore.On("LockUserState", participant1, "USDC").Return(decimal.Zero, nil)
 	mockStore.On("GetLastUserState", participant1, "USDC", false).Return(existingUserState, nil)
-	mockStore.On("GetLastUserState", participant1, "USDC", true).Return(nil, nil)
+	mockStore.On("EnsureNoOngoingEscrowOperation", participant1, "USDC").Return(nil)
 	mockStatePacker.On("PackState", mock.Anything).Return([]byte("packed"), nil)
 	mockStore.On("RecordTransaction", mock.Anything, mock.Anything).Return(nil)
 
@@ -485,20 +486,9 @@ func TestSubmitAppState_WithdrawIntent_ReceiverWithEscrowLock_Rejected(t *testin
 		},
 	}
 
-	// Last signed state has an active escrow channel
-	escrowChannelID := "0xEscrowChannel456"
-	lastSignedState := core.State{
-		Asset:           "USDC",
-		UserWallet:      participant1,
-		Epoch:           1,
-		Version:         1,
-		HomeChannelID:   &homeChannelID,
-		EscrowChannelID: &escrowChannelID,
-	}
-
 	mockStore.On("LockUserState", participant1, "USDC").Return(decimal.Zero, nil)
 	mockStore.On("GetLastUserState", participant1, "USDC", false).Return(existingUserState, nil)
-	mockStore.On("GetLastUserState", participant1, "USDC", true).Return(lastSignedState, nil)
+	mockStore.On("EnsureNoOngoingEscrowOperation", participant1, "USDC").Return(fmt.Errorf("escrow lock is still ongoing"))
 
 	// Create RPC context
 	payload, err := rpc.NewPayload(reqPayload)
@@ -516,7 +506,7 @@ func TestSubmitAppState_WithdrawIntent_ReceiverWithEscrowLock_Rejected(t *testin
 	require.NotNil(t, ctx.Response)
 	respErr := ctx.Response.Error()
 	require.NotNil(t, respErr, "Expected error when participant has active escrow lock")
-	assert.Contains(t, respErr.Error(), "last signed state is a lock with escrow channel")
+	assert.Contains(t, respErr.Error(), "escrow lock is still ongoing")
 
 	mockStore.AssertExpectations(t)
 }
@@ -638,7 +628,7 @@ func TestSubmitAppState_CloseIntent_Success(t *testing.T) {
 	mockStore.On("RecordLedgerEntry", participant1, appSessionID, "USDC", decimal.NewFromInt(-100)).Return(nil)
 	mockStore.On("LockUserState", participant1, "USDC").Return(decimal.Zero, nil)
 	mockStore.On("GetLastUserState", participant1, "USDC", false).Return(existingUserState1, nil)
-	mockStore.On("GetLastUserState", participant1, "USDC", true).Return(nil, nil)
+	mockStore.On("EnsureNoOngoingEscrowOperation", participant1, "USDC").Return(nil)
 	mockStatePacker.On("PackState", mock.Anything).Return([]byte("packed"), nil)
 	mockStore.On("RecordTransaction", mock.Anything, mock.Anything).Return(nil)
 
@@ -646,7 +636,7 @@ func TestSubmitAppState_CloseIntent_Success(t *testing.T) {
 	mockStore.On("RecordLedgerEntry", participant2, appSessionID, "USDC", decimal.NewFromInt(-50)).Return(nil)
 	mockStore.On("LockUserState", participant2, "USDC").Return(decimal.Zero, nil)
 	mockStore.On("GetLastUserState", participant2, "USDC", false).Return(existingUserState2, nil)
-	mockStore.On("GetLastUserState", participant2, "USDC", true).Return(nil, nil)
+	mockStore.On("EnsureNoOngoingEscrowOperation", participant2, "USDC").Return(nil)
 
 	// Capture stored states to verify node signatures
 	var capturedStates []core.State
@@ -988,7 +978,7 @@ func TestSubmitAppState_WithdrawIntent_MissingAllocation_Rejected(t *testing.T) 
 	mockStore.On("RecordLedgerEntry", participant1, appSessionID, "USDC", decimal.NewFromInt(-40)).Return(nil).Maybe()
 	mockStore.On("LockUserState", participant1, "USDC").Return(decimal.Zero, nil).Maybe()
 	mockStore.On("GetLastUserState", participant1, "USDC", false).Return(nil, nil).Maybe()
-	mockStore.On("GetLastUserState", participant1, "USDC", true).Return(nil, nil).Maybe()
+	mockStore.On("EnsureNoOngoingEscrowOperation", participant1, "USDC").Return(nil).Maybe()
 	mockStore.On("StoreUserState", mock.Anything, mock.Anything).Return(nil).Maybe()
 	mockStore.On("RecordTransaction", mock.Anything, mock.Anything).Return(nil).Maybe()
 

--- a/nitronode/api/app_session_v1/testing.go
+++ b/nitronode/api/app_session_v1/testing.go
@@ -108,6 +108,11 @@ func (m *MockStore) EnsureNoOngoingStateTransitions(wallet, asset string) error 
 	return args.Error(0)
 }
 
+func (m *MockStore) EnsureNoOngoingEscrowOperation(wallet, asset string) error {
+	args := m.Called(wallet, asset)
+	return args.Error(0)
+}
+
 func (m *MockStore) LockSessionKeyState(userAddress, sessionKey string, kind database.SessionKeyKind) (uint64, error) {
 	args := m.Called(userAddress, sessionKey, kind)
 	return uint64(args.Int(0)), args.Error(1)

--- a/nitronode/api/channel_v1/handler.go
+++ b/nitronode/api/channel_v1/handler.go
@@ -110,14 +110,8 @@ func (h *Handler) issueTransferReceiverState(ctx context.Context, tx Store, send
 		return nil, err
 	}
 
-	lastSignedState, err := tx.GetLastUserState(receiverWallet, senderState.Asset, true)
-	if err != nil {
-		return nil, rpc.Errorf("failed to get last %s user state for transfer receiver with address %s", senderState.Asset, receiverWallet)
-	}
-
-	// TODO: move to DB query
-	if lastSignedState != nil && lastSignedState.EscrowChannelID != nil {
-		return nil, rpc.Errorf("cannot issue release receiver state: last signed state is a lock with escrow channel %s", *lastSignedState.EscrowChannelID)
+	if err := tx.EnsureNoOngoingEscrowOperation(receiverWallet, senderState.Asset); err != nil {
+		return nil, rpc.Errorf("cannot issue transfer receiver state: %v", err)
 	}
 
 	if newState.HomeChannelID != nil {

--- a/nitronode/api/channel_v1/interface.go
+++ b/nitronode/api/channel_v1/interface.go
@@ -41,6 +41,11 @@ type Store interface {
 	// that would conflict with submitting a new state transition.
 	EnsureNoOngoingStateTransitions(wallet, asset string) error
 
+	// EnsureNoOngoingEscrowOperation validates that the user has no in-flight escrow
+	// operation (escrow_lock, mutual_lock, or unfinalized escrow_deposit/escrow_withdraw)
+	// that would prevent issuing a receiver-side state.
+	EnsureNoOngoingEscrowOperation(wallet, asset string) error
+
 	// ScheduleInitiateEscrowWithdrawal queues a blockchain action to initiate
 	// withdrawal from an escrow channel (triggered by escrow_lock transition).
 	ScheduleInitiateEscrowWithdrawal(stateID string, chainID uint64) error

--- a/nitronode/api/channel_v1/submit_state_test.go
+++ b/nitronode/api/channel_v1/submit_state_test.go
@@ -2,6 +2,7 @@ package channel_v1
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"strings"
 	"testing"
@@ -164,7 +165,7 @@ func TestSubmitState_TransferSend_Success(t *testing.T) {
 	// For issueTransferReceiverState
 	mockTxStore.On("LockUserState", receiverWallet, asset).Return(decimal.Zero, nil)
 	mockTxStore.On("GetLastUserState", receiverWallet, asset, false).Return(currentReceiverState, nil)
-	mockTxStore.On("GetLastUserState", receiverWallet, asset, true).Return(nil, nil)
+	mockTxStore.On("EnsureNoOngoingEscrowOperation", receiverWallet, asset).Return(nil)
 	mockTxStore.On("StoreUserState", mock.MatchedBy(func(state core.State) bool {
 		// Verify receiver state
 		return state.UserWallet == receiverWallet &&
@@ -324,17 +325,6 @@ func TestSubmitState_TransferSend_ReceiverWithEscrowLock_Rejected(t *testing.T) 
 		NodeSig:      nil,
 	}
 
-	// Receiver's last signed state has an active escrow channel
-	escrowChannelID := "0xEscrowChannel456"
-	lastSignedReceiverState := core.State{
-		Asset:           asset,
-		UserWallet:      receiverWallet,
-		Epoch:           1,
-		Version:         1,
-		HomeChannelID:   &homeChannelID,
-		EscrowChannelID: &escrowChannelID,
-	}
-
 	// Mock expectations
 	mockAssetStore.On("GetAssetDecimals", asset).Return(uint8(6), nil)
 	mockAssetStore.On("GetTokenDecimals", uint64(1), "0xTokenAddress").Return(uint8(6), nil)
@@ -352,7 +342,7 @@ func TestSubmitState_TransferSend_ReceiverWithEscrowLock_Rejected(t *testing.T) 
 	// For issueTransferReceiverState - receiver has an active escrow lock
 	mockTxStore.On("LockUserState", receiverWallet, asset).Return(decimal.Zero, nil)
 	mockTxStore.On("GetLastUserState", receiverWallet, asset, false).Return(currentReceiverState, nil)
-	mockTxStore.On("GetLastUserState", receiverWallet, asset, true).Return(lastSignedReceiverState, nil)
+	mockTxStore.On("EnsureNoOngoingEscrowOperation", receiverWallet, asset).Return(fmt.Errorf("escrow lock is still ongoing"))
 
 	// Create RPC request
 	rpcState := toRPCState(*incomingSenderState)
@@ -379,7 +369,7 @@ func TestSubmitState_TransferSend_ReceiverWithEscrowLock_Rejected(t *testing.T) 
 	require.NotNil(t, ctx.Response)
 	respErr := ctx.Response.Error()
 	require.NotNil(t, respErr, "Expected error when receiver has active escrow lock")
-	assert.Contains(t, respErr.Error(), "last signed state is a lock with escrow channel")
+	assert.Contains(t, respErr.Error(), "escrow lock is still ongoing")
 
 	mockTxStore.AssertExpectations(t)
 }

--- a/nitronode/api/channel_v1/testing.go
+++ b/nitronode/api/channel_v1/testing.go
@@ -56,6 +56,11 @@ func (m *MockStore) EnsureNoOngoingStateTransitions(wallet, asset string) error 
 	return args.Error(0)
 }
 
+func (m *MockStore) EnsureNoOngoingEscrowOperation(wallet, asset string) error {
+	args := m.Called(wallet, asset)
+	return args.Error(0)
+}
+
 func (m *MockStore) ScheduleInitiateEscrowWithdrawal(stateID string, chainID uint64) error {
 	args := m.Called(stateID, chainID)
 	return args.Error(0)

--- a/nitronode/store/database/db_store.go
+++ b/nitronode/store/database/db_store.go
@@ -237,3 +237,65 @@ func (s *DBStore) EnsureNoOngoingStateTransitions(wallet, asset string) error {
 
 	return nil
 }
+
+// EnsureNoOngoingEscrowOperation validates that the user has no in-flight escrow
+// operation that would prevent the node from issuing receiver-side states (transfer
+// receive, app-session release).
+//
+// Validation logic by latest signed transition type:
+//   - escrow_lock / mutual_lock: always considered ongoing (no finalization yet)
+//   - escrow_deposit / escrow_withdraw: only considered ongoing when the on-chain
+//     escrow channel state version has not caught up with the signed state version
+//   - any other transition: not an escrow operation, allow
+func (s *DBStore) EnsureNoOngoingEscrowOperation(wallet, asset string) error {
+	wallet = strings.ToLower(wallet)
+
+	type escrowCheck struct {
+		TransitionType       core.TransitionType
+		StateVersion         uint64
+		EscrowChannelVersion *uint64
+	}
+
+	var result escrowCheck
+	tx := s.db.Raw(`
+		SELECT
+			s.transition_type as transition_type,
+			s.version as state_version,
+			ec.state_version as escrow_channel_version
+		FROM channel_states s
+		LEFT JOIN channels ec ON ec.channel_id = s.escrow_channel_id
+		WHERE s.user_wallet = ?
+			AND s.asset = ?
+			AND s.user_sig IS NOT NULL
+			AND s.node_sig IS NOT NULL
+		ORDER BY s.epoch DESC, s.version DESC
+		LIMIT 1
+	`, wallet, asset).Scan(&result)
+
+	if tx.Error != nil {
+		return fmt.Errorf("failed to check ongoing escrow operation: %w", tx.Error)
+	}
+	if tx.RowsAffected == 0 {
+		return nil
+	}
+
+	switch result.TransitionType {
+	case core.TransitionTypeEscrowLock:
+		return fmt.Errorf("escrow lock is still ongoing")
+
+	case core.TransitionTypeMutualLock:
+		return fmt.Errorf("mutual lock is still ongoing")
+
+	case core.TransitionTypeEscrowDeposit:
+		if result.EscrowChannelVersion != nil && result.StateVersion != *result.EscrowChannelVersion {
+			return fmt.Errorf("escrow deposit finalization is still ongoing")
+		}
+
+	case core.TransitionTypeEscrowWithdraw:
+		if result.EscrowChannelVersion != nil && result.StateVersion != *result.EscrowChannelVersion {
+			return fmt.Errorf("escrow withdrawal finalization is still ongoing")
+		}
+	}
+
+	return nil
+}

--- a/nitronode/store/database/db_store.go
+++ b/nitronode/store/database/db_store.go
@@ -199,38 +199,38 @@ func (s *DBStore) EnsureNoOngoingStateTransitions(wallet, asset string) error {
 	switch result.TransitionType {
 	case core.TransitionTypeHomeDeposit:
 		// Verify last_state.version == home_channel.state_version
-		if result.HomeChannelVersion != nil && result.StateVersion != *result.HomeChannelVersion {
+		if result.HomeChannelVersion == nil || result.StateVersion != *result.HomeChannelVersion {
 			return fmt.Errorf("home deposit is still ongoing")
 		}
 
 	case core.TransitionTypeHomeWithdrawal:
 		// Verify last_state.version == home_channel.state_version
-		if result.HomeChannelVersion != nil && result.StateVersion != *result.HomeChannelVersion {
+		if result.HomeChannelVersion == nil || result.StateVersion != *result.HomeChannelVersion {
 			return fmt.Errorf("home withdrawal is still ongoing")
 		}
 
 	case core.TransitionTypeMutualLock:
 		// Verify last_state.version == home_channel.state_version == escrow_channel.state_version
-		if result.HomeChannelVersion != nil && result.StateVersion != *result.HomeChannelVersion ||
-			result.EscrowChannelVersion != nil && result.StateVersion != *result.EscrowChannelVersion {
+		if result.HomeChannelVersion == nil || result.StateVersion != *result.HomeChannelVersion ||
+			result.EscrowChannelVersion == nil || result.StateVersion != *result.EscrowChannelVersion {
 			return fmt.Errorf("mutual lock is still ongoing")
 		}
 
 	case core.TransitionTypeEscrowLock:
 		// Verify last_state.version == escrow_channel.state_version
-		if result.EscrowChannelVersion != nil && result.StateVersion != *result.EscrowChannelVersion {
+		if result.EscrowChannelVersion == nil || result.StateVersion != *result.EscrowChannelVersion {
 			return fmt.Errorf("escrow lock is still ongoing")
 		}
 
 	case core.TransitionTypeEscrowWithdraw:
 		// Verify last_state.version == escrow_channel.state_version
-		if result.EscrowChannelVersion != nil && result.StateVersion != *result.EscrowChannelVersion {
+		if result.EscrowChannelVersion == nil || result.StateVersion != *result.EscrowChannelVersion {
 			return fmt.Errorf("escrow withdrawal is still ongoing")
 		}
 
 	case core.TransitionTypeMigrate:
 		// Verify last_state.version == home_channel.state_version
-		if result.HomeChannelVersion != nil && result.StateVersion != *result.HomeChannelVersion {
+		if result.HomeChannelVersion == nil || result.StateVersion != *result.HomeChannelVersion {
 			return fmt.Errorf("home chain migration is still ongoing")
 		}
 	}
@@ -287,12 +287,12 @@ func (s *DBStore) EnsureNoOngoingEscrowOperation(wallet, asset string) error {
 		return fmt.Errorf("mutual lock is still ongoing")
 
 	case core.TransitionTypeEscrowDeposit:
-		if result.EscrowChannelVersion != nil && result.StateVersion != *result.EscrowChannelVersion {
+		if result.EscrowChannelVersion == nil || result.StateVersion != *result.EscrowChannelVersion {
 			return fmt.Errorf("escrow deposit finalization is still ongoing")
 		}
 
 	case core.TransitionTypeEscrowWithdraw:
-		if result.EscrowChannelVersion != nil && result.StateVersion != *result.EscrowChannelVersion {
+		if result.EscrowChannelVersion == nil || result.StateVersion != *result.EscrowChannelVersion {
 			return fmt.Errorf("escrow withdrawal finalization is still ongoing")
 		}
 	}

--- a/nitronode/store/database/db_store_test.go
+++ b/nitronode/store/database/db_store_test.go
@@ -645,6 +645,170 @@ func TestDBStore_EnsureNoOngoingStateTransitions(t *testing.T) {
 		err = store.EnsureNoOngoingStateTransitions("0xuser123", "USDC")
 		require.NoError(t, err)
 	})
+
+	const wallet = "0xuser123"
+	const asset = "USDC"
+	const homeChannelID = "0xhomechannel123"
+	const escrowChannelID = "0xescrowchannel456"
+	userSig := "0xusersig"
+	nodeSig := "0xnodesig"
+
+	newHomeChannel := func(version uint64) core.Channel {
+		return core.Channel{
+			ChannelID:         homeChannelID,
+			UserWallet:        wallet,
+			Asset:             "usdc",
+			Type:              core.ChannelTypeHome,
+			BlockchainID:      1,
+			TokenAddress:      "0xtoken123",
+			ChallengeDuration: 86400,
+			Nonce:             1,
+			Status:            core.ChannelStatusOpen,
+			StateVersion:      version,
+		}
+	}
+
+	newEscrowChannel := func(version uint64) core.Channel {
+		return core.Channel{
+			ChannelID:         escrowChannelID,
+			UserWallet:        wallet,
+			Asset:             "usdc",
+			Type:              core.ChannelTypeEscrow,
+			BlockchainID:      137,
+			TokenAddress:      "0xtoken456",
+			ChallengeDuration: 86400,
+			Nonce:             1,
+			Status:            core.ChannelStatusOpen,
+			StateVersion:      version,
+		}
+	}
+
+	newSignedState := func(version uint64, transitionType core.TransitionType, withEscrow bool) core.State {
+		hc := homeChannelID
+		state := core.State{
+			ID:            "state1",
+			Asset:         asset,
+			UserWallet:    wallet,
+			Epoch:         1,
+			Version:       version,
+			HomeChannelID: &hc,
+			Transition:    core.Transition{Type: transitionType},
+			HomeLedger: core.Ledger{
+				UserBalance: decimal.NewFromInt(500),
+				UserNetFlow: decimal.Zero,
+				NodeBalance: decimal.Zero,
+				NodeNetFlow: decimal.Zero,
+			},
+			UserSig: &userSig,
+			NodeSig: &nodeSig,
+		}
+		if withEscrow {
+			ec := escrowChannelID
+			state.EscrowChannelID = &ec
+			state.EscrowLedger = &core.Ledger{
+				UserBalance: decimal.NewFromInt(500),
+				UserNetFlow: decimal.Zero,
+				NodeBalance: decimal.Zero,
+				NodeNetFlow: decimal.Zero,
+			}
+		}
+		return state
+	}
+
+	storeState := func(t *testing.T, store DatabaseStore, state core.State) {
+		t.Helper()
+		_, err := store.LockUserState(wallet, asset)
+		require.NoError(t, err)
+		require.NoError(t, store.StoreUserState(state, ""))
+	}
+
+	t.Run("HomeDeposit - home channel missing from DB - block", func(t *testing.T) {
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+
+		store := NewDBStore(db)
+		storeState(t, store, newSignedState(1, core.TransitionTypeHomeDeposit, false))
+
+		err := store.EnsureNoOngoingStateTransitions(wallet, asset)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "home deposit is still ongoing")
+	})
+
+	t.Run("HomeWithdrawal - home channel missing from DB - block", func(t *testing.T) {
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+
+		store := NewDBStore(db)
+		storeState(t, store, newSignedState(1, core.TransitionTypeHomeWithdrawal, false))
+
+		err := store.EnsureNoOngoingStateTransitions(wallet, asset)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "home withdrawal is still ongoing")
+	})
+
+	t.Run("MutualLock - home channel missing from DB - block", func(t *testing.T) {
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+
+		store := NewDBStore(db)
+		require.NoError(t, store.CreateChannel(newEscrowChannel(2)))
+		storeState(t, store, newSignedState(2, core.TransitionTypeMutualLock, true))
+
+		err := store.EnsureNoOngoingStateTransitions(wallet, asset)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "mutual lock is still ongoing")
+	})
+
+	t.Run("MutualLock - escrow channel missing from DB - block", func(t *testing.T) {
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+
+		store := NewDBStore(db)
+		require.NoError(t, store.CreateChannel(newHomeChannel(2)))
+		storeState(t, store, newSignedState(2, core.TransitionTypeMutualLock, true))
+
+		err := store.EnsureNoOngoingStateTransitions(wallet, asset)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "mutual lock is still ongoing")
+	})
+
+	t.Run("EscrowLock - escrow channel missing from DB - block", func(t *testing.T) {
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+
+		store := NewDBStore(db)
+		require.NoError(t, store.CreateChannel(newHomeChannel(1)))
+		storeState(t, store, newSignedState(1, core.TransitionTypeEscrowLock, true))
+
+		err := store.EnsureNoOngoingStateTransitions(wallet, asset)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "escrow lock is still ongoing")
+	})
+
+	t.Run("EscrowWithdraw - escrow channel missing from DB - block", func(t *testing.T) {
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+
+		store := NewDBStore(db)
+		require.NoError(t, store.CreateChannel(newHomeChannel(4)))
+		storeState(t, store, newSignedState(4, core.TransitionTypeEscrowWithdraw, true))
+
+		err := store.EnsureNoOngoingStateTransitions(wallet, asset)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "escrow withdrawal is still ongoing")
+	})
+
+	t.Run("Migrate - home channel missing from DB - block", func(t *testing.T) {
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+
+		store := NewDBStore(db)
+		storeState(t, store, newSignedState(1, core.TransitionTypeMigrate, false))
+
+		err := store.EnsureNoOngoingStateTransitions(wallet, asset)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "home chain migration is still ongoing")
+	})
 }
 
 func TestDBStore_UpdateStateUserSigIfMissing(t *testing.T) {
@@ -998,6 +1162,34 @@ func TestDBStore_EnsureNoOngoingEscrowOperation(t *testing.T) {
 		store := NewDBStore(db)
 		require.NoError(t, store.CreateChannel(homeChannel))
 		require.NoError(t, store.CreateChannel(newEscrowChannel(2)))
+
+		storeState(t, store, newSignedState(3, core.TransitionTypeEscrowWithdraw, true))
+
+		err := store.EnsureNoOngoingEscrowOperation(wallet, asset)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "escrow withdrawal finalization is still ongoing")
+	})
+
+	t.Run("EscrowDeposit - escrow channel missing from DB - block", func(t *testing.T) {
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+
+		store := NewDBStore(db)
+		require.NoError(t, store.CreateChannel(homeChannel))
+
+		storeState(t, store, newSignedState(2, core.TransitionTypeEscrowDeposit, true))
+
+		err := store.EnsureNoOngoingEscrowOperation(wallet, asset)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "escrow deposit finalization is still ongoing")
+	})
+
+	t.Run("EscrowWithdraw - escrow channel missing from DB - block", func(t *testing.T) {
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+
+		store := NewDBStore(db)
+		require.NoError(t, store.CreateChannel(homeChannel))
 
 		storeState(t, store, newSignedState(3, core.TransitionTypeEscrowWithdraw, true))
 

--- a/nitronode/store/database/db_store_test.go
+++ b/nitronode/store/database/db_store_test.go
@@ -821,3 +821,209 @@ func TestDBStore_UpdateStateUserSigIfMissing(t *testing.T) {
 		require.NoError(t, store.UpdateStateUserSigIfMissing(homeChannelID, 99, "0xanything"))
 	})
 }
+
+func TestDBStore_EnsureNoOngoingEscrowOperation(t *testing.T) {
+	const wallet = "0xuser123"
+	const asset = "USDC"
+	const homeChannelID = "0xhomechannel123"
+	const escrowChannelID = "0xescrowchannel456"
+	const userSig = "0xusersig"
+	const nodeSig = "0xnodesig"
+
+	homeChannel := core.Channel{
+		ChannelID:         homeChannelID,
+		UserWallet:        wallet,
+		Asset:             "usdc",
+		Type:              core.ChannelTypeHome,
+		BlockchainID:      1,
+		TokenAddress:      "0xtoken123",
+		ChallengeDuration: 86400,
+		Nonce:             1,
+		Status:            core.ChannelStatusOpen,
+		StateVersion:      1,
+	}
+
+	newEscrowChannel := func(version uint64) core.Channel {
+		return core.Channel{
+			ChannelID:         escrowChannelID,
+			UserWallet:        wallet,
+			Asset:             "usdc",
+			Type:              core.ChannelTypeEscrow,
+			BlockchainID:      137,
+			TokenAddress:      "0xtoken456",
+			ChallengeDuration: 86400,
+			Nonce:             1,
+			Status:            core.ChannelStatusOpen,
+			StateVersion:      version,
+		}
+	}
+
+	newSignedState := func(version uint64, transitionType core.TransitionType, withEscrow bool) core.State {
+		state := core.State{
+			ID:            "state1",
+			Asset:         asset,
+			UserWallet:    wallet,
+			Epoch:         1,
+			Version:       version,
+			HomeChannelID: ptr(homeChannelID),
+			Transition:    core.Transition{Type: transitionType},
+			HomeLedger: core.Ledger{
+				UserBalance: decimal.NewFromInt(500),
+				UserNetFlow: decimal.Zero,
+				NodeBalance: decimal.Zero,
+				NodeNetFlow: decimal.Zero,
+			},
+			UserSig: ptr(userSig),
+			NodeSig: ptr(nodeSig),
+		}
+		if withEscrow {
+			state.EscrowChannelID = ptr(escrowChannelID)
+			state.EscrowLedger = &core.Ledger{
+				UserBalance: decimal.NewFromInt(500),
+				UserNetFlow: decimal.Zero,
+				NodeBalance: decimal.Zero,
+				NodeNetFlow: decimal.Zero,
+			}
+		}
+		return state
+	}
+
+	storeState := func(t *testing.T, store DatabaseStore, state core.State) {
+		t.Helper()
+		_, err := store.LockUserState(wallet, asset)
+		require.NoError(t, err)
+		require.NoError(t, store.StoreUserState(state, ""))
+	}
+
+	t.Run("No previous state - allow", func(t *testing.T) {
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+
+		store := NewDBStore(db)
+
+		err := store.EnsureNoOngoingEscrowOperation(wallet, asset)
+		require.NoError(t, err)
+	})
+
+	t.Run("Non-escrow transition (TransferSend) - allow", func(t *testing.T) {
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+
+		store := NewDBStore(db)
+		require.NoError(t, store.CreateChannel(homeChannel))
+
+		storeState(t, store, newSignedState(1, core.TransitionTypeTransferSend, false))
+
+		err := store.EnsureNoOngoingEscrowOperation(wallet, asset)
+		require.NoError(t, err)
+	})
+
+	t.Run("EscrowLock - block", func(t *testing.T) {
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+
+		store := NewDBStore(db)
+		require.NoError(t, store.CreateChannel(homeChannel))
+		require.NoError(t, store.CreateChannel(newEscrowChannel(1)))
+
+		storeState(t, store, newSignedState(1, core.TransitionTypeEscrowLock, true))
+
+		err := store.EnsureNoOngoingEscrowOperation(wallet, asset)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "escrow lock is still ongoing")
+	})
+
+	t.Run("MutualLock - block", func(t *testing.T) {
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+
+		store := NewDBStore(db)
+		require.NoError(t, store.CreateChannel(homeChannel))
+		require.NoError(t, store.CreateChannel(newEscrowChannel(1)))
+
+		storeState(t, store, newSignedState(1, core.TransitionTypeMutualLock, true))
+
+		err := store.EnsureNoOngoingEscrowOperation(wallet, asset)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "mutual lock is still ongoing")
+	})
+
+	t.Run("EscrowDeposit - chain caught up - allow", func(t *testing.T) {
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+
+		store := NewDBStore(db)
+		require.NoError(t, store.CreateChannel(homeChannel))
+		require.NoError(t, store.CreateChannel(newEscrowChannel(2)))
+
+		storeState(t, store, newSignedState(2, core.TransitionTypeEscrowDeposit, true))
+
+		err := store.EnsureNoOngoingEscrowOperation(wallet, asset)
+		require.NoError(t, err)
+	})
+
+	t.Run("EscrowDeposit - chain not synced - block", func(t *testing.T) {
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+
+		store := NewDBStore(db)
+		require.NoError(t, store.CreateChannel(homeChannel))
+		require.NoError(t, store.CreateChannel(newEscrowChannel(1)))
+
+		storeState(t, store, newSignedState(2, core.TransitionTypeEscrowDeposit, true))
+
+		err := store.EnsureNoOngoingEscrowOperation(wallet, asset)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "escrow deposit finalization is still ongoing")
+	})
+
+	t.Run("EscrowWithdraw - chain caught up - allow", func(t *testing.T) {
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+
+		store := NewDBStore(db)
+		require.NoError(t, store.CreateChannel(homeChannel))
+		require.NoError(t, store.CreateChannel(newEscrowChannel(3)))
+
+		storeState(t, store, newSignedState(3, core.TransitionTypeEscrowWithdraw, true))
+
+		err := store.EnsureNoOngoingEscrowOperation(wallet, asset)
+		require.NoError(t, err)
+	})
+
+	t.Run("EscrowWithdraw - chain not synced - block", func(t *testing.T) {
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+
+		store := NewDBStore(db)
+		require.NoError(t, store.CreateChannel(homeChannel))
+		require.NoError(t, store.CreateChannel(newEscrowChannel(2)))
+
+		storeState(t, store, newSignedState(3, core.TransitionTypeEscrowWithdraw, true))
+
+		err := store.EnsureNoOngoingEscrowOperation(wallet, asset)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "escrow withdrawal finalization is still ongoing")
+	})
+
+	t.Run("Unsigned state - ignored", func(t *testing.T) {
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+
+		store := NewDBStore(db)
+		require.NoError(t, store.CreateChannel(homeChannel))
+		require.NoError(t, store.CreateChannel(newEscrowChannel(1)))
+
+		state := newSignedState(2, core.TransitionTypeEscrowLock, true)
+		state.UserSig = nil
+		state.NodeSig = nil
+		storeState(t, store, state)
+
+		err := store.EnsureNoOngoingEscrowOperation(wallet, asset)
+		require.NoError(t, err)
+	})
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}

--- a/nitronode/store/database/interface.go
+++ b/nitronode/store/database/interface.go
@@ -80,6 +80,11 @@ type DatabaseStore interface {
 	// EnsureNoOngoingStateTransitions validates that no conflicting blockchain operations are pending.
 	EnsureNoOngoingStateTransitions(wallet, asset string) error
 
+	// EnsureNoOngoingEscrowOperation validates that the user has no in-flight escrow
+	// operation (escrow_lock, mutual_lock, or unfinalized escrow_deposit/escrow_withdraw)
+	// that would prevent issuing a receiver-side state.
+	EnsureNoOngoingEscrowOperation(wallet, asset string) error
+
 	// UpdateStateUserSigIfMissing backfills the user signature for a stored state when it is currently NULL.
 	UpdateStateUserSigIfMissing(channelID string, version uint64, userSig string) error
 


### PR DESCRIPTION
## Summary
- Replace the `lastSignedState.EscrowChannelID != nil` guard in `issueTransferReceiverState` (`channel_v1`) and `issueReleaseReceiverState` (`app_session_v1`) with a new `EnsureNoOngoingEscrowOperation(wallet, asset)` store method.
- Predicate keys on the latest signed transition type instead of the raw `EscrowChannelID` field: `EscrowLock` / `MutualLock` always block; `EscrowDeposit` / `EscrowWithdraw` block only when the on-chain escrow channel `state_version` hasn't caught up; everything else allows.
- Adds DB-store tests covering all branches (no prior state, non-escrow, lock-types, finalize synced/unsynced, unsigned).

## Background (audit MF-M07)
The previous guard rejected any receiver-side state whenever the receiver's latest signed state had a non-nil `EscrowChannelID`. The field is cleared by `State.NextState()` only when the previous transition was `EscrowDeposit` or `EscrowWithdraw`, so the signed state itself retains it after a finalized escrow flow. As a result, a user who completed a deposit/withdrawal could be unable to receive transfers or app-session releases until an unrelated off-chain action advanced past the finalized state.

The replacement matches the existing `EnsureNoOngoingStateTransitions` pattern (transition type + state.version vs channel.state_version) but is scoped to escrow concerns only, so home-deposit / home-withdrawal logic is untouched.

## Test plan
- [x] `go test ./nitronode/store/database/... -run EnsureNoOngoingEscrowOperation -v`
- [x] `go test ./nitronode/...`
- [x] `go test ./pkg/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Enhanced escrow operation validation to detect and block state transitions when escrow activities are in-flight, including locks, deposits, and withdrawals for wallet-asset pairs.
  - Strengthened operational safeguards by preventing state changes during pending escrow operations not yet finalized on-chain.
  - Improved consistency of escrow-related state management across payment channel and application session handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->