### PR TITLE
MF-L06: fix(contracts): clear stale challengeExpireAt on cooperative escrow finalization

### DIFF
--- a/contracts/src/ChannelHub.sol
+++ b/contracts/src/ChannelHub.sol
@@ -1218,7 +1218,7 @@ contract ChannelHub is ReentrancyGuard {
             meta.unlockAt = effects.newUnlockAt;
         }
 
-        if (effects.newChallengeExpiry > 0) {
+        if (meta.challengeExpireAt != effects.newChallengeExpiry) {
             meta.challengeExpireAt = effects.newChallengeExpiry;
         }
 
@@ -1273,7 +1273,7 @@ contract ChannelHub is ReentrancyGuard {
             _initEscrowWithdrawalMetadata(escrowId, channelId, candidate, user, approvedSignatureValidators);
         }
 
-        if (effects.newChallengeExpiry > 0) {
+        if (meta.challengeExpireAt != effects.newChallengeExpiry) {
             meta.challengeExpireAt = effects.newChallengeExpiry;
         }
 

--- a/contracts/test/ChannelHub_units/ChannelHub_finalizeEscrowDeposit.t.sol
+++ b/contracts/test/ChannelHub_units/ChannelHub_finalizeEscrowDeposit.t.sol
@@ -6,7 +6,15 @@ import {TestUtils} from "../TestUtils.sol";
 import {Utils} from "../../src/Utils.sol";
 
 import {ChannelHub} from "../../src/ChannelHub.sol";
-import {State, ChannelDefinition, StateIntent, Ledger} from "../../src/interfaces/Types.sol";
+import {EscrowDepositEngine} from "../../src/EscrowDepositEngine.sol";
+import {
+    State,
+    ChannelDefinition,
+    StateIntent,
+    Ledger,
+    EscrowStatus,
+    ParticipantIndex
+} from "../../src/interfaces/Types.sol";
 
 // forge-lint: disable-next-item(unsafe-typecast)
 contract ChannelHubTest_finalizeEscrowDeposit is ChannelHubTest_Base {
@@ -62,6 +70,88 @@ contract ChannelHubTest_finalizeEscrowDeposit is ChannelHubTest_Base {
 
         vm.expectRevert(ChannelHub.IncorrectStateIntent.selector);
         cHub.finalizeEscrowDeposit(channelId, bytes32(0), state);
+    }
+
+    // ========== Challenge Expiry Clearing ==========
+
+    // Regression test: cooperative finalization from DISPUTED must zero out challengeExpireAt.
+    // Before the fix, _applyEscrowDepositEffects used `if (effects.newChallengeExpiry > 0)` which
+    // skipped the write when the finalize effects left newChallengeExpiry at 0, leaving a stale
+    // non-zero value observable via getEscrowDepositData().
+    function test_cooperativeFinalize_fromDISPUTED_clearsChallengeExpiry() public {
+        ChannelDefinition memory altDef = ChannelDefinition({
+            challengeDuration: CHALLENGE_DURATION,
+            user: alice,
+            node: node,
+            nonce: NONCE + 1,
+            approvedSignatureValidators: 0,
+            metadata: bytes32(0)
+        });
+        bytes32 altChannelId = Utils.getChannelId(altDef, CHANNEL_HUB_VERSION);
+
+        // Current chain acts as non-home chain; NON_HOME_CHAIN_ID is the home chain.
+        State memory escrowInitState = State({
+            version: 1,
+            intent: StateIntent.INITIATE_ESCROW_DEPOSIT,
+            metadata: bytes32(0),
+            homeLedger: Ledger({
+                chainId: NON_HOME_CHAIN_ID,
+                token: NON_HOME_TOKEN,
+                decimals: 18,
+                userAllocation: DEPOSIT_AMOUNT,
+                userNetFlow: int256(DEPOSIT_AMOUNT),
+                nodeAllocation: ESCROW_AMOUNT,
+                nodeNetFlow: int256(ESCROW_AMOUNT)
+            }),
+            nonHomeLedger: Ledger({
+                chainId: uint64(block.chainid),
+                token: address(token),
+                decimals: 18,
+                userAllocation: ESCROW_AMOUNT,
+                userNetFlow: int256(ESCROW_AMOUNT),
+                nodeAllocation: 0,
+                nodeNetFlow: 0
+            }),
+            userSig: "",
+            nodeSig: ""
+        });
+        escrowInitState = mutualSignStateBothWithEcdsaValidator(escrowInitState, altChannelId, ALICE_PK);
+
+        vm.prank(alice);
+        cHub.initiateEscrowDeposit(altDef, escrowInitState);
+        bytes32 escrowId = Utils.getEscrowId(altChannelId, escrowInitState.version);
+
+        // Challenge → status becomes DISPUTED, challengeExpireAt set to a future timestamp.
+        bytes memory challengerSig = signChallengeEip191WithEcdsaValidator(altChannelId, escrowInitState, ALICE_PK);
+        cHub.challengeEscrowDeposit(escrowId, challengerSig, ParticipantIndex.USER);
+
+        (, EscrowStatus disputedStatus,, uint64 challengeExpiryAfterChallenge,,) = cHub.getEscrowDepositData(escrowId);
+        assertEq(uint8(disputedStatus), uint8(EscrowStatus.DISPUTED), "Should be DISPUTED after challenge");
+        assertGt(challengeExpiryAfterChallenge, 0, "challengeExpireAt should be non-zero after challenge");
+
+        // Cooperatively finalize before the challenge period expires.
+        // Home userNetFlow must be unchanged (delta == 0), home userAllocation grows by ESCROW_AMOUNT.
+        State memory finalizeState = TestUtils.nextState(
+            escrowInitState,
+            StateIntent.FINALIZE_ESCROW_DEPOSIT,
+            [DEPOSIT_AMOUNT + ESCROW_AMOUNT, uint256(0)],
+            [int256(DEPOSIT_AMOUNT), int256(ESCROW_AMOUNT)],
+            uint64(block.chainid),
+            address(token),
+            [uint256(0), uint256(0)],
+            [int256(ESCROW_AMOUNT), -int256(ESCROW_AMOUNT)]
+        );
+        finalizeState = mutualSignStateBothWithEcdsaValidator(finalizeState, altChannelId, ALICE_PK);
+        cHub.finalizeEscrowDeposit(altChannelId, escrowId, finalizeState);
+
+        // Assert: status FINALIZED and challengeExpireAt cleared to zero.
+        (, EscrowStatus finalStatus,, uint64 finalChallengeExpiry,,) = cHub.getEscrowDepositData(escrowId);
+        assertEq(
+            uint8(finalStatus), uint8(EscrowStatus.FINALIZED), "Should be FINALIZED after cooperative finalization"
+        );
+        assertEq(
+            finalChallengeExpiry, 0, "challengeExpireAt must be cleared after cooperative finalization from DISPUTED"
+        );
     }
 
     function test_revert_nonHomeChain_ifWrongIntent() public {

--- a/contracts/test/ChannelHub_units/ChannelHub_finalizeEscrowWithdrawal.t.sol
+++ b/contracts/test/ChannelHub_units/ChannelHub_finalizeEscrowWithdrawal.t.sol
@@ -6,7 +6,15 @@ import {TestUtils} from "../TestUtils.sol";
 import {Utils} from "../../src/Utils.sol";
 
 import {ChannelHub} from "../../src/ChannelHub.sol";
-import {State, ChannelDefinition, StateIntent, Ledger} from "../../src/interfaces/Types.sol";
+import {EscrowWithdrawalEngine} from "../../src/EscrowWithdrawalEngine.sol";
+import {
+    State,
+    ChannelDefinition,
+    StateIntent,
+    Ledger,
+    EscrowStatus,
+    ParticipantIndex
+} from "../../src/interfaces/Types.sol";
 
 // forge-lint: disable-next-item(unsafe-typecast)
 contract ChannelHubTest_finalizeEscrowWithdrawal is ChannelHubTest_Base {
@@ -62,6 +70,88 @@ contract ChannelHubTest_finalizeEscrowWithdrawal is ChannelHubTest_Base {
 
         vm.expectRevert(ChannelHub.IncorrectStateIntent.selector);
         cHub.finalizeEscrowWithdrawal(channelId, bytes32(0), state);
+    }
+
+    // ========== Challenge Expiry Clearing ==========
+
+    // Regression test: cooperative finalization from DISPUTED must zero out challengeExpireAt.
+    // Before the fix, _applyEscrowWithdrawalEffects used `if (effects.newChallengeExpiry > 0)` which
+    // skipped the write when the finalize effects left newChallengeExpiry at 0, leaving a stale
+    // non-zero value observable via getEscrowWithdrawalData().
+    function test_cooperativeFinalize_fromDISPUTED_clearsChallengeExpiry() public {
+        ChannelDefinition memory altDef = ChannelDefinition({
+            challengeDuration: CHALLENGE_DURATION,
+            user: alice,
+            node: node,
+            nonce: NONCE + 1,
+            approvedSignatureValidators: 0,
+            metadata: bytes32(0)
+        });
+        bytes32 altChannelId = Utils.getChannelId(altDef, CHANNEL_HUB_VERSION);
+
+        // Current chain acts as non-home chain; NON_HOME_CHAIN_ID is the home chain.
+        // Node locks WITHDRAWAL_AMOUNT from its vault on this (non-home) chain.
+        State memory escrowInitState = State({
+            version: 1,
+            intent: StateIntent.INITIATE_ESCROW_WITHDRAWAL,
+            metadata: bytes32(0),
+            homeLedger: Ledger({
+                chainId: NON_HOME_CHAIN_ID,
+                token: NON_HOME_TOKEN,
+                decimals: 18,
+                userAllocation: WITHDRAWAL_AMOUNT,
+                userNetFlow: int256(WITHDRAWAL_AMOUNT),
+                nodeAllocation: 0,
+                nodeNetFlow: 0
+            }),
+            nonHomeLedger: Ledger({
+                chainId: uint64(block.chainid),
+                token: address(token),
+                decimals: 18,
+                userAllocation: 0,
+                userNetFlow: 0,
+                nodeAllocation: WITHDRAWAL_AMOUNT,
+                nodeNetFlow: int256(WITHDRAWAL_AMOUNT)
+            }),
+            userSig: "",
+            nodeSig: ""
+        });
+        escrowInitState = mutualSignStateBothWithEcdsaValidator(escrowInitState, altChannelId, ALICE_PK);
+
+        cHub.initiateEscrowWithdrawal(altDef, escrowInitState);
+        bytes32 escrowId = Utils.getEscrowId(altChannelId, escrowInitState.version);
+
+        // Challenge → status becomes DISPUTED, challengeExpireAt set to a future timestamp.
+        bytes memory challengerSig = signChallengeEip191WithEcdsaValidator(altChannelId, escrowInitState, ALICE_PK);
+        cHub.challengeEscrowWithdrawal(escrowId, challengerSig, ParticipantIndex.USER);
+
+        (, EscrowStatus disputedStatus, uint64 challengeExpiryAfterChallenge,,) = cHub.getEscrowWithdrawalData(escrowId);
+        assertEq(uint8(disputedStatus), uint8(EscrowStatus.DISPUTED), "Should be DISPUTED after challenge");
+        assertGt(challengeExpiryAfterChallenge, 0, "challengeExpireAt should be non-zero after challenge");
+
+        // Cooperatively finalize before the challenge period expires.
+        // User allocation on home decreases by WITHDRAWAL_AMOUNT; node releases locked funds to user.
+        State memory finalizeState = TestUtils.nextState(
+            escrowInitState,
+            StateIntent.FINALIZE_ESCROW_WITHDRAWAL,
+            [uint256(0), uint256(0)],
+            [int256(WITHDRAWAL_AMOUNT), -int256(WITHDRAWAL_AMOUNT)],
+            uint64(block.chainid),
+            address(token),
+            [uint256(0), uint256(0)],
+            [-int256(WITHDRAWAL_AMOUNT), int256(WITHDRAWAL_AMOUNT)]
+        );
+        finalizeState = mutualSignStateBothWithEcdsaValidator(finalizeState, altChannelId, ALICE_PK);
+        cHub.finalizeEscrowWithdrawal(altChannelId, escrowId, finalizeState);
+
+        // Assert: status FINALIZED and challengeExpireAt cleared to zero.
+        (, EscrowStatus finalStatus, uint64 finalChallengeExpiry,,) = cHub.getEscrowWithdrawalData(escrowId);
+        assertEq(
+            uint8(finalStatus), uint8(EscrowStatus.FINALIZED), "Should be FINALIZED after cooperative finalization"
+        );
+        assertEq(
+            finalChallengeExpiry, 0, "challengeExpireAt must be cleared after cooperative finalization from DISPUTED"
+        );
     }
 
     function test_revert_nonHomeChain_ifWrongIntent() public {


### PR DESCRIPTION
## Problem

`_applyEscrowDepositEffects()` and `_applyEscrowWithdrawalEffects()` only updated `meta.challengeExpireAt` when `effects.newChallengeExpiry > 0`. Since cooperative finalization leaves `newChallengeExpiry` at its zero default, this condition was never true — meaning a prior non-zero `challengeExpireAt` set during a challenge was silently left in storage after finalization.

The result: a cooperatively finalized escrow (transitioning from `DISPUTED` to `FINALIZED`) would still report a non-zero `challengeExpiry` through `getEscrowDepositData()` / `getEscrowWithdrawalData()`, misleading indexers, SDKs, and UIs.

The unilateral timeout paths cleared `challengeExpireAt` explicitly, so only the cooperative path from `DISPUTED` was affected.

## Fix

Replace the `> 0` guard with a `!=` comparison in both apply helpers, mirroring the pattern already used in the channel apply path:

```solidity
// before
if (effects.newChallengeExpiry > 0) {
    meta.challengeExpireAt = effects.newChallengeExpiry;
}

// after
if (meta.challengeExpireAt != effects.newChallengeExpiry) {
    meta.challengeExpireAt = effects.newChallengeExpiry;
}
```

## Tests

Regression tests added to:
- `test/ChannelHub_units/ChannelHub_finalizeEscrowDeposit.t.sol` — `test_cooperativeFinalize_fromDISPUTED_clearsChallengeExpiry`
- `test/ChannelHub_units/ChannelHub_finalizeEscrowWithdrawal.t.sol` — `test_cooperativeFinalize_fromDISPUTED_clearsChallengeExpiry`

Each test: initiates an escrow → challenges it (asserting non-zero `challengeExpireAt`) → cooperatively finalizes before challenge expires → asserts `challengeExpireAt == 0` and status `FINALIZED`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed escrow challenge expiry handling to ensure the stored expiry value is properly updated in all scenarios, including when resetting to zero.

* **Tests**
  * Added regression tests verifying cooperative escrow finalization correctly clears challenge expiry values after disputes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/layer-3/nitrolite/pull/754)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->