### PR TITLE
MF-L02: docs(protocol): qualify enforcement guarantee for intent-specific execution paths

### DIFF
--- a/docs/protocol/enforcement.md
+++ b/docs/protocol/enforcement.md
@@ -31,7 +31,7 @@ Node-issued pending states (those carrying only the node's signature) are NOT en
 Off-chain states and on-chain enforcement states are related as follows:
 
 - Participants advance state off-chain through signed updates
-- At any time, any party MAY submit the latest mutually signed state to the blockchain layer
+- Any party MAY submit the latest mutually signed state to the blockchain layer, provided a valid execution path exists for that state's intent in the current channel context
 - The blockchain layer validates the submitted state and updates its record
 - On-chain state always reflects the latest successfully checkpointed state
 
@@ -69,7 +69,7 @@ The creation process:
 3. The blockchain layer validates signatures, creates the channel record, and applies fund effects according to the state's intent
 4. The channel is now active on the on-chain layer
 
-The state submitted for channel creation MAY carry a DEPOSIT, WITHDRAW, or OPERATE intent.
+The state submitted for channel creation MAY carry a DEPOSIT, WITHDRAW, or OPERATE intent. OPERATE intent requires the user net flow delta to be zero relative to the previous on-chain state (which is the empty state for a new channel). An OPERATE state that carries accumulated user net flow from an unconfirmed prior DEPOSIT state cannot be used to create a channel — parties MUST enforce the DEPOSIT state on-chain before advancing to subsequent OPERATE states that depend on it.
 
 ## State Submission
 

--- a/docs/protocol/enforcement.md
+++ b/docs/protocol/enforcement.md
@@ -69,7 +69,7 @@ The creation process:
 3. The blockchain layer validates signatures, creates the channel record, and applies fund effects according to the state's intent
 4. The channel is now active on the on-chain layer
 
-The state submitted for channel creation MAY carry a DEPOSIT, WITHDRAW, or OPERATE intent. OPERATE intent requires the user net flow delta to be zero relative to the previous on-chain state (which is the empty state for a new channel). An OPERATE state that carries accumulated user net flow from an unconfirmed prior DEPOSIT state cannot be used to create a channel — parties MUST enforce the DEPOSIT state on-chain before advancing to subsequent OPERATE states that depend on it.
+The state submitted for channel creation MAY carry a DEPOSIT, WITHDRAW, or OPERATE intent. OPERATE intent requires the user net flow delta to be zero relative to the previous on-chain state (which is the empty state for a new channel). An OPERATE state that carries accumulated user net flow from an unenforced prior DEPOSIT state cannot be used to create or checkpoint a channel — parties MUST enforce the DEPOSIT state on-chain before advancing to subsequent OPERATE states that depend on it.
 
 ## State Submission
 

--- a/docs/protocol/overview.md
+++ b/docs/protocol/overview.md
@@ -60,7 +60,7 @@ A state represents the current agreed asset allocations and metadata shared betw
 User and a node advance states off-chain by exchanging signed state transitions. Each new state MUST have a version exactly one greater than the previous state. Transitions include deposits, withdrawals, transfers, commits, releases, escrow operations, and migrations.
 
 **State Enforcement**
-Any party MAY submit the latest signed state to the blockchain layer for on-chain enforcement. The blockchain layer validates signatures, version ordering, and ledger invariants before accepting a state.
+Any party MAY submit the latest mutually signed state to the blockchain layer for on-chain enforcement, provided that state's intent has a valid execution path in the current channel context. The blockchain layer validates signatures, version ordering, and ledger invariants before accepting a state.
 
 **Unified Assets**
 The same asset from multiple blockchains is represented in a unified model, enabling cross-chain operations among users and apps. The protocol normalizes amounts by decimal precision when comparing allocations across chains.

--- a/docs/protocol/overview.md
+++ b/docs/protocol/overview.md
@@ -2,7 +2,7 @@
 
 Nitrolite is a state channel protocol that enables high-speed off-chain interactions between users while preserving on-chain security guarantees.
 
-Users exchange signed state updates off-chain with Nodes that act as a hub connecting network participants. Any user can enforce the latest agreed state on the blockchain layer at any time.
+Users exchange signed state updates off-chain with Nodes that act as a hub connecting network participants. Any user can enforce the latest agreed state on the blockchain layer, provided a valid execution path exists for that state's intent in the current channel context.
 
 ## Table of Contents
 
@@ -23,7 +23,7 @@ Users exchange signed state updates off-chain with Nodes that act as a hub conne
 The protocol is designed to achieve:
 
 - **Off-chain scalability** — minimize on-chain transactions by moving state advancement off-chain
-- **Blockchain security guarantees** — any user can fall back to the blockchain layer to enforce the latest state
+- **Blockchain security guarantees** — any user can fall back to the blockchain layer to enforce the latest state, provided a valid execution path exists for that state's intent
 - **Cross-chain asset interaction** — operate on assets across multiple blockchains through a unified model
 - **Extensibility** — support additional functionality through protocol extensions without modifying the core protocol
 

--- a/docs/protocol/security-and-limitations.md
+++ b/docs/protocol/security-and-limitations.md
@@ -41,7 +41,8 @@ Each state update MUST satisfy transition-specific rules. Invalid transitions ar
 
 The blockchain layer provides the following guarantees:
 
-- Any party MAY submit the latest signed state at any time
+- Any party MAY submit the latest mutually signed state to the blockchain layer; enforcement succeeds when a valid execution path exists for that state's intent in the current channel context
+- Parties MUST retain and enforce intermediate states (such as a DEPOSIT state) before discarding them — a subsequent OPERATE state built on top of an unconfirmed DEPOSIT cannot be used to create or advance a channel on-chain, because OPERATE requires zero change in user net flow relative to the last enforced state
 - The blockchain layer accepts only states with valid signatures and a higher version than the current on-chain state
 - After the challenge period, the enforced state becomes final
 - Final state allocations determine asset distribution

--- a/docs/protocol/security-and-limitations.md
+++ b/docs/protocol/security-and-limitations.md
@@ -17,7 +17,7 @@ However, the protocol in its current form is not fully trust-minimized. The prim
 The protocol aims to guarantee:
 
 - **Asset safety** — participants MUST NOT lose assets without signing a state that authorizes the change
-- **State finality** — the latest mutually signed state can always be enforced on-chain
+- **State finality** — the latest mutually signed state can be enforced on-chain when a valid execution path exists for its intent; parties MUST retain any intermediate states required to establish that path
 - **Non-repudiation** — a participant cannot deny having signed a state
 - **Censorship resistance** — any party MAY independently enforce state on the blockchain layer
 
@@ -42,7 +42,7 @@ Each state update MUST satisfy transition-specific rules. Invalid transitions ar
 The blockchain layer provides the following guarantees:
 
 - Any party MAY submit the latest mutually signed state to the blockchain layer; enforcement succeeds when a valid execution path exists for that state's intent in the current channel context
-- Parties MUST retain and enforce intermediate states (such as a DEPOSIT state) before discarding them — a subsequent OPERATE state built on top of an unconfirmed DEPOSIT cannot be used to create or advance a channel on-chain, because OPERATE requires zero change in user net flow relative to the last enforced state
+- Parties MUST retain and enforce intermediate states (such as a DEPOSIT state) before discarding them — a subsequent OPERATE state built on top of an unenforced DEPOSIT cannot be used to create or checkpoint a channel on-chain, because OPERATE requires zero change in user net flow relative to the last enforced state
 - The blockchain layer accepts only states with valid signatures and a higher version than the current on-chain state
 - After the challenge period, the enforced state becomes final
 - Final state allocations determine asset distribution


### PR DESCRIPTION
Qualifies the enforcement guarantee across three protocol docs.

The blanket statement "Any party MAY submit the latest signed state at any time" is not fully accurate: an OPERATE state with non-zero user net flow delta cannot be used to create or checkpoint a channel from VOID status, because OPERATE requires zero user net flow change relative to the last enforced state.

**Changes:**
- `docs/protocol/security-and-limitations.md`: rewrite Enforcement Guarantees section — adds intent-path qualifier and a new bullet requiring parties to retain intermediate states (e.g. DEPOSIT) before discarding them
- `docs/protocol/enforcement.md`: qualify the Enforcement Model bullet; add caveat in Channel Creation section about OPERATE intent not being usable when user net flow was accumulated from an unconfirmed DEPOSIT state
- `docs/protocol/overview.md`: qualify the State Enforcement paragraph

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Updated protocol enforcement submission rules, including requirements for valid execution paths when submitting states
- Clarified channel creation restrictions and requirements for state operations
- Enhanced enforcement guarantees documentation with improved clarity on state management and enforcement behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->