### PR TITLE
MF-L04: fix(contracts): reject redundant native value

### DIFF
--- a/contracts/src/ChannelHub.sol
+++ b/contracts/src/ChannelHub.sol
@@ -1153,8 +1153,6 @@ contract ChannelHub is ReentrancyGuard {
         ChannelMeta storage meta = _channels[channelId];
         address token = candidate.homeLedger.token;
 
-        _requireMsgValueForUserFundsDelta(token, effects.userFundsDelta);
-
         meta.lastState = candidate;
 
         address user = def.user;
@@ -1164,6 +1162,8 @@ contract ChannelHub is ReentrancyGuard {
             uint256 amount = effects.userFundsDelta.toUint256();
             _pullFunds(user, token, amount);
             meta.lockedFunds += amount;
+        } else {
+            require(msg.value == 0, IncorrectValue());
         }
 
         if (effects.nodeFundsDelta > 0) {
@@ -1206,8 +1206,6 @@ contract ChannelHub is ReentrancyGuard {
         EscrowDepositMeta storage meta = _escrowDeposits[escrowId];
         address token = effects.updateInitState ? candidate.nonHomeLedger.token : meta.initState.nonHomeLedger.token;
 
-        _requireMsgValueForUserFundsDelta(token, effects.userFundsDelta);
-
         if (effects.newStatus != EscrowStatus.VOID) {
             meta.status = effects.newStatus;
         }
@@ -1229,10 +1227,13 @@ contract ChannelHub is ReentrancyGuard {
             uint256 amount = effects.userFundsDelta.toUint256();
             _pullFunds(user, token, amount);
             meta.lockedAmount += amount;
-        } else if (effects.userFundsDelta < 0) {
-            uint256 amount = (-effects.userFundsDelta).toUint256();
-            _nonRevertingPushFunds(user, token, amount);
-            meta.lockedAmount -= amount;
+        } else {
+            require(msg.value == 0, IncorrectValue());
+            if (effects.userFundsDelta < 0) {
+                uint256 amount = (-effects.userFundsDelta).toUint256();
+                _nonRevertingPushFunds(user, token, amount);
+                meta.lockedAmount -= amount;
+            }
         }
 
         // Handle node funds (positive = pull from node vault, negative = release to vault)
@@ -1378,11 +1379,7 @@ contract ChannelHub is ReentrancyGuard {
         return _escrowWithdrawals[escrowId].channelId == bytes32(0) && _isChannelHomeChain(channelId);
     }
 
-    function _requireMsgValueForUserFundsDelta(address token, int256 userFundsDelta) internal view {
-        uint256 amount = userFundsDelta > 0 ? userFundsDelta.toUint256() : 0;
-        _requireMsgValueForPull(token, amount);
-    }
-
+    /// @dev native token: requires msg.value == amount; ERC20: requires msg.value == 0.
     function _requireMsgValueForPull(address token, uint256 amount) internal view {
         if (token == address(0)) {
             require(msg.value == amount, IncorrectValue());
@@ -1392,9 +1389,9 @@ contract ChannelHub is ReentrancyGuard {
     }
 
     function _pullFunds(address from, address token, uint256 amount) internal nonReentrant {
-        _requireMsgValueForPull(token, amount);
-
         if (amount == 0) return;
+
+        _requireMsgValueForPull(token, amount);
 
         if (token != address(0)) {
             IERC20(token).safeTransferFrom(from, address(this), amount);

--- a/contracts/src/ChannelHub.sol
+++ b/contracts/src/ChannelHub.sol
@@ -633,8 +633,9 @@ contract ChannelHub is ReentrancyGuard {
             ChannelEngine.TransitionEffects memory effects = ChannelEngine.validateTransition(ctx, candidate);
 
             _applyTransitionEffects(channelId, def, candidate, effects);
+        } else {
+            require(msg.value == 0, IncorrectValue());
         }
-        // else: challenging with same version, state already processed
 
         (ISignatureValidator validator, bytes calldata sigData) =
             _extractValidator(challengerSig, approvedSignatureValidators);
@@ -700,6 +701,7 @@ contract ChannelHub is ReentrancyGuard {
 
         if (_isChannelHomeChain(channelId)) {
             require(msg.sender == NODE, IncorrectMsgSender());
+            require(msg.value == 0, IncorrectValue());
             _processHomeChainEscrow(channelId, candidate);
             emit EscrowDepositInitiatedOnHome(escrowId, channelId, candidate);
         } else {
@@ -1149,11 +1151,13 @@ contract ChannelHub is ReentrancyGuard {
         ChannelEngine.TransitionEffects memory effects
     ) internal {
         ChannelMeta storage meta = _channels[channelId];
+        address token = candidate.homeLedger.token;
+
+        _requireMsgValueForUserFundsDelta(token, effects.userFundsDelta);
 
         meta.lastState = candidate;
 
         address user = def.user;
-        address token = candidate.homeLedger.token;
 
         // Process POSITIVE deltas first (additions to lockedFunds) to prevent underflow
         if (effects.userFundsDelta > 0) {
@@ -1200,6 +1204,9 @@ contract ChannelHub is ReentrancyGuard {
         uint256 approvedSignatureValidators
     ) internal {
         EscrowDepositMeta storage meta = _escrowDeposits[escrowId];
+        address token = effects.updateInitState ? candidate.nonHomeLedger.token : meta.initState.nonHomeLedger.token;
+
+        _requireMsgValueForUserFundsDelta(token, effects.userFundsDelta);
 
         if (effects.newStatus != EscrowStatus.VOID) {
             meta.status = effects.newStatus;
@@ -1216,9 +1223,6 @@ contract ChannelHub is ReentrancyGuard {
         if (effects.newChallengeExpiry > 0) {
             meta.challengeExpireAt = effects.newChallengeExpiry;
         }
-
-        // Determine the correct token to use (from init state for finalization, from candidate for initiation)
-        address token = effects.updateInitState ? candidate.nonHomeLedger.token : meta.initState.nonHomeLedger.token;
 
         // Handle user funds (positive = pull from user)
         if (effects.userFundsDelta > 0) {
@@ -1374,14 +1378,23 @@ contract ChannelHub is ReentrancyGuard {
         return _escrowWithdrawals[escrowId].channelId == bytes32(0) && _isChannelHomeChain(channelId);
     }
 
-    function _pullFunds(address from, address token, uint256 amount) internal nonReentrant {
-        if (amount == 0) return;
+    function _requireMsgValueForUserFundsDelta(address token, int256 userFundsDelta) internal view {
+        uint256 amount = userFundsDelta > 0 ? userFundsDelta.toUint256() : 0;
+        _requireMsgValueForPull(token, amount);
+    }
 
+    function _requireMsgValueForPull(address token, uint256 amount) internal view {
         if (token == address(0)) {
             require(msg.value == amount, IncorrectValue());
         } else {
             require(msg.value == 0, IncorrectValue());
         }
+    }
+
+    function _pullFunds(address from, address token, uint256 amount) internal nonReentrant {
+        _requireMsgValueForPull(token, amount);
+
+        if (amount == 0) return;
 
         if (token != address(0)) {
             IERC20(token).safeTransferFrom(from, address(this), amount);

--- a/contracts/test/ChannelHub_units/ChannelHub_challenge.t.sol
+++ b/contracts/test/ChannelHub_units/ChannelHub_challenge.t.sol
@@ -112,7 +112,7 @@ contract ChannelHubTest_challenge is ChannelHubTest_Base {
         cHub.challengeChannel{value: 1}(channelId, initState, challengerSig, ParticipantIndex.NODE);
     }
 
-    function test_revert_ifETHSent_initiateEscrowDeposit_homeChainChallenge() public {
+    function test_revert_challengeChannel_initiateEscrowDepositIntent_ifETHSent() public {
         bytes memory challengerSig = signChallengeEip191WithEcdsaValidator(channelId, escrowState, NODE_PK);
 
         vm.deal(node, 1);

--- a/contracts/test/ChannelHub_units/ChannelHub_challenge.t.sol
+++ b/contracts/test/ChannelHub_units/ChannelHub_challenge.t.sol
@@ -101,6 +101,88 @@ contract ChannelHubTest_challenge is ChannelHubTest_Base {
         cHub.challengeChannel(channelId, state, challengerSig, ParticipantIndex.USER);
     }
 
+    // ========== Payable ==========
+
+    function test_revert_ifETHSent_sameVersionChallenge() public {
+        bytes memory challengerSig = signChallengeEip191WithEcdsaValidator(channelId, initState, NODE_PK);
+
+        vm.deal(node, 1);
+        vm.expectRevert(ChannelHub.IncorrectValue.selector);
+        vm.prank(node);
+        cHub.challengeChannel{value: 1}(channelId, initState, challengerSig, ParticipantIndex.NODE);
+    }
+
+    function test_revert_ifETHSent_initiateEscrowDeposit_homeChainChallenge() public {
+        bytes memory challengerSig = signChallengeEip191WithEcdsaValidator(channelId, escrowState, NODE_PK);
+
+        vm.deal(node, 1);
+        vm.expectRevert(ChannelHub.IncorrectValue.selector);
+        vm.prank(node);
+        cHub.challengeChannel{value: 1}(channelId, escrowState, challengerSig, ParticipantIndex.NODE);
+    }
+
+    function test_nativeDepositChallenge_acceptsExactETH() public {
+        uint256 depositDelta = 100;
+        ChannelDefinition memory nativeDef = ChannelDefinition({
+            challengeDuration: CHALLENGE_DURATION,
+            user: alice,
+            node: node,
+            nonce: NONCE + 1,
+            approvedSignatureValidators: 0,
+            metadata: bytes32(0)
+        });
+        bytes32 nativeChannelId = Utils.getChannelId(nativeDef, CHANNEL_HUB_VERSION);
+
+        State memory nativeInitState = State({
+            version: 0,
+            intent: StateIntent.DEPOSIT,
+            metadata: bytes32(0),
+            homeLedger: Ledger({
+                chainId: uint64(block.chainid),
+                token: address(0),
+                decimals: 18,
+                userAllocation: DEPOSIT_AMOUNT,
+                userNetFlow: int256(DEPOSIT_AMOUNT),
+                nodeAllocation: 0,
+                nodeNetFlow: 0
+            }),
+            nonHomeLedger: TestUtils.emptyLedger(),
+            userSig: "",
+            nodeSig: ""
+        });
+        nativeInitState = mutualSignStateBothWithEcdsaValidator(nativeInitState, nativeChannelId, ALICE_PK);
+
+        vm.deal(alice, DEPOSIT_AMOUNT);
+        vm.prank(alice);
+        cHub.createChannel{value: DEPOSIT_AMOUNT}(nativeDef, nativeInitState);
+
+        State memory depositState = TestUtils.nextState(
+            nativeInitState,
+            StateIntent.DEPOSIT,
+            [uint256(DEPOSIT_AMOUNT + depositDelta), uint256(0)],
+            [int256(DEPOSIT_AMOUNT + depositDelta), int256(0)]
+        );
+        depositState = mutualSignStateBothWithEcdsaValidator(depositState, nativeChannelId, ALICE_PK);
+        bytes memory challengerSig = signChallengeEip191WithEcdsaValidator(nativeChannelId, depositState, NODE_PK);
+
+        uint256 hubBalanceBefore = address(cHub).balance;
+        vm.deal(node, depositDelta);
+        vm.prank(node);
+        cHub.challengeChannel{value: depositDelta}(nativeChannelId, depositState, challengerSig, ParticipantIndex.NODE);
+
+        (ChannelStatus status,, State memory latestState, uint256 challengeExpiry,) =
+            cHub.getChannelData(nativeChannelId);
+        assertEq(uint8(status), uint8(ChannelStatus.DISPUTED), "Channel should be DISPUTED");
+        assertEq(latestState.version, 1, "Native deposit state should be enforced");
+        assertEq(
+            latestState.homeLedger.userAllocation,
+            DEPOSIT_AMOUNT + depositDelta,
+            "Native allocation should include challenge deposit"
+        );
+        assertEq(challengeExpiry, block.timestamp + CHALLENGE_DURATION, "Challenge expiry should be set");
+        assertEq(address(cHub).balance, hubBalanceBefore + depositDelta, "Native ETH should be pulled");
+    }
+
     // ========== INITIATE_ESCROW_DEPOSIT caller restriction ==========
 
     function test_revert_initiateEscrowDeposit_homeChain_callerNotNode() public {

--- a/contracts/test/ChannelHub_units/ChannelHub_initiateEscrowDeposit.t.sol
+++ b/contracts/test/ChannelHub_units/ChannelHub_initiateEscrowDeposit.t.sol
@@ -5,7 +5,14 @@ import {ChannelHubTest_Base} from "../ChannelHub_Base.t.sol";
 import {TestUtils} from "../TestUtils.sol";
 import {Utils} from "../../src/Utils.sol";
 import {ChannelHub} from "../../src/ChannelHub.sol";
-import {State, ChannelDefinition, StateIntent, Ledger, ChannelStatus} from "../../src/interfaces/Types.sol";
+import {
+    State,
+    ChannelDefinition,
+    StateIntent,
+    Ledger,
+    ChannelStatus,
+    EscrowStatus
+} from "../../src/interfaces/Types.sol";
 
 // forge-lint: disable-next-item(unsafe-typecast)
 contract ChannelHubTest_initiateEscrowDeposit is ChannelHubTest_Base {
@@ -86,6 +93,13 @@ contract ChannelHubTest_initiateEscrowDeposit is ChannelHubTest_Base {
         cHub.initiateEscrowDeposit(def, escrowState);
     }
 
+    function test_revert_homeChain_ifETHSent() public {
+        vm.deal(node, 1);
+        vm.expectRevert(ChannelHub.IncorrectValue.selector);
+        vm.prank(node);
+        cHub.initiateEscrowDeposit{value: 1}(def, escrowState);
+    }
+
     function test_homeChain_nodeCanSubmit() public {
         uint256 nodeBalanceBefore = cHub.getNodeBalance(address(token));
 
@@ -99,5 +113,75 @@ contract ChannelHubTest_initiateEscrowDeposit is ChannelHubTest_Base {
             nodeBalanceBefore - ESCROW_AMOUNT,
             "Node balance should decrease by escrow amount"
         );
+    }
+
+    // ========== Non-home native deposit ==========
+
+    function test_nonHomeChain_nativeDeposit_acceptsExactETH() public {
+        (ChannelDefinition memory nonHomeDef, bytes32 nonHomeChannelId, State memory nativeEscrowState) =
+            _buildNonHomeNativeEscrowDeposit();
+        bytes32 escrowId = Utils.getEscrowId(nonHomeChannelId, nativeEscrowState.version);
+
+        uint256 hubBalanceBefore = address(cHub).balance;
+        vm.deal(alice, ESCROW_AMOUNT);
+        vm.prank(alice);
+        cHub.initiateEscrowDeposit{value: ESCROW_AMOUNT}(nonHomeDef, nativeEscrowState);
+
+        (, EscrowStatus status,,, uint256 lockedAmount,) = cHub.getEscrowDepositData(escrowId);
+        assertEq(uint8(status), uint8(EscrowStatus.INITIALIZED), "Escrow should be initialized");
+        assertEq(lockedAmount, ESCROW_AMOUNT, "Escrow should lock native ETH");
+        assertEq(address(cHub).balance, hubBalanceBefore + ESCROW_AMOUNT, "Native ETH should be pulled");
+    }
+
+    function test_revert_nonHomeChain_nativeDeposit_wrongValue() public {
+        (ChannelDefinition memory nonHomeDef,, State memory nativeEscrowState) = _buildNonHomeNativeEscrowDeposit();
+
+        vm.deal(alice, ESCROW_AMOUNT - 1);
+        vm.expectRevert(ChannelHub.IncorrectValue.selector);
+        vm.prank(alice);
+        cHub.initiateEscrowDeposit{value: ESCROW_AMOUNT - 1}(nonHomeDef, nativeEscrowState);
+    }
+
+    function _buildNonHomeNativeEscrowDeposit()
+        internal
+        view
+        returns (ChannelDefinition memory nonHomeDef, bytes32 nonHomeChannelId, State memory nativeEscrowState)
+    {
+        nonHomeDef = ChannelDefinition({
+            challengeDuration: CHALLENGE_DURATION,
+            user: alice,
+            node: node,
+            nonce: NONCE + 1,
+            approvedSignatureValidators: 0,
+            metadata: bytes32(0)
+        });
+        nonHomeChannelId = Utils.getChannelId(nonHomeDef, CHANNEL_HUB_VERSION);
+
+        nativeEscrowState = State({
+            version: 1,
+            intent: StateIntent.INITIATE_ESCROW_DEPOSIT,
+            metadata: bytes32(0),
+            homeLedger: Ledger({
+                chainId: NON_HOME_CHAIN_ID,
+                token: NON_HOME_TOKEN,
+                decimals: 18,
+                userAllocation: ESCROW_AMOUNT,
+                userNetFlow: int256(ESCROW_AMOUNT),
+                nodeAllocation: ESCROW_AMOUNT,
+                nodeNetFlow: int256(ESCROW_AMOUNT)
+            }),
+            nonHomeLedger: Ledger({
+                chainId: uint64(block.chainid),
+                token: address(0),
+                decimals: 18,
+                userAllocation: ESCROW_AMOUNT,
+                userNetFlow: int256(ESCROW_AMOUNT),
+                nodeAllocation: 0,
+                nodeNetFlow: 0
+            }),
+            userSig: "",
+            nodeSig: ""
+        });
+        nativeEscrowState = mutualSignStateBothWithEcdsaValidator(nativeEscrowState, nonHomeChannelId, ALICE_PK);
     }
 }


### PR DESCRIPTION
## summary

fixes l-04 by rejecting redundant native value on channel challenge and escrow deposit paths that do not consume `msg.value`.

## root cause

`challengeChannel()` and the home-chain branch of `initiateEscrowDeposit()` are payable, but some valid paths do not pull user funds. those calls could accept native value that was not credited to channel, escrow, node, or reclaim accounting.

## changes

- validate `msg.value` from computed transition effects before applying channel or escrow deposit effects
- reject non-zero value for same-version challenges and home-chain escrow deposit initiation
- keep exact native value support for real native user-pull paths
- tighten `_pullFunds()` so zero-amount pulls cannot bypass value validation
- add unit tests for rejected surplus eth and valid exact native eth flows

## validation

- `forge test --match-contract 'ChannelHubTest_(challenge|initiateEscrowDeposit)'` passed, 13 tests
- `forge test` passed, 282 tests
- `forge fmt --check src/ChannelHub.sol test/ChannelHub_units/ChannelHub_challenge.t.sol test/ChannelHub_units/ChannelHub_initiateEscrowDeposit.t.sol` passed
- `git diff --check` passed

- `slither . --filter-paths 'lib|test'` ran with Slither 0.11.5; it reports 83 findings on this branch and the same 83 findings on `fix/audit-findings-final`, so no new Slither finding was introduced by this PR. The reported categories are existing project-level warnings: arbitrary-send-eth, reentrancy-eth/events, return-bomb, timestamp, assembly, solc-version, low-level-calls, naming-convention, and too-many-digits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced native ETH validation during channel challenges to ensure correct payment amounts are provided
  * Improved escrow deposit handling with stricter ETH value verification for both home-chain and non-home-chain payment scenarios

* **Tests**
  * Added comprehensive test coverage for ETH payment validation across channel challenge and escrow deposit operations

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/layer-3/nitrolite/pull/741)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
