### PR TITLE
Harden SDK MCP release workflow and deps

### DIFF
--- a/.github/workflows/publish-sdk-mcp.yml
+++ b/.github/workflows/publish-sdk-mcp.yml
@@ -38,7 +38,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: 'https://registry.npmjs.org'
           cache: npm
           cache-dependency-path: 'sdk/mcp/package-lock.json'
 
@@ -59,7 +58,7 @@ jobs:
         run: npm run build
 
       - name: Verify release preflight
-        if: startsWith(github.ref, 'refs/tags/mcp-v')
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/mcp-v')
         working-directory: ./sdk/mcp
         run: npm run verify:release-preflight
 
@@ -95,7 +94,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Download package artifact
         uses: actions/download-artifact@v4
@@ -212,7 +210,7 @@ jobs:
     needs:
       - verify-and-pack
       - smoke
-    if: startsWith(github.ref, 'refs/tags/mcp-v')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/mcp-v')
     environment: mcp-release
     permissions:
       contents: read
@@ -239,7 +237,7 @@ jobs:
     name: Publish MCP Registry metadata
     runs-on: ubuntu-latest
     needs: publish-npm
-    if: startsWith(github.ref, 'refs/tags/mcp-v')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/mcp-v')
     environment: mcp-release
     permissions:
       contents: read

--- a/sdk/mcp/package-lock.json
+++ b/sdk/mcp/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.28.0",
-        "zod": "^3.23.0"
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^4.4.3"
       },
       "bin": {
         "yellow-sdk-mcp": "dist/index.js"
@@ -479,9 +479,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.28.0.tgz",
-      "integrity": "sha512-gmloF+i+flI8ouQK7MWW4mOwuMh4RePBuPFAEPC6+pdqyWOUMDOixb6qZ69owLJpz6XmyllCouc4t8YWO+E2Nw==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -1103,9 +1103,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1703,9 +1703,9 @@
       "license": "ISC"
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/sdk/mcp/package.json
+++ b/sdk/mcp/package.json
@@ -25,8 +25,8 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.28.0",
-    "zod": "^3.23.0"
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^4.4.3"
   },
   "overrides": {
     "ip-address": "^10.2.0"

--- a/sdk/mcp/scripts/prepare-package-content.mjs
+++ b/sdk/mcp/scripts/prepare-package-content.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 import { createHash } from 'node:crypto';
 import { execFileSync } from 'node:child_process';
-import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
-import { dirname, join, relative, resolve, sep } from 'node:path';
+import { cpSync, existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
@@ -33,6 +33,12 @@ function readJson(path) {
   return JSON.parse(readFileSync(path, 'utf-8'));
 }
 
+function assertWithin(root, path) {
+  const rel = relative(root, path);
+  if (rel === '' || (!rel.startsWith('..') && !isAbsolute(rel))) return;
+  throw new Error(`Refusing to write outside ${relative(repoRoot, root)}: ${path}`);
+}
+
 function getSourceCommit() {
   if (process.env.GITHUB_SHA) return process.env.GITHUB_SHA;
   try {
@@ -59,6 +65,11 @@ function copyFilteredDirectory(sourceDir, targetDir, extensions) {
     if (entry === 'node_modules' || entry === 'dist') continue;
     const sourcePath = join(sourceDir, entry);
     const targetPath = join(targetDir, entry);
+    assertWithin(contentRoot, targetPath);
+    const linkStats = lstatSync(sourcePath);
+    if (linkStats.isSymbolicLink()) {
+      throw new Error(`Refusing to package symlink: ${relative(repoRoot, sourcePath)}`);
+    }
     const stats = statSync(sourcePath);
     if (stats.isDirectory()) {
       copied += copyFilteredDirectory(sourcePath, targetPath, extensions);
@@ -112,6 +123,8 @@ const copyResults = [];
 for (const spec of copySpecs) {
   const sourcePath = resolve(repoRoot, spec.from);
   const targetPath = resolve(contentRoot, spec.to);
+  assertWithin(repoRoot, sourcePath);
+  assertWithin(contentRoot, targetPath);
   if (!existsSync(sourcePath)) {
     if (spec.required) {
       throw new Error(`Missing required content source: ${relative(repoRoot, sourcePath)}`);
@@ -120,6 +133,10 @@ for (const spec of copySpecs) {
     continue;
   }
   const stats = statSync(sourcePath);
+  const linkStats = lstatSync(sourcePath);
+  if (linkStats.isSymbolicLink()) {
+    throw new Error(`Refusing to package symlink: ${relative(repoRoot, sourcePath)}`);
+  }
   let files = 0;
   if (stats.isDirectory()) {
     files = copyFilteredDirectory(sourcePath, targetPath, spec.extensions);

--- a/sdk/mcp/scripts/set-executable.mjs
+++ b/sdk/mcp/scripts/set-executable.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-import { chmodSync, existsSync, statSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { chmodSync, existsSync, lstatSync, statSync } from 'node:fs';
+import { isAbsolute, relative, resolve } from 'node:path';
 
 const target = process.argv[2];
 
@@ -9,9 +9,18 @@ if (!target) {
 }
 
 const targetPath = resolve(process.cwd(), target);
+const rel = relative(process.cwd(), targetPath);
+
+if (rel === '' || rel.startsWith('..') || isAbsolute(rel)) {
+  throw new Error(`Executable target must stay inside the package directory: ${target}`);
+}
 
 if (!existsSync(targetPath)) {
   throw new Error(`Cannot make missing file executable: ${target}`);
+}
+
+if (lstatSync(targetPath).isSymbolicLink()) {
+  throw new Error(`Executable target must not be a symlink: ${target}`);
 }
 
 if (!statSync(targetPath).isFile()) {

--- a/sdk/mcp/src/index.ts
+++ b/sdk/mcp/src/index.ts
@@ -1807,6 +1807,10 @@ server.resource('protocol-auth-flow', 'nitrolite://protocol/auth-flow', async ()
 
 // ========================== TOOLS ==========================================
 
+function boundedToolString(description: string, max = 120) {
+    return z.string().trim().min(1).max(max).describe(description);
+}
+
 server.tool(
     'server_info',
     'Return Yellow SDK MCP package, SDK, compat, and indexed content version information for debugging and support.',
@@ -1841,7 +1845,7 @@ server.tool(
     'lookup_method',
     'Look up a specific SDK Client method by name — returns signature, params, return type, usage context',
     {
-        name: z.string().describe('Method name (e.g. "transfer", "deposit", "getChannels", "Transfer", "Deposit")'),
+        name: boundedToolString('Method name (e.g. "transfer", "deposit", "getChannels", "Transfer", "Deposit")'),
         language: z.enum(['typescript', 'go', 'both']).optional().default('typescript').describe('SDK language to search: "typescript" (default), "go", or "both"'),
     },
     async ({ name, language }) => {
@@ -1879,7 +1883,7 @@ server.tool(
     'lookup_type',
     'Look up a type, interface, or enum by name — returns fields and source location',
     {
-        name: z.string().describe('Type name (e.g. "Channel", "State", "RPCMethod", "AppSessionV1", "ChannelStatus")'),
+        name: boundedToolString('Type name (e.g. "Channel", "State", "RPCMethod", "AppSessionV1", "ChannelStatus")'),
         language: z.enum(['typescript', 'go', 'both']).optional().default('typescript').describe('SDK language to search: "typescript" (default), "go", or "both"'),
     },
     async ({ name, language }) => {
@@ -1922,7 +1926,7 @@ server.tool(
     'search_api',
     'Fuzzy search across all SDK methods and types',
     {
-        query: z.string().describe('Search query (e.g. "session key", "balance", "transfer", "AppSession")'),
+        query: boundedToolString('Search query (e.g. "session key", "balance", "transfer", "AppSession")', 160),
         language: z.enum(['typescript', 'go', 'both']).optional().default('typescript').describe('SDK language to search: "typescript" (default), "go", or "both"'),
     },
     async ({ query, language }) => {
@@ -1982,7 +1986,7 @@ server.tool(
 server.tool(
     'get_rpc_method',
     'Get the RPC wire format for a 0.5.x compat-layer method and its v1 equivalent. For v1 method reference, see docs/api.yaml.',
-    { method: z.string().describe('0.5.x compat method name (e.g. "get_channels", "transfer", "create_app_session")') },
+    { method: boundedToolString('0.5.x compat method name (e.g. "get_channels", "transfer", "create_app_session")') },
     async ({ method }) => {
         // NOTE: These are 0.5.x compat-layer method names mapped to their v1 wire equivalents.
         // The v1 API uses grouped methods (e.g. channels.v1.submit_state). The canonical v1
@@ -2015,7 +2019,7 @@ server.tool(
 server.tool(
     'validate_import',
     'Check if a symbol is exported from sdk-compat barrel — returns yes/no + correct import path',
-    { symbol: z.string().describe('Symbol name (e.g. "NitroliteClient", "RPCMethod", "createTransferMessage")') },
+    { symbol: boundedToolString('Symbol name (e.g. "NitroliteClient", "RPCMethod", "createTransferMessage")') },
     async ({ symbol }) => {
         const compatMatch = findNamedExport(compatExports, symbol);
         if (compatMatch.found) {
@@ -2037,7 +2041,7 @@ server.tool(
 server.tool(
     'explain_concept',
     'Plain-English explanation of a Nitrolite protocol concept (e.g. "state channel", "app session", "challenge period")',
-    { concept: z.string().describe('Concept name (e.g. "state channel", "app session", "challenge period", "nitronode", "vault")') },
+    { concept: boundedToolString('Concept name (e.g. "state channel", "app session", "challenge period", "nitronode", "vault")') },
     async ({ concept }) => {
         const query = concept.toLowerCase().trim();
 
@@ -2076,7 +2080,7 @@ server.tool(
 server.tool(
     'lookup_rpc_method',
     'Look up a v1 RPC method from docs/api.yaml — returns description, request/response fields. Methods use grouped naming: {group}.v1.{method}',
-    { method: z.string().describe('V1 RPC method name or search term (e.g. "channels.v1.get_home_channel", "submit_state", "get_balances")') },
+    { method: boundedToolString('V1 RPC method name or search term (e.g. "channels.v1.get_home_channel", "submit_state", "get_balances")') },
     async ({ method }) => {
         const query = method.toLowerCase().trim();
 


### PR DESCRIPTION
## Summary
- harden the SDK MCP publish workflow so npm/MCP release jobs require push tag events and PR validation does not configure the npm registry
- absorb Dependabot PR #729 by updating `hono` to `4.12.18`
- bump unpublished MCP direct dependencies: `@modelcontextprotocol/sdk` to `^1.29.0` and `zod` to `^4.4.3`
- add package-script hardening for symlink/path traversal cases and bound MCP tool string inputs

## Root Cause
PR validation was not publishing, but `publish-sdk-mcp.yml` ran on PRs that touched shared paths and the validation jobs configured npm registry publishing context. That made the CI job look publish-adjacent. Actual publish jobs were skipped on PRs; this adds explicit `push` + `mcp-v*` tag guards and keeps npm registry configuration scoped to the real publish job.

## Related
- Includes the dependency fix from https://github.com/layer-3/nitrolite/pull/729

## Validation
- `npm ci`
- `npm audit --omit=dev --audit-level=moderate`
- `npm audit signatures`
- production dependency install-script scan
- `npm outdated --omit=dev --json`
- `npm run typecheck`
- `npm run build`
- CI-style `npm pack` + `npm run verify:package`
- installed-tarball MCP smoke test
- `actionlint`
- `git diff --check`
- negative tests for symlink packaging and external chmod target rejection

Note: Semgrep was not available through npm in this environment, so the SAST pass used static review/code tracing plus targeted negative tests for the concrete filesystem risks fixed here.
