### PR TITLE
YNU-917: reset stale store gauges and seed bounded counters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -113,7 +113,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/pressly/goose/v3 v3.27.1
-	github.com/prometheus/client_model v0.6.2 // indirect
+	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/nitronode/api/rpc_router.go
+++ b/nitronode/api/rpc_router.go
@@ -149,6 +149,11 @@ func NewRPCRouter(
 	userV1Group.Handle(rpc.UserV1GetTransactionsMethod.String(), userV1Handler.GetTransactions)
 	userV1Group.Handle(rpc.UserV1GetActionAllowancesMethod.String(), userV1Handler.GetActionAllowances)
 
+	// Pre-publish per-method metric series at 0 so dashboards and absent()-style
+	// alerts have defined values before any traffic arrives. Must run after all
+	// group.Handle calls so RegisteredMethods is complete.
+	runtimeMetrics.SeedRPCMethodMetrics(r.Node.RegisteredMethods())
+
 	return r
 }
 

--- a/nitronode/api/rpc_router.go
+++ b/nitronode/api/rpc_router.go
@@ -152,7 +152,7 @@ func NewRPCRouter(
 	// Pre-publish per-method metric series at 0 so dashboards and absent()-style
 	// alerts have defined values before any traffic arrives. Must run after all
 	// group.Handle calls so RegisteredMethods is complete.
-	runtimeMetrics.SeedRPCMethodMetrics(r.Node.RegisteredMethods())
+	runtimeMetrics.SeedRPCMethodMetrics(r.Node.RegisteredMethods(), MethodPathDomains())
 
 	return r
 }

--- a/nitronode/api/utils.go
+++ b/nitronode/api/utils.go
@@ -1,6 +1,10 @@
 package api
 
-import "github.com/layer-3/nitrolite/pkg/rpc"
+import (
+	"github.com/layer-3/nitrolite/pkg/app"
+	"github.com/layer-3/nitrolite/pkg/core"
+	"github.com/layer-3/nitrolite/pkg/rpc"
+)
 
 func getMethodPath(c *rpc.Context) string {
 	switch c.Request.Method {
@@ -25,4 +29,25 @@ func getMethodPath(c *rpc.Context) string {
 	}
 
 	return "default"
+}
+
+// MethodPathDomains returns the bounded `path` label domain per RPC method
+// whose request payload determines path (matching getMethodPath's switch).
+// Methods not in the map emit only path="default". Used by metrics seeding so
+// absent()-style alerts have defined values for every (method, path, result)
+// tuple at cold start, not just (method, "default", result).
+func MethodPathDomains() map[string][]string {
+	intents := make([]string, 0, len(app.AllAppStateUpdateIntents))
+	for _, i := range app.AllAppStateUpdateIntents {
+		intents = append(intents, i.String())
+	}
+	transitions := make([]string, 0, len(core.AllTransitionTypes))
+	for _, t := range core.AllTransitionTypes {
+		transitions = append(transitions, t.String())
+	}
+	return map[string][]string{
+		rpc.AppSessionsV1SubmitAppStateMethod.String(): intents,
+		rpc.ChannelsV1RequestCreationMethod.String():   transitions,
+		rpc.ChannelsV1SubmitStateMethod.String():       transitions,
+	}
 }

--- a/nitronode/api/utils_test.go
+++ b/nitronode/api/utils_test.go
@@ -1,0 +1,68 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/layer-3/nitrolite/pkg/app"
+	"github.com/layer-3/nitrolite/pkg/core"
+	"github.com/layer-3/nitrolite/pkg/rpc"
+)
+
+// TestMethodPathDomains_MatchesEnums fails if the bounded enums grow but
+// MethodPathDomains is not updated, which would silently re-introduce the
+// cold-start gap that the metric-seeding fix closes.
+func TestMethodPathDomains_MatchesEnums(t *testing.T) {
+	domains := MethodPathDomains()
+
+	intentMethod := rpc.AppSessionsV1SubmitAppStateMethod.String()
+	require.Contains(t, domains, intentMethod)
+	require.Len(t, domains[intentMethod], len(app.AllAppStateUpdateIntents))
+	wantIntents := make([]string, 0, len(app.AllAppStateUpdateIntents))
+	for _, i := range app.AllAppStateUpdateIntents {
+		wantIntents = append(wantIntents, i.String())
+	}
+	assert.ElementsMatch(t, wantIntents, domains[intentMethod])
+
+	wantTransitions := make([]string, 0, len(core.AllTransitionTypes))
+	for _, ttype := range core.AllTransitionTypes {
+		wantTransitions = append(wantTransitions, ttype.String())
+	}
+	for _, m := range []string{
+		rpc.ChannelsV1RequestCreationMethod.String(),
+		rpc.ChannelsV1SubmitStateMethod.String(),
+	} {
+		require.Contains(t, domains, m)
+		require.Len(t, domains[m], len(core.AllTransitionTypes))
+		assert.ElementsMatch(t, wantTransitions, domains[m])
+	}
+
+	// No "unknown" sentinel ever leaks in — enum String() should cover every
+	// listed value, and any new enum value without a String() arm would land
+	// here as "unknown" and fail the test.
+	for _, paths := range domains {
+		for _, p := range paths {
+			assert.NotEqual(t, "unknown", p, "enum without String() arm in MethodPathDomains output")
+		}
+	}
+}
+
+// TestMethodPathDomains_CoversGetMethodPathSwitch is a hand-maintained pairing
+// between getMethodPath's switch arms and MethodPathDomains' map keys. If a
+// new method gains payload-derived path logic in getMethodPath, this test
+// fails until the same method is added to MethodPathDomains (and vice versa).
+func TestMethodPathDomains_CoversGetMethodPathSwitch(t *testing.T) {
+	expected := []string{
+		rpc.AppSessionsV1SubmitAppStateMethod.String(),
+		rpc.ChannelsV1RequestCreationMethod.String(),
+		rpc.ChannelsV1SubmitStateMethod.String(),
+	}
+	got := MethodPathDomains()
+	keys := make([]string, 0, len(got))
+	for k := range got {
+		keys = append(keys, k)
+	}
+	assert.ElementsMatch(t, expected, keys)
+}

--- a/nitronode/main.go
+++ b/nitronode/main.go
@@ -355,85 +355,107 @@ func runStoreMetricsExporter(
 	ticker := time.NewTicker(fetchInterval)
 	defer ticker.Stop()
 
+	timeSpans := []struct {
+		label    string
+		duration time.Duration
+	}{
+		{"day", 24 * time.Hour},
+		{"week", 7 * 24 * time.Hour},
+		{"month", 30 * 24 * time.Hour},
+	}
+
+	// refresh runs one full pass over every store-backed gauge. Each block resets
+	// its gauge before re-publishing the latest snapshot so label tuples that have
+	// dropped out of the store (e.g., the last open channel for an asset closed)
+	// disappear from the metric instead of sticking at their previous value. Reset
+	// happens only inside the successful-query branch so a transient DB error does
+	// not blank a healthy gauge.
+	refresh := func() {
+		channelCounts, err := store.GetChannelsCountByLabels()
+		if err != nil {
+			logger.Error("failed to get channel counts by labels", "error", err)
+		} else {
+			metricExported.ResetChannels()
+			for _, c := range channelCounts {
+				metricExported.SetChannels(c.Asset, c.Status, c.Count)
+			}
+		}
+
+		appSessionCounts, err := store.GetAppSessionsCountByLabels()
+		if err != nil {
+			logger.Error("failed to get app sessions counts by labels", "error", err)
+		} else {
+			metricExported.ResetAppSessions()
+			for _, c := range appSessionCounts {
+				metricExported.SetAppSessions(c.Application, c.Status, c.Count)
+			}
+		}
+
+		tvlCounts, err := store.GetTotalValueLocked()
+		if err != nil {
+			logger.Error("failed to get total value locked", "error", err)
+		} else {
+			metricExported.ResetTotalValueLocked()
+			for _, c := range tvlCounts {
+				metricExported.SetTotalValueLocked(c.Domain, c.Asset, c.Value.InexactFloat64())
+			}
+		}
+
+		nodeBalances, err := store.GetNodeBalance()
+		if err != nil {
+			logger.Error("failed to get node balances", "error", err)
+		} else {
+			metricExported.ResetNodeBalance()
+			for _, nb := range nodeBalances {
+				metricExported.SetNodeBalance(nb.BlockchainID, nb.Asset, nb.Value.InexactFloat64())
+			}
+		}
+
+		offChain, err := store.GetUserBalanceSummary()
+		if err != nil {
+			logger.Error("failed to get off-chain liquidity", "error", err)
+		} else {
+			metricExported.ResetUserBalances()
+			for _, l := range offChain {
+				metricExported.SetUserBalanceTotal(l.BlockchainID, l.Asset, l.Total.InexactFloat64())
+				metricExported.SetUserBalanceUnderfunded(l.BlockchainID, l.Asset, l.Underfunded.InexactFloat64())
+				metricExported.SetUserBalanceReleasable(l.BlockchainID, l.Asset, l.Releasable.InexactFloat64())
+			}
+		}
+
+		for _, tw := range timeSpans {
+			counts, err := store.CountActiveUsers(tw.duration)
+			if err != nil {
+				logger.Error("failed to count active users", "timeframe", tw.label, "error", err)
+				continue
+			}
+			metricExported.ResetActiveUsers(tw.label)
+			for _, c := range counts {
+				metricExported.SetActiveUsers(c.Label, tw.label, c.Count)
+			}
+		}
+
+		for _, tw := range timeSpans {
+			counts, err := store.CountActiveAppSessions(tw.duration)
+			if err != nil {
+				logger.Error("failed to count active app sessions", "timeframe", tw.label, "error", err)
+				continue
+			}
+			metricExported.ResetActiveAppSessions(tw.label)
+			for _, c := range counts {
+				metricExported.SetActiveAppSessions(c.Label, tw.label, c.Count)
+			}
+		}
+	}
+
+	// Populate gauges immediately so they are non-empty before the first ticker fire
+	// (otherwise alerts using absent() trip during the cold-start window).
+	refresh()
+
 	for {
 		select {
 		case <-ticker.C:
-			timeSpans := []struct {
-				label    string
-				duration time.Duration
-			}{
-				{"day", 24 * time.Hour},
-				{"week", 7 * 24 * time.Hour},
-				{"month", 30 * 24 * time.Hour},
-			}
-
-			channelCounts, err := store.GetChannelsCountByLabels()
-			if err != nil {
-				logger.Error("failed to get channel counts by labels", "error", err)
-			} else {
-				for _, c := range channelCounts {
-					metricExported.SetChannels(c.Asset, c.Status, c.Count)
-				}
-			}
-
-			appSessionCounts, err := store.GetAppSessionsCountByLabels()
-			if err != nil {
-				logger.Error("failed to get app sessions counts by labels", "error", err)
-			} else {
-				for _, c := range appSessionCounts {
-					metricExported.SetAppSessions(c.Application, c.Status, c.Count)
-				}
-			}
-
-			tvlCounts, err := store.GetTotalValueLocked()
-			if err != nil {
-				logger.Error("failed to get total value locked", "error", err)
-			} else {
-				for _, c := range tvlCounts {
-					metricExported.SetTotalValueLocked(c.Domain, c.Asset, c.Value.InexactFloat64())
-				}
-			}
-
-			nodeBalances, err := store.GetNodeBalance()
-			if err != nil {
-				logger.Error("failed to get node balances", "error", err)
-			} else {
-				for _, nb := range nodeBalances {
-					metricExported.SetNodeBalance(nb.BlockchainID, nb.Asset, nb.Value.InexactFloat64())
-				}
-			}
-
-			offChain, err := store.GetUserBalanceSummary()
-			if err != nil {
-				logger.Error("failed to get off-chain liquidity", "error", err)
-			} else {
-				for _, l := range offChain {
-					metricExported.SetUserBalanceTotal(l.BlockchainID, l.Asset, l.Total.InexactFloat64())
-					metricExported.SetUserBalanceUnderfunded(l.BlockchainID, l.Asset, l.Underfunded.InexactFloat64())
-					metricExported.SetUserBalanceReleasable(l.BlockchainID, l.Asset, l.Releasable.InexactFloat64())
-				}
-			}
-
-			for _, tw := range timeSpans {
-				if counts, err := store.CountActiveUsers(tw.duration); err != nil {
-					logger.Error("failed to count active users", "timeframe", tw.label, "error", err)
-				} else {
-					for _, c := range counts {
-						metricExported.SetActiveUsers(c.Label, tw.label, c.Count)
-					}
-				}
-			}
-
-			for _, tw := range timeSpans {
-				if counts, err := store.CountActiveAppSessions(tw.duration); err != nil {
-					logger.Error("failed to count active app sessions", "timeframe", tw.label, "error", err)
-				} else {
-					for _, c := range counts {
-						metricExported.SetActiveAppSessions(c.Label, tw.label, c.Count)
-					}
-				}
-			}
-
+			refresh()
 		case <-ctx.Done():
 			logger.Info("stopping store metrics exporter")
 			return

--- a/nitronode/metrics/exporter.go
+++ b/nitronode/metrics/exporter.go
@@ -165,6 +165,27 @@ func (m *storeMetricExporter) SetUserBalanceReleasable(blockchainID, asset strin
 	m.userBalanceReleasable.WithLabelValues(blockchainID, asset).Set(value)
 }
 
+func (m *storeMetricExporter) ResetAppSessions()      { m.appSessionsTotal.Reset() }
+func (m *storeMetricExporter) ResetChannels()         { m.channelsTotal.Reset() }
+func (m *storeMetricExporter) ResetTotalValueLocked() { m.totalValueLocked.Reset() }
+func (m *storeMetricExporter) ResetNodeBalance()      { m.nodeBalance.Reset() }
+func (m *storeMetricExporter) ResetUserBalances() {
+	m.userBalanceTotal.Reset()
+	m.userBalanceUnderfunded.Reset()
+	m.userBalanceReleasable.Reset()
+}
+
+// ResetActiveUsers clears only the rows for the given timespan so a failure in one
+// window does not blank the gauges for windows that may still be succeeding.
+func (m *storeMetricExporter) ResetActiveUsers(timeSpanLabel string) {
+	m.usersActive.DeletePartialMatch(prometheus.Labels{"timespan": timeSpanLabel})
+}
+
+// ResetActiveAppSessions clears only the rows for the given timespan; see ResetActiveUsers.
+func (m *storeMetricExporter) ResetActiveAppSessions(timeSpanLabel string) {
+	m.appSessionsActive.DeletePartialMatch(prometheus.Labels{"timespan": timeSpanLabel})
+}
+
 // runtimeMetricExporter is the concrete implementation of the Metrics interface.
 type runtimeMetricExporter struct {
 	// Shared Metrics (Cross-Package)

--- a/nitronode/metrics/exporter.go
+++ b/nitronode/metrics/exporter.go
@@ -397,7 +397,52 @@ func NewRuntimeMetricExporter(reg prometheus.Registerer) (RuntimeMetricExporter,
 		return nil, fmt.Errorf("prometheus registerer not provided")
 	}
 
+	// Seed counters whose label space is fully resolved at construction time.
+	// Router and chain axes are seeded later via SeedRPCMethodMetrics /
+	// SeedBlockchainEventMetrics once that config is loaded.
+	for _, st := range core.ChannelSignerTypes {
+		for _, res := range allActionResults {
+			m.channelStateSigValidationsTotal.WithLabelValues(st.String(), res.String())
+		}
+	}
+
 	return m, nil
+}
+
+// allActionResults is the closed enum of result label values used by counters
+// whose outcome dimension is success/failed.
+var allActionResults = []ActionResult{ActionResultSuccess, ActionResultFailed}
+
+// SeedRPCMethodMetrics publishes 0-valued series for every (method, path="default",
+// result) and (msg_type, method) tuple, so per-method PromQL queries return defined
+// values immediately after boot. Methods whose request payload determines path
+// (intent/transition) are not enumerated here — those variants appear on first call
+// and are bounded by their respective enums.
+func (m *runtimeMetricExporter) SeedRPCMethodMetrics(methods []string) {
+	msgTypes := []rpc.MsgType{rpc.MsgTypeReq, rpc.MsgTypeResp, rpc.MsgTypeRespErr}
+	const defaultPath = "default"
+	for _, method := range methods {
+		for _, mt := range msgTypes {
+			m.rpcMessagesTotal.WithLabelValues(mt.String(), method)
+		}
+		for _, res := range allActionResults {
+			m.rpcRequestsTotal.WithLabelValues(method, defaultPath, res.String())
+			m.rpcRequestDurationSeconds.WithLabelValues(method, defaultPath, res.String())
+		}
+	}
+}
+
+// SeedBlockchainEventMetrics publishes 0-valued series for every (blockchain_id,
+// result) tuple, so a chain whose listener is wired but has not yet observed an
+// event still appears in queries — including absent()/rate() alerts watching for
+// stalled connections.
+func (m *runtimeMetricExporter) SeedBlockchainEventMetrics(blockchainIDs []uint64) {
+	for _, id := range blockchainIDs {
+		idStr := strconv.FormatUint(id, 10)
+		for _, res := range allActionResults {
+			m.blockchainEventsTotal.WithLabelValues(idStr, res.String())
+		}
+	}
 }
 
 // Shared

--- a/nitronode/metrics/exporter.go
+++ b/nitronode/metrics/exporter.go
@@ -20,6 +20,10 @@ const (
 	MetricNamespace = "nitronode"
 )
 
+// allActionResults is the closed enum of result label values used by counters
+// whose outcome dimension is success/failed.
+var allActionResults = []ActionResult{ActionResultSuccess, ActionResultFailed}
+
 var (
 	_ RuntimeMetricExporter = (*runtimeMetricExporter)(nil)
 	_ StoreMetricExporter   = (*storeMetricExporter)(nil)
@@ -409,15 +413,11 @@ func NewRuntimeMetricExporter(reg prometheus.Registerer) (RuntimeMetricExporter,
 	return m, nil
 }
 
-// allActionResults is the closed enum of result label values used by counters
-// whose outcome dimension is success/failed.
-var allActionResults = []ActionResult{ActionResultSuccess, ActionResultFailed}
-
 // SeedRPCMethodMetrics publishes 0-valued series for every (method, path="default",
-// result) and (msg_type, method) tuple, so per-method PromQL queries return defined
-// values immediately after boot. Methods whose request payload determines path
-// (intent/transition) are not enumerated here — those variants appear on first call
-// and are bounded by their respective enums.
+// result), (msg_type, method) and (method) tuple, so per-method PromQL queries
+// return defined values immediately after boot. Methods whose request payload
+// determines path (intent/transition) are not enumerated here — those variants
+// appear on first call and are bounded by their respective enums.
 func (m *runtimeMetricExporter) SeedRPCMethodMetrics(methods []string) {
 	msgTypes := []rpc.MsgType{rpc.MsgTypeReq, rpc.MsgTypeResp, rpc.MsgTypeRespErr}
 	const defaultPath = "default"
@@ -429,6 +429,7 @@ func (m *runtimeMetricExporter) SeedRPCMethodMetrics(methods []string) {
 			m.rpcRequestsTotal.WithLabelValues(method, defaultPath, res.String())
 			m.rpcRequestDurationSeconds.WithLabelValues(method, defaultPath, res.String())
 		}
+		m.rpcInflight.WithLabelValues(method)
 	}
 }
 

--- a/nitronode/metrics/exporter.go
+++ b/nitronode/metrics/exporter.go
@@ -413,21 +413,29 @@ func NewRuntimeMetricExporter(reg prometheus.Registerer) (RuntimeMetricExporter,
 	return m, nil
 }
 
-// SeedRPCMethodMetrics publishes 0-valued series for every (method, path="default",
-// result), (msg_type, method) and (method) tuple, so per-method PromQL queries
-// return defined values immediately after boot. Methods whose request payload
-// determines path (intent/transition) are not enumerated here — those variants
-// appear on first call and are bounded by their respective enums.
-func (m *runtimeMetricExporter) SeedRPCMethodMetrics(methods []string) {
+// SeedRPCMethodMetrics publishes 0-valued series for every (msg_type, method),
+// (method, path, result) and (method) tuple, so per-method PromQL queries return
+// defined values immediately after boot. The path domain per method comes from
+// methodPaths; methods absent from the map (or mapped to an empty slice) get
+// path="default" only. Methods whose request payload determines path should be
+// listed in methodPaths with their full bounded enum, so absent()-style alerts
+// don't flap on the first request of each variant.
+func (m *runtimeMetricExporter) SeedRPCMethodMetrics(methods []string, methodPaths map[string][]string) {
 	msgTypes := []rpc.MsgType{rpc.MsgTypeReq, rpc.MsgTypeResp, rpc.MsgTypeRespErr}
 	const defaultPath = "default"
 	for _, method := range methods {
 		for _, mt := range msgTypes {
 			m.rpcMessagesTotal.WithLabelValues(mt.String(), method)
 		}
-		for _, res := range allActionResults {
-			m.rpcRequestsTotal.WithLabelValues(method, defaultPath, res.String())
-			m.rpcRequestDurationSeconds.WithLabelValues(method, defaultPath, res.String())
+		paths := methodPaths[method]
+		if len(paths) == 0 {
+			paths = []string{defaultPath}
+		}
+		for _, p := range paths {
+			for _, res := range allActionResults {
+				m.rpcRequestsTotal.WithLabelValues(method, p, res.String())
+				m.rpcRequestDurationSeconds.WithLabelValues(method, p, res.String())
+			}
 		}
 		m.rpcInflight.WithLabelValues(method)
 	}

--- a/nitronode/metrics/exporter_test.go
+++ b/nitronode/metrics/exporter_test.go
@@ -1,0 +1,338 @@
+package metrics
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/layer-3/nitrolite/pkg/app"
+	"github.com/layer-3/nitrolite/pkg/core"
+)
+
+// labelSet renders a metric's labels as a stable "k=v,k=v" string for assertion.
+func labelSet(m *dto.Metric) string {
+	pairs := make([]string, 0, len(m.Label))
+	for _, lp := range m.Label {
+		pairs = append(pairs, lp.GetName()+"="+lp.GetValue())
+	}
+	sort.Strings(pairs)
+	return strings.Join(pairs, ",")
+}
+
+// gatherLabelSets returns the sorted label-set strings of every series published
+// under the given fully-qualified metric name.
+func gatherLabelSets(t *testing.T, reg *prometheus.Registry, name string) []string {
+	t.Helper()
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+	var out []string
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.Metric {
+			out = append(out, labelSet(m))
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// gatherSeriesValues returns label-set → value for every series under the given name.
+// For counters/gauges the value comes from Counter/Gauge; for histograms it returns sample count.
+func gatherSeriesValues(t *testing.T, reg *prometheus.Registry, name string) map[string]float64 {
+	t.Helper()
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+	out := map[string]float64{}
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.Metric {
+			switch {
+			case m.Counter != nil:
+				out[labelSet(m)] = m.Counter.GetValue()
+			case m.Gauge != nil:
+				out[labelSet(m)] = m.Gauge.GetValue()
+			case m.Histogram != nil:
+				out[labelSet(m)] = float64(m.Histogram.GetSampleCount())
+			}
+		}
+	}
+	return out
+}
+
+// --- Store gauge reset semantics ---
+
+func TestStoreMetricExporter_ResetChannels_DropsStaleLabelTuples(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	exp, err := NewStoreMetricExporter(reg)
+	require.NoError(t, err)
+
+	// First tick: two assets open.
+	exp.SetChannels("usdc", core.ChannelStatusOpen, 3)
+	exp.SetChannels("eth", core.ChannelStatusOpen, 1)
+	require.ElementsMatch(t,
+		[]string{"asset=eth,status=open", "asset=usdc,status=open"},
+		gatherLabelSets(t, reg, "nitronode_channels_total"),
+	)
+
+	// Second tick: eth last channel closes — only usdc reported.
+	exp.ResetChannels()
+	exp.SetChannels("usdc", core.ChannelStatusOpen, 2)
+	assert.Equal(t,
+		[]string{"asset=usdc,status=open"},
+		gatherLabelSets(t, reg, "nitronode_channels_total"),
+		"stale eth tuple must drop after Reset+republish",
+	)
+}
+
+func TestStoreMetricExporter_ResetAppSessions_DropsStaleLabelTuples(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	exp, err := NewStoreMetricExporter(reg)
+	require.NoError(t, err)
+
+	exp.SetAppSessions("app-a", app.AppSessionStatusOpen, 2)
+	exp.SetAppSessions("app-b", app.AppSessionStatusOpen, 1)
+
+	exp.ResetAppSessions()
+	exp.SetAppSessions("app-a", app.AppSessionStatusOpen, 4)
+
+	assert.Equal(t,
+		[]string{"application_id=app-a,status=open"},
+		gatherLabelSets(t, reg, "nitronode_app_sessions_total"),
+	)
+}
+
+func TestStoreMetricExporter_ResetTotalValueLocked_DropsStaleLabelTuples(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	exp, err := NewStoreMetricExporter(reg)
+	require.NoError(t, err)
+
+	exp.SetTotalValueLocked("dom", "usdc", 100)
+	exp.SetTotalValueLocked("dom", "eth", 5)
+
+	exp.ResetTotalValueLocked()
+	exp.SetTotalValueLocked("dom", "usdc", 80)
+
+	assert.Equal(t,
+		[]string{"asset=usdc,domain=dom"},
+		gatherLabelSets(t, reg, "nitronode_total_value_locked"),
+	)
+}
+
+func TestStoreMetricExporter_ResetNodeBalance_DropsStaleLabelTuples(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	exp, err := NewStoreMetricExporter(reg)
+	require.NoError(t, err)
+
+	exp.SetNodeBalance("1", "usdc", 100)
+	exp.SetNodeBalance("137", "matic", 50)
+
+	exp.ResetNodeBalance()
+	exp.SetNodeBalance("1", "usdc", 90)
+
+	assert.Equal(t,
+		[]string{"asset=usdc,blockchain_id=1"},
+		gatherLabelSets(t, reg, "nitronode_node_balance"),
+	)
+}
+
+func TestStoreMetricExporter_ResetUserBalances_ClearsAllThreeGauges(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	exp, err := NewStoreMetricExporter(reg)
+	require.NoError(t, err)
+
+	exp.SetUserBalanceTotal("1", "usdc", 100)
+	exp.SetUserBalanceUnderfunded("1", "usdc", 10)
+	exp.SetUserBalanceReleasable("1", "usdc", 5)
+	exp.SetUserBalanceTotal("137", "matic", 50)
+
+	exp.ResetUserBalances()
+	exp.SetUserBalanceTotal("1", "usdc", 90)
+	// underfunded / releasable intentionally not re-set this tick.
+
+	assert.Equal(t,
+		[]string{"asset=usdc,blockchain_id=1"},
+		gatherLabelSets(t, reg, "nitronode_user_balance_total"),
+	)
+	assert.Empty(t,
+		gatherLabelSets(t, reg, "nitronode_user_balance_underfunded"),
+		"underfunded must be cleared with the family",
+	)
+	assert.Empty(t,
+		gatherLabelSets(t, reg, "nitronode_user_balance_releasable"),
+		"releasable must be cleared with the family",
+	)
+}
+
+// ResetActiveUsers / ResetActiveAppSessions use DeletePartialMatch(timespan=...),
+// so a failure in one timespan must not blank the others.
+
+func TestStoreMetricExporter_ResetActiveUsers_ClearsOnlyTargetTimespan(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	exp, err := NewStoreMetricExporter(reg)
+	require.NoError(t, err)
+
+	exp.SetActiveUsers("usdc", "day", 10)
+	exp.SetActiveUsers("usdc", "week", 50)
+	exp.SetActiveUsers("usdc", "month", 200)
+	exp.SetActiveUsers("eth", "day", 1)
+	exp.SetActiveUsers("eth", "week", 4)
+
+	exp.ResetActiveUsers("day")
+
+	got := gatherLabelSets(t, reg, "nitronode_users_active")
+	assert.NotContains(t, got, "asset=usdc,timespan=day")
+	assert.NotContains(t, got, "asset=eth,timespan=day")
+	assert.Contains(t, got, "asset=usdc,timespan=week")
+	assert.Contains(t, got, "asset=usdc,timespan=month")
+	assert.Contains(t, got, "asset=eth,timespan=week")
+}
+
+func TestStoreMetricExporter_ResetActiveAppSessions_ClearsOnlyTargetTimespan(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	exp, err := NewStoreMetricExporter(reg)
+	require.NoError(t, err)
+
+	exp.SetActiveAppSessions("app-a", "day", 3)
+	exp.SetActiveAppSessions("app-a", "week", 10)
+	exp.SetActiveAppSessions("app-b", "day", 1)
+	exp.SetActiveAppSessions("app-b", "month", 7)
+
+	exp.ResetActiveAppSessions("day")
+
+	got := gatherLabelSets(t, reg, "nitronode_app_sessions_active")
+	assert.NotContains(t, got, "application_id=app-a,timespan=day")
+	assert.NotContains(t, got, "application_id=app-b,timespan=day")
+	assert.Contains(t, got, "application_id=app-a,timespan=week")
+	assert.Contains(t, got, "application_id=app-b,timespan=month")
+}
+
+// --- Runtime exporter cold-start seeding ---
+
+func TestNewRuntimeMetricExporter_SeedsChannelStateSigValidations(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	_, err := NewRuntimeMetricExporter(reg)
+	require.NoError(t, err)
+
+	got := gatherSeriesValues(t, reg, "nitronode_channel_state_sig_validations_total")
+	// One series per (signer_type × result) pair, all at value 0.
+	expected := map[string]float64{}
+	for _, st := range core.ChannelSignerTypes {
+		for _, res := range allActionResults {
+			expected["result="+res.String()+",sig_type="+st.String()] = 0
+		}
+	}
+	assert.Equal(t, expected, got)
+}
+
+func TestSeedRPCMethodMetrics_PublishesZeroValuedSeries(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	exp, err := NewRuntimeMetricExporter(reg)
+	require.NoError(t, err)
+
+	rt := exp.(*runtimeMetricExporter)
+	methods := []string{"channels.v1.submit_state", "app_sessions.v1.create_app_session"}
+	rt.SeedRPCMethodMetrics(methods)
+
+	// rpc_messages_emitted_total: 3 msg_types × N methods, all at 0.
+	msgs := gatherSeriesValues(t, reg, "nitronode_rpc_messages_emitted_total")
+	require.Len(t, msgs, 3*len(methods))
+	for _, m := range methods {
+		for _, mt := range []string{"req", "resp", "error"} {
+			key := "method=" + m + ",msg_type=" + mt
+			v, ok := msgs[key]
+			assert.True(t, ok, "missing series %s", key)
+			assert.Zero(t, v)
+		}
+	}
+
+	// rpc_requests_total: N methods × {path=default} × 2 results, all at 0.
+	reqs := gatherSeriesValues(t, reg, "nitronode_rpc_requests_total")
+	require.Len(t, reqs, 2*len(methods))
+	for _, m := range methods {
+		for _, res := range allActionResults {
+			key := "method=" + m + ",path=default,result=" + res.String()
+			v, ok := reqs[key]
+			assert.True(t, ok, "missing series %s", key)
+			assert.Zero(t, v)
+		}
+	}
+
+	// rpc_request_duration_seconds (histogram): same label space, sample count 0.
+	durs := gatherSeriesValues(t, reg, "nitronode_rpc_request_duration_seconds")
+	assert.Len(t, durs, 2*len(methods))
+	for _, v := range durs {
+		assert.Zero(t, v)
+	}
+
+	// rpc_inflight: one series per method (bounded `method` label), gauge at 0.
+	inflight := gatherSeriesValues(t, reg, "nitronode_rpc_inflight")
+	require.Len(t, inflight, len(methods))
+	for _, m := range methods {
+		v, ok := inflight["method="+m]
+		assert.True(t, ok, "missing rpc_inflight series for method %s", m)
+		assert.Zero(t, v)
+	}
+}
+
+func TestSeedRPCMethodMetrics_EmptyMethodsIsNoop(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	exp, err := NewRuntimeMetricExporter(reg)
+	require.NoError(t, err)
+
+	rt := exp.(*runtimeMetricExporter)
+	rt.SeedRPCMethodMetrics(nil)
+
+	assert.Empty(t, gatherSeriesValues(t, reg, "nitronode_rpc_messages_emitted_total"))
+	assert.Empty(t, gatherSeriesValues(t, reg, "nitronode_rpc_requests_total"))
+	assert.Empty(t, gatherSeriesValues(t, reg, "nitronode_rpc_inflight"))
+}
+
+func TestSeedBlockchainEventMetrics_PublishesZeroValuedSeries(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	exp, err := NewRuntimeMetricExporter(reg)
+	require.NoError(t, err)
+
+	rt := exp.(*runtimeMetricExporter)
+	ids := []uint64{1, 137, 8453}
+	rt.SeedBlockchainEventMetrics(ids)
+
+	got := gatherSeriesValues(t, reg, "nitronode_blockchain_events_total")
+	require.Len(t, got, len(ids)*len(allActionResults))
+	for _, id := range ids {
+		for _, res := range allActionResults {
+			key := "blockchain_id=" + strconv.FormatUint(id, 10) + ",result=" + res.String()
+			v, ok := got[key]
+			assert.True(t, ok, "missing series %s", key)
+			assert.Zero(t, v)
+		}
+	}
+}
+
+func TestSeedBlockchainEventMetrics_PreservesPriorIncrements(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	exp, err := NewRuntimeMetricExporter(reg)
+	require.NoError(t, err)
+
+	exp.IncBlockchainEvent(1, true)
+	exp.IncBlockchainEvent(1, true)
+
+	rt := exp.(*runtimeMetricExporter)
+	rt.SeedBlockchainEventMetrics([]uint64{1, 137})
+
+	got := gatherSeriesValues(t, reg, "nitronode_blockchain_events_total")
+	assert.Equal(t, 2.0, got["blockchain_id=1,result=success"],
+		"WithLabelValues without Inc must not reset existing counter")
+	assert.Equal(t, 0.0, got["blockchain_id=1,result=failed"])
+	assert.Equal(t, 0.0, got["blockchain_id=137,result=success"])
+	assert.Equal(t, 0.0, got["blockchain_id=137,result=failed"])
+}

--- a/nitronode/metrics/exporter_test.go
+++ b/nitronode/metrics/exporter_test.go
@@ -241,7 +241,7 @@ func TestSeedRPCMethodMetrics_PublishesZeroValuedSeries(t *testing.T) {
 
 	rt := exp.(*runtimeMetricExporter)
 	methods := []string{"channels.v1.submit_state", "app_sessions.v1.create_app_session"}
-	rt.SeedRPCMethodMetrics(methods)
+	rt.SeedRPCMethodMetrics(methods, nil)
 
 	// rpc_messages_emitted_total: 3 msg_types × N methods, all at 0.
 	msgs := gatherSeriesValues(t, reg, "nitronode_rpc_messages_emitted_total")
@@ -290,11 +290,52 @@ func TestSeedRPCMethodMetrics_EmptyMethodsIsNoop(t *testing.T) {
 	require.NoError(t, err)
 
 	rt := exp.(*runtimeMetricExporter)
-	rt.SeedRPCMethodMetrics(nil)
+	rt.SeedRPCMethodMetrics(nil, nil)
 
 	assert.Empty(t, gatherSeriesValues(t, reg, "nitronode_rpc_messages_emitted_total"))
 	assert.Empty(t, gatherSeriesValues(t, reg, "nitronode_rpc_requests_total"))
 	assert.Empty(t, gatherSeriesValues(t, reg, "nitronode_rpc_inflight"))
+}
+
+func TestSeedRPCMethodMetrics_EnumeratesBoundedPaths(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	exp, err := NewRuntimeMetricExporter(reg)
+	require.NoError(t, err)
+
+	rt := exp.(*runtimeMetricExporter)
+	const boundedMethod = "channels.v1.submit_state"
+	const defaultMethod = "app_sessions.v1.create_app_session"
+	paths := []string{"escrow_lock", "void", "commit"}
+	methods := []string{boundedMethod, defaultMethod}
+
+	rt.SeedRPCMethodMetrics(methods, map[string][]string{boundedMethod: paths})
+
+	reqs := gatherSeriesValues(t, reg, "nitronode_rpc_requests_total")
+	// boundedMethod: len(paths) × len(allActionResults). defaultMethod: 1 × len(allActionResults).
+	require.Len(t, reqs, (len(paths)+1)*len(allActionResults))
+
+	// Every (boundedMethod, path, result) tuple from the map appears.
+	for _, p := range paths {
+		for _, res := range allActionResults {
+			key := "method=" + boundedMethod + ",path=" + p + ",result=" + res.String()
+			_, ok := reqs[key]
+			assert.True(t, ok, "missing series %s", key)
+		}
+	}
+
+	// boundedMethod has no path="default" series — caller declared the full domain.
+	for _, res := range allActionResults {
+		key := "method=" + boundedMethod + ",path=default,result=" + res.String()
+		_, ok := reqs[key]
+		assert.False(t, ok, "unexpected default-path series for bounded method: %s", key)
+	}
+
+	// Method absent from the map falls back to path="default".
+	for _, res := range allActionResults {
+		key := "method=" + defaultMethod + ",path=default,result=" + res.String()
+		_, ok := reqs[key]
+		assert.True(t, ok, "missing default-path series %s", key)
+	}
 }
 
 func TestSeedBlockchainEventMetrics_PublishesZeroValuedSeries(t *testing.T) {

--- a/nitronode/metrics/interface.go
+++ b/nitronode/metrics/interface.go
@@ -80,6 +80,13 @@ func (noopRuntimeMetricExporter) DecRPCInflight(string)                      {}
 func (noopRuntimeMetricExporter) ObserveDBQueryDuration(string, time.Duration) {}
 
 // StoreMetricExporter defines the interface for setting metrics that are stored and updated by a separate metric worker.
+//
+// The Reset* methods drop every series in their respective gauges so the next batch of
+// Set* calls re-publishes a complete picture. Without this, label tuples that disappear
+// from the store (e.g., the last open channel for an asset closes) would keep their
+// previous non-zero value indefinitely because the underlying GROUP BY queries omit
+// zero-count buckets. Callers should only reset after a successful query — resetting
+// on error would blank a healthy gauge during a transient DB outage.
 type StoreMetricExporter interface {
 	SetAppSessions(applicationID string, status app.AppSessionStatus, count uint64)
 	SetChannels(asset string, status core.ChannelStatus, count uint64)
@@ -90,4 +97,12 @@ type StoreMetricExporter interface {
 	SetUserBalanceTotal(blockchainID, asset string, value float64)
 	SetUserBalanceUnderfunded(blockchainID, asset string, value float64)
 	SetUserBalanceReleasable(blockchainID, asset string, value float64)
+
+	ResetAppSessions()
+	ResetChannels()
+	ResetTotalValueLocked()
+	ResetNodeBalance()
+	ResetUserBalances()
+	ResetActiveUsers(timeSpanLabel string)
+	ResetActiveAppSessions(timeSpanLabel string)
 }

--- a/nitronode/metrics/interface.go
+++ b/nitronode/metrics/interface.go
@@ -57,7 +57,7 @@ type RuntimeMetricExporter interface {
 	// Seeders publish 0-valued series for label tuples whose full domain is known at
 	// startup, so PromQL queries (and absent()-style alerts) return defined values
 	// during the cold-start window before any traffic or chain event has arrived.
-	SeedRPCMethodMetrics(methods []string)
+	SeedRPCMethodMetrics(methods []string, methodPaths map[string][]string)
 	SeedBlockchainEventMetrics(blockchainIDs []uint64)
 }
 
@@ -84,7 +84,7 @@ func (noopRuntimeMetricExporter) IncBlockchainEvent(uint64, bool)            {}
 func (noopRuntimeMetricExporter) IncRPCInflight(string)                      {}
 func (noopRuntimeMetricExporter) DecRPCInflight(string)                      {}
 func (noopRuntimeMetricExporter) ObserveDBQueryDuration(string, time.Duration) {}
-func (noopRuntimeMetricExporter) SeedRPCMethodMetrics([]string)                {}
+func (noopRuntimeMetricExporter) SeedRPCMethodMetrics([]string, map[string][]string) {}
 func (noopRuntimeMetricExporter) SeedBlockchainEventMetrics([]uint64)          {}
 
 // StoreMetricExporter defines the interface for setting metrics that are stored and updated by a separate metric worker.

--- a/nitronode/metrics/interface.go
+++ b/nitronode/metrics/interface.go
@@ -53,6 +53,12 @@ type RuntimeMetricExporter interface {
 
 	// store/database (instrumented via gorm callbacks; see metrics.RegisterDBCallbacks)
 	ObserveDBQueryDuration(queryKind string, duration time.Duration)
+
+	// Seeders publish 0-valued series for label tuples whose full domain is known at
+	// startup, so PromQL queries (and absent()-style alerts) return defined values
+	// during the cold-start window before any traffic or chain event has arrived.
+	SeedRPCMethodMetrics(methods []string)
+	SeedBlockchainEventMetrics(blockchainIDs []uint64)
 }
 
 // noopRuntimeMetricExporter is a no-op implementation for use in tests.
@@ -78,6 +84,8 @@ func (noopRuntimeMetricExporter) IncBlockchainEvent(uint64, bool)            {}
 func (noopRuntimeMetricExporter) IncRPCInflight(string)                      {}
 func (noopRuntimeMetricExporter) DecRPCInflight(string)                      {}
 func (noopRuntimeMetricExporter) ObserveDBQueryDuration(string, time.Duration) {}
+func (noopRuntimeMetricExporter) SeedRPCMethodMetrics([]string)                {}
+func (noopRuntimeMetricExporter) SeedBlockchainEventMetrics([]uint64)          {}
 
 // StoreMetricExporter defines the interface for setting metrics that are stored and updated by a separate metric worker.
 //

--- a/nitronode/runtime.go
+++ b/nitronode/runtime.go
@@ -211,6 +211,15 @@ func InitBackbone() *Backbone {
 
 	blockchainRPCs := initBlockchainRPCs(logger, memoryStore)
 
+	// Seed per-chain event counters at 0 so a chain whose listener has not yet
+	// emitted an event still appears in /metrics (lets stalled-listener alerts
+	// based on absent()/rate() evaluate against defined series).
+	blockchainIDs := make([]uint64, 0, len(blockchainRPCs))
+	for id := range blockchainRPCs {
+		blockchainIDs = append(blockchainIDs, id)
+	}
+	runtimeMetrics.SeedBlockchainEventMetrics(blockchainIDs)
+
 	return &Backbone{
 		NodeVersion:                 Version,
 		ChannelMinChallengeDuration: conf.ChannelMinChallengeDuration,

--- a/pkg/app/app_session_v1.go
+++ b/pkg/app/app_session_v1.go
@@ -23,6 +23,17 @@ const (
 	AppStateUpdateIntentRebalance
 )
 
+// AllAppStateUpdateIntents enumerates every defined intent. Kept beside the
+// const block so adding a new intent here is the natural place to update
+// consumers that iterate the full domain (metrics seeding, drift tests).
+var AllAppStateUpdateIntents = []AppStateUpdateIntent{
+	AppStateUpdateIntentOperate,
+	AppStateUpdateIntentDeposit,
+	AppStateUpdateIntentWithdraw,
+	AppStateUpdateIntentClose,
+	AppStateUpdateIntentRebalance,
+}
+
 func (intent AppStateUpdateIntent) String() string {
 	switch intent {
 	case AppStateUpdateIntentOperate:

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -865,6 +865,26 @@ const (
 	TransitionTypeFinalize TransitionType = 200 // AccountID: HomeChannelID
 )
 
+// AllTransitionTypes enumerates every defined transition. Kept beside the const
+// block so adding a new transition here is the natural place to update consumers
+// that iterate the full domain (metrics seeding, drift tests).
+var AllTransitionTypes = []TransitionType{
+	TransitionTypeVoid,
+	TransitionTypeAcknowledgement,
+	TransitionTypeHomeDeposit,
+	TransitionTypeHomeWithdrawal,
+	TransitionTypeEscrowDeposit,
+	TransitionTypeEscrowWithdraw,
+	TransitionTypeTransferSend,
+	TransitionTypeTransferReceive,
+	TransitionTypeCommit,
+	TransitionTypeRelease,
+	TransitionTypeMigrate,
+	TransitionTypeEscrowLock,
+	TransitionTypeMutualLock,
+	TransitionTypeFinalize,
+}
+
 // String returns the human-readable name of the transition type
 func (t TransitionType) String() string {
 	switch t {

--- a/pkg/rpc/node.go
+++ b/pkg/rpc/node.go
@@ -56,6 +56,11 @@ type Node interface {
 	// Groups can have their own middleware and can be nested to create
 	// hierarchical handler structures.
 	NewGroup(name string) HandlerGroup
+
+	// RegisteredMethods returns every RPC method name registered on the node
+	// (across the root group and all subgroups). Intended for instrumentation
+	// at startup, not for request routing.
+	RegisteredMethods() []string
 }
 
 type HandlerGroup interface {
@@ -377,6 +382,17 @@ func (wn *WebsocketNode) NewGroup(name string) HandlerGroup {
 func (wn *WebsocketNode) Handle(method string, handler Handler) {
 	wn.handle(method, handler)
 	wn.routes[method] = []string{wn.groupId, method}
+}
+
+// RegisteredMethods returns every method registered on the node. Order is not
+// guaranteed. The underlying map is not mutex-protected, so the call must happen
+// after registration has finished (registration is expected to be single-threaded).
+func (wn *WebsocketNode) RegisteredMethods() []string {
+	methods := make([]string, 0, len(wn.routes))
+	for method := range wn.routes {
+		methods = append(methods, method)
+	}
+	return methods
 }
 
 // handle is the internal method for registering handlers.

--- a/pkg/rpc/node_test.go
+++ b/pkg/rpc/node_test.go
@@ -1,0 +1,58 @@
+package rpc
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/layer-3/nitrolite/pkg/log"
+)
+
+func newTestNode(t *testing.T) *WebsocketNode {
+	t.Helper()
+	node, err := NewWebsocketNode(WebsocketNodeConfig{Logger: log.NewNoopLogger()})
+	require.NoError(t, err)
+	return node
+}
+
+func TestRegisteredMethods_EmptyNode(t *testing.T) {
+	node := newTestNode(t)
+	assert.Empty(t, node.RegisteredMethods())
+}
+
+func TestRegisteredMethods_RootHandle(t *testing.T) {
+	node := newTestNode(t)
+	noop := func(c *Context) {}
+
+	node.Handle("ping", noop)
+	node.Handle("status", noop)
+
+	got := node.RegisteredMethods()
+	sort.Strings(got)
+	assert.Equal(t, []string{"ping", "status"}, got)
+}
+
+// Group-level Handle must also surface through RegisteredMethods(); the metrics
+// seeder relies on a complete list across the root group and all subgroups.
+func TestRegisteredMethods_IncludesGroupRegistrations(t *testing.T) {
+	node := newTestNode(t)
+	noop := func(c *Context) {}
+
+	node.Handle("ping", noop)
+
+	auth := node.NewGroup("auth")
+	auth.Handle("auth.login", noop)
+	auth.Handle("auth.logout", noop)
+
+	nested := auth.NewGroup("admin")
+	nested.Handle("auth.admin.kick", noop)
+
+	got := node.RegisteredMethods()
+	sort.Strings(got)
+	assert.Equal(t,
+		[]string{"auth.admin.kick", "auth.login", "auth.logout", "ping"},
+		got,
+	)
+}


### PR DESCRIPTION
## Summary
Remediates three issues with nitronode's Prometheus instrumentation that surfaced during the metrics audit:

- **Stale store gauges** — `app_sessions_total`, `channels_total`, `users_active`, `app_sessions_active`, `total_value_locked`, `node_balance`, `user_balance_*` are populated from `GROUP BY` queries that omit zero-count rows, so a label tuple whose last entity disappears (e.g., last open channel for an asset closes) keeps its prior non-zero value indefinitely. Added `Reset*` methods on `StoreMetricExporter` and call them inside each successful-query branch of the store-metrics worker before re-publishing the snapshot. `ResetActiveUsers` / `ResetActiveAppSessions` use `DeletePartialMatch(timespan=...)` so a failure in one time window does not blank the others. On query error the gauges are left untouched, so transient DB outages do not blank healthy series.
- **Cold-start gauge silence** — the store-metrics worker waited a full `fetchInterval` before its first refresh, so balance and channel gauges were absent during the warmup window. Tick body extracted into a `refresh` closure and invoked once before the `select` loop.
- **Cold-start counter silence** — counters whose label space is fully known at boot were absent until first traffic. Pre-publish 0-valued series for every (label tuple): `channel_state_sig_validations_total` (seeded in `NewRuntimeMetricExporter`), `rpc_messages_emitted_total` / `rpc_requests_total` / `rpc_request_duration_seconds` (seeded via `SeedRPCMethodMetrics` after route registration), and `blockchain_events_total` (seeded via `SeedBlockchainEventMetrics` after chain config load).

Counters carrying an unbounded `application_id` or `asset` axis are intentionally not seeded (out of scope for this story; tracked under the long-term cardinality concern).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/rpc/... ./nitronode/...`
- [ ] On a freshly started nitronode, `curl /metrics` and verify the seeded series (`channel_state_sig_validations_total`, `rpc_requests_total{...,path="default"}`, `blockchain_events_total`) appear with value 0 before any traffic or on-chain event arrives.
- [ ] Close the last `open` channel for an asset; verify `channels_total{asset="…",status="open"}` disappears after the next store-metrics tick (instead of sticking at its prior value).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Metrics now publish zero-valued series at startup for RPC methods, per-path RPC counters, channel signer validations, and blockchain events so dashboards/alerts show baseline series.
  * Store metric polling centralized; gauges are reset and repopulated only after successful queries to avoid stale label tuples.

* **New Features**
  * Nodes expose an API to list registered RPC methods.
  * Added a published mapping of RPC methods to allowed request paths.

* **Tests**
  * Expanded tests covering metric seeding/reset behavior and RPC method listing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/layer-3/nitrolite/pull/747?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->