### PR TITLE
MF-M09: fix(nitronode): auto-challenge home channel on withheld escrow finalize

### DIFF
--- a/nitronode/blockchain_worker.go
+++ b/nitronode/blockchain_worker.go
@@ -37,20 +37,32 @@ const (
 )
 
 type BlockchainWorker struct {
-	blockchainID uint64
-	client       core.BlockchainClient
-	store        BlockchainWorkerStore
-	logger       log.Logger
-	metrics      MetricsExporter
+	blockchainID  uint64
+	client        core.BlockchainClient
+	store         BlockchainWorkerStore
+	channelSigner core.ChannelSigner
+	assetStore    core.AssetStore
+	logger        log.Logger
+	metrics       MetricsExporter
 }
 
-func NewBlockchainWorker(blockchainID uint64, client core.BlockchainClient, store BlockchainWorkerStore, logger log.Logger, m MetricsExporter) *BlockchainWorker {
+func NewBlockchainWorker(
+	blockchainID uint64,
+	client core.BlockchainClient,
+	store BlockchainWorkerStore,
+	channelSigner core.ChannelSigner,
+	assetStore core.AssetStore,
+	logger log.Logger,
+	m MetricsExporter,
+) *BlockchainWorker {
 	return &BlockchainWorker{
-		blockchainID: blockchainID,
-		client:       client,
-		store:        store,
-		logger:       logger.WithName("bw").WithKV("blockchainID", blockchainID),
-		metrics:      m,
+		blockchainID:  blockchainID,
+		client:        client,
+		store:         store,
+		channelSigner: channelSigner,
+		assetStore:    assetStore,
+		logger:        logger.WithName("bw").WithKV("blockchainID", blockchainID),
+		metrics:       m,
 	}
 }
 
@@ -166,6 +178,9 @@ func (w *BlockchainWorker) processAction(_ context.Context, action database.Bloc
 	case database.ActionTypeCheckpoint:
 		txHash, err = w.client.Checkpoint(*state)
 
+	case database.ActionTypeChallenge:
+		txHash, err = w.submitChallenge(*state)
+
 	// case database.ActionTypeInitiateEscrowDeposit:
 	// 	txHash, err = w.processInitiateEscrow(state, w.client.InitiateEscrowDeposit)
 
@@ -196,6 +211,20 @@ func (w *BlockchainWorker) processAction(_ context.Context, action database.Bloc
 	logger.Info("action completed successfully", "txHash", txHash)
 
 	return true
+}
+
+// submitChallenge produces a node challenger signature for the given state and submits
+// challengeChannel(...) on the channel's home blockchain.
+func (w *BlockchainWorker) submitChallenge(state core.State) (string, error) {
+	packed, err := core.PackChallengeState(state, w.assetStore)
+	if err != nil {
+		return "", fmt.Errorf("failed to pack challenge state: %w", err)
+	}
+	challengerSig, err := w.channelSigner.Sign(packed)
+	if err != nil {
+		return "", fmt.Errorf("failed to sign challenge state: %w", err)
+	}
+	return w.client.Challenge(state, challengerSig, core.ChannelParticipantNode)
 }
 
 // func (w *BlockchainWorker) processInitiateEscrow(state *core.State, initiate func(core.ChannelDefinition, core.State) (string, error)) (string, error) {

--- a/nitronode/event_handlers/service.go
+++ b/nitronode/event_handlers/service.go
@@ -359,7 +359,19 @@ func (s *EventHandlerService) scheduleHomeChannelChallengeForEscrowDeposit(ctx c
 		return nil
 	}
 	if homeChannel.Status != core.ChannelStatusOpen {
-		logger.Warn("home channel not Open, skipping auto-challenge", "homeChannelId", *initiateState.HomeChannelID, "homeStatus", homeChannel.Status, "escrowChannelId", escrowChanID)
+		switch homeChannel.Status {
+		case core.ChannelStatusChallenged:
+			logger.Warn("home channel already Challenged, skipping auto-challenge", "homeChannelId", *initiateState.HomeChannelID, "escrowChannelId", escrowChanID)
+		case core.ChannelStatusClosed:
+			logger.Error("home channel Closed, defense window passed", "homeChannelId", *initiateState.HomeChannelID, "escrowChannelId", escrowChanID)
+		default:
+			logger.Warn("home channel not Open, skipping auto-challenge", "homeChannelId", *initiateState.HomeChannelID, "homeStatus", homeChannel.Status, "escrowChannelId", escrowChanID)
+		}
+		return nil
+	}
+
+	if initiateState.HomeLedger.BlockchainID == 0 {
+		logger.Error("INITIATE_ESCROW_DEPOSIT state has zero home BlockchainID, cannot defend home channel automatically", "homeChannelId", *initiateState.HomeChannelID, "escrowChannelId", escrowChanID)
 		return nil
 	}
 

--- a/nitronode/event_handlers/service.go
+++ b/nitronode/event_handlers/service.go
@@ -266,9 +266,13 @@ func (s *EventHandlerService) HandleEscrowDepositInitiated(ctx context.Context, 
 }
 
 // HandleEscrowDepositChallenged processes the EscrowDepositChallenged event emitted when an escrow
-// deposit is challenged on-chain. Similar to home channel challenges, it marks the channel as Challenged,
-// sets the expiration time, and automatically schedules a checkpoint with the latest signed state
-// to resolve the challenge.
+// deposit is challenged on-chain. It marks the channel as Challenged and sets the expiration time.
+// Resolution policy depends on whether the node holds a newer fully-signed state for this channel:
+//   - If a newer signed FINALIZE_ESCROW_DEPOSIT exists, finalize the escrow on the non-home chain.
+//   - Otherwise the user is withholding finalize: defend the node allocation on the home chain by
+//     scheduling challengeChannel(...) with the INITIATE_ESCROW_DEPOSIT state. Without this, the user
+//     can let the non-home challenge expire, recover escrow-chain funds, and still threaten the
+//     home-chain finalize path against the node's locked allocation.
 func (s *EventHandlerService) HandleEscrowDepositChallenged(ctx context.Context, tx core.ChannelHubEventHandlerStore, event *core.EscrowDepositChallengedEvent) error {
 	logger := log.FromContext(ctx)
 	chanID := event.ChannelID
@@ -304,17 +308,17 @@ func (s *EventHandlerService) HandleEscrowDepositChallenged(ctx context.Context,
 	if err != nil {
 		return err
 	}
-	if lastSignedState == nil {
-		logger.Warn("no state found for channel during EscrowDepositChallenged event", "channelId", chanID)
-	} else if lastSignedState.Version <= event.StateVersion {
-		logger.Warn("last signed state version is not greater than challenged state version", "channelId", chanID, "lastSignedStateVersion", lastSignedState.Version, "challengedStateVersion", event.StateVersion)
-	} else {
+	if lastSignedState != nil && lastSignedState.Version > event.StateVersion {
 		if lastSignedState.EscrowLedger == nil {
 			logger.Warn("last signed state has no escrow ledger during EscrowDepositChallenged event", "channelId", chanID)
 		} else {
 			if err := tx.ScheduleFinalizeEscrowDeposit(lastSignedState.ID, lastSignedState.EscrowLedger.BlockchainID); err != nil {
 				return err
 			}
+		}
+	} else {
+		if err := s.scheduleHomeChannelChallengeForEscrowDeposit(ctx, tx, chanID, event.StateVersion); err != nil {
+			return err
 		}
 	}
 
@@ -323,6 +327,51 @@ func (s *EventHandlerService) HandleEscrowDepositChallenged(ctx context.Context,
 	}
 
 	logger.Info("handled EscrowDepositChallenged event", "channelId", event.ChannelID, "stateVersion", event.StateVersion, "userWallet", channel.UserWallet)
+	return nil
+}
+
+// scheduleHomeChannelChallengeForEscrowDeposit queues a challengeChannel(...) submission on the home
+// chain using the INITIATE_ESCROW_DEPOSIT state referenced by the escrow event. This anchors the
+// home channel in DISPUTED so the user cannot later push a withheld FINALIZE state on home, and
+// starts the home-chain challenge timer the operator uses to recover the node allocation.
+func (s *EventHandlerService) scheduleHomeChannelChallengeForEscrowDeposit(ctx context.Context, tx core.ChannelHubEventHandlerStore, escrowChanID string, stateVersion uint64) error {
+	logger := log.FromContext(ctx)
+
+	initiateState, err := tx.GetStateByChannelIDAndVersion(escrowChanID, stateVersion)
+	if err != nil {
+		return err
+	}
+	if initiateState == nil {
+		logger.Error("INITIATE_ESCROW_DEPOSIT state missing locally, cannot defend home channel automatically", "escrowChannelId", escrowChanID, "stateVersion", stateVersion)
+		return nil
+	}
+	if initiateState.HomeChannelID == nil {
+		logger.Error("INITIATE_ESCROW_DEPOSIT state has no home channel ID, cannot defend home channel automatically", "escrowChannelId", escrowChanID, "stateVersion", stateVersion)
+		return nil
+	}
+
+	homeChannel, err := tx.GetChannelByID(*initiateState.HomeChannelID)
+	if err != nil {
+		return err
+	}
+	if homeChannel == nil {
+		logger.Error("home channel not found, cannot defend home channel automatically", "homeChannelId", *initiateState.HomeChannelID, "escrowChannelId", escrowChanID)
+		return nil
+	}
+	if homeChannel.Status != core.ChannelStatusOpen {
+		logger.Warn("home channel not Open, skipping auto-challenge", "homeChannelId", *initiateState.HomeChannelID, "homeStatus", homeChannel.Status, "escrowChannelId", escrowChanID)
+		return nil
+	}
+
+	if err := tx.ScheduleChallenge(initiateState.ID, initiateState.HomeLedger.BlockchainID); err != nil {
+		return err
+	}
+
+	logger.Warn("scheduled home-channel challenge to defend node allocation against withheld escrow finalize",
+		"homeChannelId", *initiateState.HomeChannelID,
+		"escrowChannelId", escrowChanID,
+		"stateVersion", stateVersion,
+	)
 	return nil
 }
 

--- a/nitronode/event_handlers/service_test.go
+++ b/nitronode/event_handlers/service_test.go
@@ -546,6 +546,238 @@ func TestHandleEscrowDepositChallenged_NoLocalState_NoSchedule(t *testing.T) {
 	mockStore.AssertNotCalled(t, "ScheduleFinalizeEscrowDeposit", mock.Anything, mock.Anything)
 }
 
+func TestHandleEscrowDepositChallenged_HomeChannelIDNil_SkipsChallenge(t *testing.T) {
+	mockStore := new(MockStore)
+	ctx := log.SetContextLogger(context.Background(), log.NewNoopLogger())
+	service := &EventHandlerService{}
+
+	escrowChannelID := "0xEscrowChannel123"
+	challengeExpiry := uint64(time.Now().Add(time.Hour).Unix())
+
+	escrowChannel := &core.Channel{
+		ChannelID:    escrowChannelID,
+		Asset:        "usdc",
+		Type:         core.ChannelTypeEscrow,
+		Status:       core.ChannelStatusOpen,
+		StateVersion: 1,
+	}
+
+	initiateState := &core.State{
+		ID:            "initiate-state-id",
+		Version:       3,
+		HomeChannelID: nil,
+		HomeLedger: core.Ledger{
+			BlockchainID: 1,
+		},
+	}
+
+	event := &core.EscrowDepositChallengedEvent{
+		ChannelID:       escrowChannelID,
+		StateVersion:    3,
+		ChallengeExpiry: challengeExpiry,
+	}
+
+	mockStore.On("GetChannelByID", escrowChannelID).Return(escrowChannel, nil)
+	mockStore.On("UpdateChannel", mock.Anything).Return(nil)
+	mockStore.On("GetLastStateByChannelID", escrowChannelID, true).Return(initiateState, nil)
+	mockStore.On("GetStateByChannelIDAndVersion", escrowChannelID, uint64(3)).Return(initiateState, nil)
+	mockStore.On("UpdateStateUserSigIfMissing", escrowChannelID, uint64(3), "").Return(nil)
+
+	err := service.HandleEscrowDepositChallenged(ctx, mockStore, event)
+
+	require.NoError(t, err)
+	mockStore.AssertExpectations(t)
+	mockStore.AssertNotCalled(t, "ScheduleChallenge", mock.Anything, mock.Anything)
+	mockStore.AssertNotCalled(t, "ScheduleFinalizeEscrowDeposit", mock.Anything, mock.Anything)
+}
+
+func TestHandleEscrowDepositChallenged_HomeChannelNotFound_SkipsChallenge(t *testing.T) {
+	mockStore := new(MockStore)
+	ctx := log.SetContextLogger(context.Background(), log.NewNoopLogger())
+	service := &EventHandlerService{}
+
+	escrowChannelID := "0xEscrowChannel123"
+	homeChannelID := "0xHomeChannel456"
+	challengeExpiry := uint64(time.Now().Add(time.Hour).Unix())
+
+	escrowChannel := &core.Channel{
+		ChannelID:    escrowChannelID,
+		Asset:        "usdc",
+		Type:         core.ChannelTypeEscrow,
+		Status:       core.ChannelStatusOpen,
+		StateVersion: 1,
+	}
+
+	initiateState := &core.State{
+		ID:            "initiate-state-id",
+		Version:       3,
+		HomeChannelID: &homeChannelID,
+		HomeLedger: core.Ledger{
+			BlockchainID: 1,
+		},
+	}
+
+	event := &core.EscrowDepositChallengedEvent{
+		ChannelID:       escrowChannelID,
+		StateVersion:    3,
+		ChallengeExpiry: challengeExpiry,
+	}
+
+	mockStore.On("GetChannelByID", escrowChannelID).Return(escrowChannel, nil)
+	mockStore.On("UpdateChannel", mock.Anything).Return(nil)
+	mockStore.On("GetLastStateByChannelID", escrowChannelID, true).Return(initiateState, nil)
+	mockStore.On("GetStateByChannelIDAndVersion", escrowChannelID, uint64(3)).Return(initiateState, nil)
+	mockStore.On("GetChannelByID", homeChannelID).Return((*core.Channel)(nil), nil)
+	mockStore.On("UpdateStateUserSigIfMissing", escrowChannelID, uint64(3), "").Return(nil)
+
+	err := service.HandleEscrowDepositChallenged(ctx, mockStore, event)
+
+	require.NoError(t, err)
+	mockStore.AssertExpectations(t)
+	mockStore.AssertNotCalled(t, "ScheduleChallenge", mock.Anything, mock.Anything)
+	mockStore.AssertNotCalled(t, "ScheduleFinalizeEscrowDeposit", mock.Anything, mock.Anything)
+}
+
+func TestHandleEscrowDepositChallenged_GetStateByVersionError_Propagates(t *testing.T) {
+	mockStore := new(MockStore)
+	ctx := log.SetContextLogger(context.Background(), log.NewNoopLogger())
+	service := &EventHandlerService{}
+
+	escrowChannelID := "0xEscrowChannel123"
+	challengeExpiry := uint64(time.Now().Add(time.Hour).Unix())
+
+	escrowChannel := &core.Channel{
+		ChannelID:    escrowChannelID,
+		Asset:        "usdc",
+		Type:         core.ChannelTypeEscrow,
+		Status:       core.ChannelStatusOpen,
+		StateVersion: 1,
+	}
+
+	event := &core.EscrowDepositChallengedEvent{
+		ChannelID:       escrowChannelID,
+		StateVersion:    3,
+		ChallengeExpiry: challengeExpiry,
+	}
+
+	dbErr := errors.New("db boom")
+
+	mockStore.On("GetChannelByID", escrowChannelID).Return(escrowChannel, nil)
+	mockStore.On("UpdateChannel", mock.Anything).Return(nil)
+	mockStore.On("GetLastStateByChannelID", escrowChannelID, true).Return(nil, nil)
+	mockStore.On("GetStateByChannelIDAndVersion", escrowChannelID, uint64(3)).Return(nil, dbErr)
+
+	err := service.HandleEscrowDepositChallenged(ctx, mockStore, event)
+
+	require.ErrorIs(t, err, dbErr)
+	mockStore.AssertExpectations(t)
+	mockStore.AssertNotCalled(t, "ScheduleChallenge", mock.Anything, mock.Anything)
+	mockStore.AssertNotCalled(t, "UpdateStateUserSigIfMissing", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestHandleEscrowDepositChallenged_GetHomeChannelError_Propagates(t *testing.T) {
+	mockStore := new(MockStore)
+	ctx := log.SetContextLogger(context.Background(), log.NewNoopLogger())
+	service := &EventHandlerService{}
+
+	escrowChannelID := "0xEscrowChannel123"
+	homeChannelID := "0xHomeChannel456"
+	challengeExpiry := uint64(time.Now().Add(time.Hour).Unix())
+
+	escrowChannel := &core.Channel{
+		ChannelID:    escrowChannelID,
+		Asset:        "usdc",
+		Type:         core.ChannelTypeEscrow,
+		Status:       core.ChannelStatusOpen,
+		StateVersion: 1,
+	}
+
+	initiateState := &core.State{
+		ID:            "initiate-state-id",
+		Version:       3,
+		HomeChannelID: &homeChannelID,
+		HomeLedger: core.Ledger{
+			BlockchainID: 1,
+		},
+	}
+
+	event := &core.EscrowDepositChallengedEvent{
+		ChannelID:       escrowChannelID,
+		StateVersion:    3,
+		ChallengeExpiry: challengeExpiry,
+	}
+
+	dbErr := errors.New("db boom")
+
+	mockStore.On("GetChannelByID", escrowChannelID).Return(escrowChannel, nil)
+	mockStore.On("UpdateChannel", mock.Anything).Return(nil)
+	mockStore.On("GetLastStateByChannelID", escrowChannelID, true).Return(initiateState, nil)
+	mockStore.On("GetStateByChannelIDAndVersion", escrowChannelID, uint64(3)).Return(initiateState, nil)
+	mockStore.On("GetChannelByID", homeChannelID).Return((*core.Channel)(nil), dbErr)
+
+	err := service.HandleEscrowDepositChallenged(ctx, mockStore, event)
+
+	require.ErrorIs(t, err, dbErr)
+	mockStore.AssertExpectations(t)
+	mockStore.AssertNotCalled(t, "ScheduleChallenge", mock.Anything, mock.Anything)
+	mockStore.AssertNotCalled(t, "UpdateStateUserSigIfMissing", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestHandleEscrowDepositChallenged_HomeBlockchainIDZero_SkipsChallenge(t *testing.T) {
+	mockStore := new(MockStore)
+	ctx := log.SetContextLogger(context.Background(), log.NewNoopLogger())
+	service := &EventHandlerService{}
+
+	escrowChannelID := "0xEscrowChannel123"
+	homeChannelID := "0xHomeChannel456"
+	challengeExpiry := uint64(time.Now().Add(time.Hour).Unix())
+
+	escrowChannel := &core.Channel{
+		ChannelID:    escrowChannelID,
+		Asset:        "usdc",
+		Type:         core.ChannelTypeEscrow,
+		Status:       core.ChannelStatusOpen,
+		StateVersion: 1,
+	}
+
+	homeChannel := &core.Channel{
+		ChannelID:    homeChannelID,
+		Asset:        "usdc",
+		Type:         core.ChannelTypeHome,
+		Status:       core.ChannelStatusOpen,
+		BlockchainID: 1,
+	}
+
+	initiateState := &core.State{
+		ID:            "initiate-state-id",
+		Version:       3,
+		HomeChannelID: &homeChannelID,
+		HomeLedger: core.Ledger{
+			BlockchainID: 0,
+		},
+	}
+
+	event := &core.EscrowDepositChallengedEvent{
+		ChannelID:       escrowChannelID,
+		StateVersion:    3,
+		ChallengeExpiry: challengeExpiry,
+	}
+
+	mockStore.On("GetChannelByID", escrowChannelID).Return(escrowChannel, nil)
+	mockStore.On("UpdateChannel", mock.Anything).Return(nil)
+	mockStore.On("GetLastStateByChannelID", escrowChannelID, true).Return(initiateState, nil)
+	mockStore.On("GetStateByChannelIDAndVersion", escrowChannelID, uint64(3)).Return(initiateState, nil)
+	mockStore.On("GetChannelByID", homeChannelID).Return(homeChannel, nil)
+	mockStore.On("UpdateStateUserSigIfMissing", escrowChannelID, uint64(3), "").Return(nil)
+
+	err := service.HandleEscrowDepositChallenged(ctx, mockStore, event)
+
+	require.NoError(t, err)
+	mockStore.AssertExpectations(t)
+	mockStore.AssertNotCalled(t, "ScheduleChallenge", mock.Anything, mock.Anything)
+	mockStore.AssertNotCalled(t, "ScheduleFinalizeEscrowDeposit", mock.Anything, mock.Anything)
+}
+
 func TestHandleEscrowDepositFinalized_Success(t *testing.T) {
 	// Setup
 	mockStore := new(MockStore)

--- a/nitronode/event_handlers/service_test.go
+++ b/nitronode/event_handlers/service_test.go
@@ -389,6 +389,163 @@ func TestHandleEscrowDepositChallenged_Success(t *testing.T) {
 	mockStore.AssertExpectations(t)
 }
 
+func TestHandleEscrowDepositChallenged_NoFinalize_SchedulesHomeChallenge(t *testing.T) {
+	mockStore := new(MockStore)
+	ctx := log.SetContextLogger(context.Background(), log.NewNoopLogger())
+	service := &EventHandlerService{}
+
+	escrowChannelID := "0xEscrowChannel123"
+	homeChannelID := "0xHomeChannel456"
+	userWallet := "0x1234567890123456789012345678901234567890"
+	challengeExpiry := uint64(time.Now().Add(time.Hour).Unix())
+
+	escrowChannel := &core.Channel{
+		ChannelID:    escrowChannelID,
+		UserWallet:   userWallet,
+		Asset:        "usdc",
+		Type:         core.ChannelTypeEscrow,
+		Status:       core.ChannelStatusOpen,
+		StateVersion: 1,
+	}
+
+	homeChannel := &core.Channel{
+		ChannelID:    homeChannelID,
+		UserWallet:   userWallet,
+		Asset:        "usdc",
+		Type:         core.ChannelTypeHome,
+		Status:       core.ChannelStatusOpen,
+		BlockchainID: 1,
+	}
+
+	initiateState := &core.State{
+		ID:            "initiate-state-id",
+		Version:       3,
+		HomeChannelID: &homeChannelID,
+		HomeLedger: core.Ledger{
+			BlockchainID: 1,
+		},
+		EscrowLedger: &core.Ledger{
+			BlockchainID: 2,
+		},
+	}
+
+	event := &core.EscrowDepositChallengedEvent{
+		ChannelID:       escrowChannelID,
+		StateVersion:    3,
+		ChallengeExpiry: challengeExpiry,
+	}
+
+	mockStore.On("GetChannelByID", escrowChannelID).Return(escrowChannel, nil)
+	mockStore.On("UpdateChannel", mock.MatchedBy(func(ch core.Channel) bool {
+		return ch.ChannelID == escrowChannelID &&
+			ch.Status == core.ChannelStatusChallenged &&
+			ch.StateVersion == 3
+	})).Return(nil)
+	// No newer signed FINALIZE state available locally — node only has the INITIATE state.
+	mockStore.On("GetLastStateByChannelID", escrowChannelID, true).Return(initiateState, nil)
+	mockStore.On("GetStateByChannelIDAndVersion", escrowChannelID, uint64(3)).Return(initiateState, nil)
+	mockStore.On("GetChannelByID", homeChannelID).Return(homeChannel, nil)
+	mockStore.On("ScheduleChallenge", "initiate-state-id", uint64(1)).Return(nil)
+	mockStore.On("UpdateStateUserSigIfMissing", escrowChannelID, uint64(3), "").Return(nil)
+
+	err := service.HandleEscrowDepositChallenged(ctx, mockStore, event)
+
+	require.NoError(t, err)
+	mockStore.AssertExpectations(t)
+	mockStore.AssertNotCalled(t, "ScheduleFinalizeEscrowDeposit", mock.Anything, mock.Anything)
+}
+
+func TestHandleEscrowDepositChallenged_NoFinalize_HomeChannelNotOpen_SkipsChallenge(t *testing.T) {
+	mockStore := new(MockStore)
+	ctx := log.SetContextLogger(context.Background(), log.NewNoopLogger())
+	service := &EventHandlerService{}
+
+	escrowChannelID := "0xEscrowChannel123"
+	homeChannelID := "0xHomeChannel456"
+	challengeExpiry := uint64(time.Now().Add(time.Hour).Unix())
+
+	escrowChannel := &core.Channel{
+		ChannelID:    escrowChannelID,
+		Asset:        "usdc",
+		Type:         core.ChannelTypeEscrow,
+		Status:       core.ChannelStatusOpen,
+		StateVersion: 1,
+	}
+
+	homeChannel := &core.Channel{
+		ChannelID:    homeChannelID,
+		Asset:        "usdc",
+		Type:         core.ChannelTypeHome,
+		Status:       core.ChannelStatusChallenged,
+		BlockchainID: 1,
+	}
+
+	initiateState := &core.State{
+		ID:            "initiate-state-id",
+		Version:       3,
+		HomeChannelID: &homeChannelID,
+		HomeLedger: core.Ledger{
+			BlockchainID: 1,
+		},
+	}
+
+	event := &core.EscrowDepositChallengedEvent{
+		ChannelID:       escrowChannelID,
+		StateVersion:    3,
+		ChallengeExpiry: challengeExpiry,
+	}
+
+	mockStore.On("GetChannelByID", escrowChannelID).Return(escrowChannel, nil)
+	mockStore.On("UpdateChannel", mock.Anything).Return(nil)
+	mockStore.On("GetLastStateByChannelID", escrowChannelID, true).Return(initiateState, nil)
+	mockStore.On("GetStateByChannelIDAndVersion", escrowChannelID, uint64(3)).Return(initiateState, nil)
+	mockStore.On("GetChannelByID", homeChannelID).Return(homeChannel, nil)
+	mockStore.On("UpdateStateUserSigIfMissing", escrowChannelID, uint64(3), "").Return(nil)
+
+	err := service.HandleEscrowDepositChallenged(ctx, mockStore, event)
+
+	require.NoError(t, err)
+	mockStore.AssertExpectations(t)
+	mockStore.AssertNotCalled(t, "ScheduleChallenge", mock.Anything, mock.Anything)
+	mockStore.AssertNotCalled(t, "ScheduleFinalizeEscrowDeposit", mock.Anything, mock.Anything)
+}
+
+func TestHandleEscrowDepositChallenged_NoLocalState_NoSchedule(t *testing.T) {
+	mockStore := new(MockStore)
+	ctx := log.SetContextLogger(context.Background(), log.NewNoopLogger())
+	service := &EventHandlerService{}
+
+	escrowChannelID := "0xEscrowChannel123"
+	challengeExpiry := uint64(time.Now().Add(time.Hour).Unix())
+
+	escrowChannel := &core.Channel{
+		ChannelID:    escrowChannelID,
+		Asset:        "usdc",
+		Type:         core.ChannelTypeEscrow,
+		Status:       core.ChannelStatusOpen,
+		StateVersion: 1,
+	}
+
+	event := &core.EscrowDepositChallengedEvent{
+		ChannelID:       escrowChannelID,
+		StateVersion:    3,
+		ChallengeExpiry: challengeExpiry,
+	}
+
+	mockStore.On("GetChannelByID", escrowChannelID).Return(escrowChannel, nil)
+	mockStore.On("UpdateChannel", mock.Anything).Return(nil)
+	mockStore.On("GetLastStateByChannelID", escrowChannelID, true).Return(nil, nil)
+	mockStore.On("GetStateByChannelIDAndVersion", escrowChannelID, uint64(3)).Return(nil, nil)
+	mockStore.On("UpdateStateUserSigIfMissing", escrowChannelID, uint64(3), "").Return(nil)
+
+	err := service.HandleEscrowDepositChallenged(ctx, mockStore, event)
+
+	require.NoError(t, err)
+	mockStore.AssertExpectations(t)
+	mockStore.AssertNotCalled(t, "ScheduleChallenge", mock.Anything, mock.Anything)
+	mockStore.AssertNotCalled(t, "ScheduleFinalizeEscrowDeposit", mock.Anything, mock.Anything)
+}
+
 func TestHandleEscrowDepositFinalized_Success(t *testing.T) {
 	// Setup
 	mockStore := new(MockStore)

--- a/nitronode/event_handlers/testing.go
+++ b/nitronode/event_handlers/testing.go
@@ -51,6 +51,12 @@ func (m *MockStore) ScheduleCheckpoint(stateID string, chainID uint64) error {
 	return args.Error(0)
 }
 
+// ScheduleChallenge mocks scheduling a challenge operation
+func (m *MockStore) ScheduleChallenge(stateID string, chainID uint64) error {
+	args := m.Called(stateID, chainID)
+	return args.Error(0)
+}
+
 // ScheduleInitiateEscrowDeposit mocks scheduling an escrow deposit checkpoint
 func (m *MockStore) ScheduleInitiateEscrowDeposit(stateID string, chainID uint64) error {
 	args := m.Called(stateID, chainID)

--- a/nitronode/main.go
+++ b/nitronode/main.go
@@ -79,6 +79,11 @@ func main() {
 
 	eventHandlerService := event_handlers.NewEventHandlerService()
 
+	nodeChannelSigner, err := core.NewChannelDefaultSigner(bb.StateSigner)
+	if err != nil {
+		logger.Fatal("failed to build node channel signer", "error", err)
+	}
+
 	for _, b := range blockchains {
 		rpcURL, ok := bb.BlockchainRPCs[b.ID]
 		if !ok {
@@ -126,7 +131,7 @@ func main() {
 				}
 			})
 
-			worker := NewBlockchainWorker(b.ID, blockchainClient, bb.DbStore, logger, bb.RuntimeMetrics)
+			worker := NewBlockchainWorker(b.ID, blockchainClient, bb.DbStore, nodeChannelSigner, bb.MemoryStore, logger, bb.RuntimeMetrics)
 			worker.Start(blockchainCtx, func(err error) {
 				if err != nil {
 					logger.Fatal("blockchain worker stopped", "error", err, "blockchainID", b.ID)

--- a/nitronode/store/database/blockchain_action.go
+++ b/nitronode/store/database/blockchain_action.go
@@ -12,6 +12,7 @@ type BlockchainActionType uint8
 
 const (
 	ActionTypeCheckpoint BlockchainActionType = 1
+	ActionTypeChallenge  BlockchainActionType = 2
 
 	ActionTypeInitiateEscrowDeposit BlockchainActionType = 10
 	ActionTypeFinalizeEscrowDeposit BlockchainActionType = 11
@@ -24,6 +25,8 @@ func (t BlockchainActionType) String() string {
 	switch t {
 	case ActionTypeCheckpoint:
 		return "checkpoint"
+	case ActionTypeChallenge:
+		return "challenge"
 	case ActionTypeInitiateEscrowDeposit:
 		return "initiate_escrow_deposit"
 	case ActionTypeFinalizeEscrowDeposit:
@@ -66,6 +69,13 @@ func (BlockchainAction) TableName() string {
 // ScheduleCheckpoint queues a blockchain action to checkpoint a state on home blockchain.
 func (s *DBStore) ScheduleCheckpoint(stateID string, blockchainID uint64) error {
 	return s.scheduleStateEnforcement(stateID, blockchainID, ActionTypeCheckpoint)
+}
+
+// ScheduleChallenge queues a blockchain action to challenge a channel on its home blockchain
+// using the provided state. The worker submits the state via challengeChannel(...) with a
+// node-produced challenger signature.
+func (s *DBStore) ScheduleChallenge(stateID string, blockchainID uint64) error {
+	return s.scheduleStateEnforcement(stateID, blockchainID, ActionTypeChallenge)
 }
 
 // ScheduleInitiateEscrowDeposit queues a blockchain action to initiate escrow deposit on home blockchain.

--- a/nitronode/store/database/interface.go
+++ b/nitronode/store/database/interface.go
@@ -102,6 +102,10 @@ type DatabaseStore interface {
 	// This queues the state to be submitted on-chain to update the channel's on-chain state.
 	ScheduleCheckpoint(stateID string, chainID uint64) error
 
+	// ScheduleChallenge schedules a challengeChannel(...) submission on the channel's home
+	// blockchain using the provided state and a node-produced challenger signature.
+	ScheduleChallenge(stateID string, chainID uint64) error
+
 	// ScheduleFinalizeEscrowDeposit schedules a checkpoint for an escrow deposit operation.
 	// This queues the state to be submitted on-chain to finalize an escrow deposit.
 	ScheduleFinalizeEscrowDeposit(stateID string, chainID uint64) error

--- a/pkg/blockchain/evm/channel_hub_reactor.go
+++ b/pkg/blockchain/evm/channel_hub_reactor.go
@@ -49,6 +49,10 @@ type ChannelHubReactorStore interface {
 	// This queues the state to be submitted on-chain to update the channel's on-chain state.
 	ScheduleCheckpoint(stateID string, chainID uint64) error
 
+	// ScheduleChallenge schedules a challengeChannel(...) submission on the channel's home
+	// blockchain using the provided state and a node-produced challenger signature.
+	ScheduleChallenge(stateID string, chainID uint64) error
+
 	// ScheduleInitiateEscrowDeposit schedules an initiate for an escrow deposit operation.
 	// This queues the state to be submitted on-chain to finalize an escrow deposit.
 	ScheduleInitiateEscrowDeposit(stateID string, chainID uint64) error

--- a/pkg/blockchain/evm/channel_hub_reactor_test.go
+++ b/pkg/blockchain/evm/channel_hub_reactor_test.go
@@ -55,6 +55,11 @@ func (m *mockChannelHubStore) ScheduleCheckpoint(stateID string, chainID uint64)
 	return args.Error(0)
 }
 
+func (m *mockChannelHubStore) ScheduleChallenge(stateID string, chainID uint64) error {
+	args := m.Called(stateID, chainID)
+	return args.Error(0)
+}
+
 func (m *mockChannelHubStore) ScheduleInitiateEscrowDeposit(stateID string, chainID uint64) error {
 	args := m.Called(stateID, chainID)
 	return args.Error(0)

--- a/pkg/core/interface.go
+++ b/pkg/core/interface.go
@@ -122,6 +122,10 @@ type ChannelHubEventHandlerStore interface {
 	// This queues the state to be submitted on-chain to update the channel's on-chain state.
 	ScheduleCheckpoint(stateID string, chainID uint64) error
 
+	// ScheduleChallenge schedules a challengeChannel(...) submission on the channel's home
+	// blockchain using the provided state and a node-produced challenger signature.
+	ScheduleChallenge(stateID string, chainID uint64) error
+
 	// ScheduleInitiateEscrowDeposit schedules an initiate for an escrow deposit operation.
 	// This queues the state to be submitted on-chain to finalize an escrow deposit.
 	ScheduleInitiateEscrowDeposit(stateID string, chainID uint64) error


### PR DESCRIPTION
## Summary
- When `EscrowDepositChallenged` fires without a newer fully-signed `FINALIZE_ESCROW_DEPOSIT` available locally, the node now schedules a `challengeChannel(...)` on the home blockchain using the `INITIATE_ESCROW_DEPOSIT` state and a node-produced challenger signature.
- Closes the cross-chain attack where a user lets the non-home escrow challenge expire, recovers escrow-chain funds, and then enforces FINALIZE on home against the node's locked allocation.
- Introduces generic `ActionTypeChallenge = 2` + `ScheduleChallenge(stateID, chainID)`. `BlockchainWorker` packs via `core.PackChallengeState`, signs with the node `ChannelSigner`, and submits via `BlockchainClient.Challenge(state, sig, ChannelParticipantNode)`.

## Behavior change in `HandleEscrowDepositChallenged`
- Branch A (newer signed FINALIZE exists) — unchanged, still schedules `FinalizeEscrowDeposit` on the escrow chain.
- Branch B (no newer FINALIZE, or last signed state is the INITIATE itself) — fetches the INITIATE state via `GetStateByChannelIDAndVersion`, resolves its home channel, and schedules `Challenge` on the home blockchain. Skips with a warning if the INITIATE state is missing locally, has no `HomeChannelID`, or the home channel is not `Open`.
- After the home challenge timer expires, operator runs `closeChannel(...)` manually to recover the node allocation (existing manual recovery path).

## Test plan
- [x] `go test ./nitronode/event_handlers/... -run TestHandleEscrowDepositChallenged -count=1`
- [x] `go test ./nitronode/... ./pkg/... -count=1` (full suite green)
- [x] `go build ./...`
- [x] `go vet ./...`
- [ ] Manual integration: user withholds FINALIZE state, observe home channel transitions to DISPUTED on-chain after escrow challenge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validator registration event monitoring with recovery support on reconnection.
  * Implemented pagination (default/max page size 10) for key state query endpoints.
  * Added WebSocket per-connection rate limiting and maximum message size enforcement.

* **Documentation**
  * Clarified signature domain compatibility between on-chain and off-chain validators.
  * Updated protocol enforcement rules for channel state submission requirements.
  * Added validator registration monitoring and ERC-20 approval security guidance.

* **Configuration**
  * Added configurable WebSocket DoS hardening environment variables.
  * Made database SSL mode configurable (default: `require`).

* **Bug Fixes & Improvements**
  * Enhanced escrow operation locking and user signature persistence.
  * Enforced per-user session key caps for improved resource management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/layer-3/nitrolite/pull/753)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->