### PR TITLE
MF-I07: fix(contracts): enforce max challenge duration

### DIFF
--- a/contracts/src/ChannelHub.sol
+++ b/contracts/src/ChannelHub.sol
@@ -164,6 +164,7 @@ contract ChannelHub is ReentrancyGuard {
 
     // TODO: estimate these values better
     uint32 public constant MIN_CHALLENGE_DURATION = 1 days;
+    uint32 public constant MAX_CHALLENGE_DURATION = 7 days;
 
     uint32 public constant ESCROW_DEPOSIT_UNLOCK_DELAY = 3 hours;
 
@@ -1344,7 +1345,10 @@ contract ChannelHub is ReentrancyGuard {
         require(user != address(0), InvalidAddress());
         require(def.node == NODE, IncorrectNode());
         require(user != NODE, AddressCollision(user));
-        require(def.challengeDuration >= MIN_CHALLENGE_DURATION, IncorrectChallengeDuration());
+        require(
+            def.challengeDuration >= MIN_CHALLENGE_DURATION && def.challengeDuration <= MAX_CHALLENGE_DURATION,
+            IncorrectChallengeDuration()
+        );
     }
 
     /// @dev Returns true when the channel is active and considers the current chain its home chain.

--- a/contracts/test/ChannelHub_units/ChannelHub_createChannel.t.sol
+++ b/contracts/test/ChannelHub_units/ChannelHub_createChannel.t.sol
@@ -105,6 +105,23 @@ contract ChannelHubTest_createChannel is ChannelHubTest_Base {
         );
     }
 
+    function test_createChannel_allowsMaxChallengeDuration() public {
+        def.challengeDuration = cHub.MAX_CHALLENGE_DURATION();
+        bytes32 maxDurationChannelId = Utils.getChannelId(def, CHANNEL_HUB_VERSION);
+        State memory state = mutualSignStateBothWithEcdsaValidator(initialDepositState, maxDurationChannelId, ALICE_PK);
+
+        vm.prank(alice);
+        cHub.createChannel(def, state);
+
+        verifyChannelData(
+            maxDurationChannelId,
+            ChannelStatus.OPERATING,
+            0,
+            0,
+            "Channel status should be OPERATING when challenge duration is the contract max"
+        );
+    }
+
     // ========== Revert: createChannel on existing channel ==========
 
     function _createDefaultChannel() internal {
@@ -164,6 +181,28 @@ contract ChannelHubTest_createChannel is ChannelHubTest_Base {
         state.intent = StateIntent.CLOSE;
 
         vm.expectRevert(ChannelHub.IncorrectStateIntent.selector);
+        cHub.createChannel(def, state);
+    }
+
+    // ========== Challenge duration ==========
+
+    function test_revert_ifChallengeDurationAboveMax() public {
+        def.challengeDuration = cHub.MAX_CHALLENGE_DURATION() + 1;
+        bytes32 tooLongChannelId = Utils.getChannelId(def, CHANNEL_HUB_VERSION);
+        State memory state = mutualSignStateBothWithEcdsaValidator(initialDepositState, tooLongChannelId, ALICE_PK);
+
+        vm.prank(alice);
+        vm.expectRevert(ChannelHub.IncorrectChallengeDuration.selector);
+        cHub.createChannel(def, state);
+    }
+
+    function test_revert_ifChallengeDurationBelowMin() public {
+        def.challengeDuration = cHub.MIN_CHALLENGE_DURATION() - 1;
+        bytes32 tooShortChannelId = Utils.getChannelId(def, CHANNEL_HUB_VERSION);
+        State memory state = mutualSignStateBothWithEcdsaValidator(initialDepositState, tooShortChannelId, ALICE_PK);
+
+        vm.prank(alice);
+        vm.expectRevert(ChannelHub.IncorrectChallengeDuration.selector);
         cHub.createChannel(def, state);
     }
 

--- a/nitronode/runtime.go
+++ b/nitronode/runtime.go
@@ -32,6 +32,11 @@ var embedMigrations embed.FS
 
 var Version = "v1.0.0" // set at build time with -ldflags "-X main.Version=x.y.z"
 
+const (
+	channelHubMinChallengeDuration uint32 = 24 * 60 * 60
+	channelHubMaxChallengeDuration uint32 = 7 * 24 * 60 * 60
+)
+
 type Backbone struct {
 	NodeVersion                 string
 	ChannelMinChallengeDuration uint32
@@ -106,6 +111,31 @@ type ValidationLimits struct {
 	MaxSessionKeysPerUser int `yaml:"max_session_keys_per_user" env:"NITRONODE_MAX_SESSION_KEYS_PER_USER" env-default:"100"`
 }
 
+func validateChannelChallengeConfig(minChallenge, maxChallenge uint32) error {
+	if minChallenge < channelHubMinChallengeDuration {
+		return fmt.Errorf(
+			"NITRONODE_CHANNEL_MIN_CHALLENGE_DURATION must be at least %d seconds, got %d",
+			channelHubMinChallengeDuration,
+			minChallenge,
+		)
+	}
+	if maxChallenge > channelHubMaxChallengeDuration {
+		return fmt.Errorf(
+			"NITRONODE_CHANNEL_MAX_CHALLENGE_DURATION must be at most %d seconds, got %d",
+			channelHubMaxChallengeDuration,
+			maxChallenge,
+		)
+	}
+	if minChallenge > maxChallenge {
+		return fmt.Errorf(
+			"NITRONODE_CHANNEL_MIN_CHALLENGE_DURATION must be <= NITRONODE_CHANNEL_MAX_CHALLENGE_DURATION, got min=%d max=%d",
+			minChallenge,
+			maxChallenge,
+		)
+	}
+	return nil
+}
+
 // InitBackbone initializes the backbone components of the application.
 func InitBackbone() *Backbone {
 	closers := []func() error{} // collect closer functions for resources that need cleanup
@@ -125,6 +155,9 @@ func InitBackbone() *Backbone {
 	var conf FullConfig
 	if err := cleanenv.ReadEnv(&conf); err != nil {
 		logger.Fatal("failed to read env", "err", err)
+	}
+	if err := validateChannelChallengeConfig(conf.ChannelMinChallengeDuration, conf.ChannelMaxChallengeDuration); err != nil {
+		logger.Fatal("invalid channel challenge duration config", "error", err)
 	}
 
 	logger.Info("config loaded", "version", Version)

--- a/nitronode/runtime.go
+++ b/nitronode/runtime.go
@@ -32,11 +32,6 @@ var embedMigrations embed.FS
 
 var Version = "v1.0.0" // set at build time with -ldflags "-X main.Version=x.y.z"
 
-const (
-	channelHubMinChallengeDuration uint32 = 24 * 60 * 60
-	channelHubMaxChallengeDuration uint32 = 7 * 24 * 60 * 60
-)
-
 type Backbone struct {
 	NodeVersion                 string
 	ChannelMinChallengeDuration uint32
@@ -112,17 +107,17 @@ type ValidationLimits struct {
 }
 
 func validateChannelChallengeConfig(minChallenge, maxChallenge uint32) error {
-	if minChallenge < channelHubMinChallengeDuration {
+	if minChallenge < core.ChannelMinChallengeDuration {
 		return fmt.Errorf(
 			"NITRONODE_CHANNEL_MIN_CHALLENGE_DURATION must be at least %d seconds, got %d",
-			channelHubMinChallengeDuration,
+			core.ChannelMinChallengeDuration,
 			minChallenge,
 		)
 	}
-	if maxChallenge > channelHubMaxChallengeDuration {
+	if maxChallenge > core.ChannelMaxChallengeDuration {
 		return fmt.Errorf(
 			"NITRONODE_CHANNEL_MAX_CHALLENGE_DURATION must be at most %d seconds, got %d",
-			channelHubMaxChallengeDuration,
+			core.ChannelMaxChallengeDuration,
 			maxChallenge,
 		)
 	}

--- a/nitronode/runtime_config_test.go
+++ b/nitronode/runtime_config_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"strings"
 	"testing"
+
+	"github.com/layer-3/nitrolite/pkg/core"
 )
 
 func TestValidateChannelChallengeConfig(t *testing.T) {
@@ -15,8 +17,8 @@ func TestValidateChannelChallengeConfig(t *testing.T) {
 	}{
 		{
 			name:         "default range passes",
-			minChallenge: 86400,
-			maxChallenge: 604800,
+			minChallenge: core.ChannelMinChallengeDuration,
+			maxChallenge: core.ChannelMaxChallengeDuration,
 		},
 		{
 			name:         "stricter range passes",
@@ -25,22 +27,22 @@ func TestValidateChannelChallengeConfig(t *testing.T) {
 		},
 		{
 			name:          "max above contract limit fails",
-			minChallenge:  86400,
-			maxChallenge:  604801,
+			minChallenge:  core.ChannelMinChallengeDuration,
+			maxChallenge:  core.ChannelMaxChallengeDuration + 1,
 			wantErr:       true,
 			errorContains: "NITRONODE_CHANNEL_MAX_CHALLENGE_DURATION",
 		},
 		{
 			name:          "min below contract limit fails",
-			minChallenge:  86399,
-			maxChallenge:  604800,
+			minChallenge:  core.ChannelMinChallengeDuration - 1,
+			maxChallenge:  core.ChannelMaxChallengeDuration,
 			wantErr:       true,
 			errorContains: "NITRONODE_CHANNEL_MIN_CHALLENGE_DURATION",
 		},
 		{
 			name:          "min greater than max fails",
-			minChallenge:  604800,
-			maxChallenge:  86400,
+			minChallenge:  core.ChannelMaxChallengeDuration,
+			maxChallenge:  core.ChannelMinChallengeDuration,
 			wantErr:       true,
 			errorContains: "must be <=",
 		},

--- a/nitronode/runtime_config_test.go
+++ b/nitronode/runtime_config_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateChannelChallengeConfig(t *testing.T) {
+	tests := []struct {
+		name          string
+		minChallenge  uint32
+		maxChallenge  uint32
+		wantErr       bool
+		errorContains string
+	}{
+		{
+			name:         "default range passes",
+			minChallenge: 86400,
+			maxChallenge: 604800,
+		},
+		{
+			name:         "stricter range passes",
+			minChallenge: 172800,
+			maxChallenge: 345600,
+		},
+		{
+			name:          "max above contract limit fails",
+			minChallenge:  86400,
+			maxChallenge:  604801,
+			wantErr:       true,
+			errorContains: "NITRONODE_CHANNEL_MAX_CHALLENGE_DURATION",
+		},
+		{
+			name:          "min below contract limit fails",
+			minChallenge:  86399,
+			maxChallenge:  604800,
+			wantErr:       true,
+			errorContains: "NITRONODE_CHANNEL_MIN_CHALLENGE_DURATION",
+		},
+		{
+			name:          "min greater than max fails",
+			minChallenge:  604800,
+			maxChallenge:  86400,
+			wantErr:       true,
+			errorContains: "must be <=",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateChannelChallengeConfig(tt.minChallenge, tt.maxChallenge)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.errorContains) {
+					t.Fatalf("expected error containing %q, got %q", tt.errorContains, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}

--- a/pkg/core/utils.go
+++ b/pkg/core/utils.go
@@ -16,6 +16,11 @@ const (
 	// This version is encoded as the first byte of the channelId to prevent replay attacks
 	// across different ChannelHub deployments on the same chain.
 	ChannelHubVersion uint8 = 1
+
+	// ChannelMinChallengeDuration and ChannelMaxChallengeDuration mirror the
+	// ChannelHub challenge-duration bounds.
+	ChannelMinChallengeDuration uint32 = 24 * 60 * 60
+	ChannelMaxChallengeDuration uint32 = 7 * 24 * 60 * 60
 )
 
 var (

--- a/sdk/ts/src/blockchain/evm/channel_hub_abi.ts
+++ b/sdk/ts/src/blockchain/evm/channel_hub_abi.ts
@@ -50,6 +50,19 @@ export const ChannelHubAbi = [
   },
   {
     type: 'function',
+    name: 'MAX_CHALLENGE_DURATION',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'uint32',
+        internalType: 'uint32'
+      }
+    ],
+    stateMutability: 'view'
+  },
+  {
+    type: 'function',
     name: 'MAX_DEPOSIT_ESCROW_STEPS',
     inputs: [],
     outputs: [


### PR DESCRIPTION
## summary
- enforce the 7-day max challenge duration in `ChannelHub`
- fail NitroNode startup when configured challenge bounds are looser than the contract
- update the checked-in TS ChannelHub ABI

## tests
- `cd contracts && forge test`
- `go test ./...`
- `cd sdk/ts && npm run typecheck && npm run build:ci`