### PR TITLE
MF-I08: docs: document ChannelClosed event orientation ambiguity during abandoned migration

### DIFF
--- a/contracts/SECURITY.md
+++ b/contracts/SECURITY.md
@@ -171,6 +171,25 @@ no funds can be permanently locked if it does.
 
 ---
 
+### ChannelClosed event orientation during abandoned migration
+
+`initiateMigration()` on the new home chain swaps `homeLedger` ↔ `nonHomeLedger` before storing the state, so that `homeLedger` always represents the chain where execution happens. A consequence of this swap is that `meta.lastState` on the new home chain is stored in opposite orientation from what both parties signed.
+
+If a migration is initiated but never finalized and both channel copies are subsequently challenged and closed after timeout, `ChannelClosed` can be emitted on **both chains** for the same `channelId` and state version, but with **opposite `homeLedger`/`nonHomeLedger` orientation** in `finalState`:
+
+- **Old home chain** (`OPERATING`/`DISPUTED`): `finalState.homeLedger` describes the old home chain (original orientation as signed).
+- **New home chain** (`MIGRATING_IN`/`DISPUTED`): `finalState.homeLedger` describes the new home chain (swapped orientation as stored).
+
+On-chain accounting is correct in both cases — each chain pays from its own locally stored allocations. The concern is for **off-chain consumers** of the `ChannelClosed` event:
+
+- Key `ChannelClosed` events by `(chainId, ChannelHub, channelId)`, never by `channelId` alone.
+- Treat each emission as a distinct local settlement; there is no single canonical `finalState` for an abandoned migration close.
+- Code that persists the emitted `finalState` must handle the swapped ledger orientation for channels in `MIGRATING_IN` status at close time.
+
+Under correct Node behavior this scenario does not occur: the Node stops issuing new states during migration and ensures either finalization or reversion before closing. The on-chain contract handles it safely so that no funds are permanently locked if it does occur.
+
+---
+
 ## Trust Assumptions
 
 Beyond the cryptographic and on-chain guarantees listed above, correct user fund protection depends on the following trust assumptions about Node behavior.

--- a/protocol-description.md
+++ b/protocol-description.md
@@ -559,8 +559,22 @@ This works because `prevStoredState` was swapped during `INITIATE_MIGRATION`.
 * Signatures are validated **before** swapping (using the original signed state)
 * After swapping, signatures are invalidated (`userSig = ""`, `nodeSig = ""`) to prevent misuse
 * The swapped state is only used internally for storage and validation
-* Events emit the original signed state (before swap) for off-chain observability
+* Migration lifecycle events (`MigrationInInitiated`, `MigrationOutInitiated`, `MigrationInFinalized`, `MigrationOutFinalized`) emit the original signed state (before swap) for off-chain observability
+* `ChannelClosed` is an exception: it emits `meta.lastState`, which on the new home chain is the already-swapped state stored during `initiateMigration()`
 * This approach maintains the critical invariant: **ChannelEngine always sees homeLedger as the current chain**
+
+#### Dual-close during abandoned migration
+
+If a migration is initiated but never finalized and both channel copies are subsequently challenged and closed after timeout, `ChannelClosed` can be emitted on both chains for the same `channelId` and state version but with **opposite `homeLedger`/`nonHomeLedger` orientation**:
+
+* Old home chain (`OPERATING`/`DISPUTED`): emits `finalState` with `homeLedger` = old home chain (original orientation)
+* New home chain (`MIGRATING_IN`/`DISPUTED`): emits `finalState` with `homeLedger` = new home chain (swapped orientation)
+
+On-chain fund accounting is correct in both cases — each chain pays from its own locally stored allocations. The concern is for off-chain consumers:
+
+* Index and key `ChannelClosed` events by `(chainId, ChannelHub, channelId)`, never by `channelId` alone
+* Treat each emission as a distinct local settlement; there is no single canonical `finalState` for an abandoned migration
+* Code that persists the emitted `finalState` must handle the swapped ledger orientation for channels in `MIGRATING_IN` status
 
 ---
 


### PR DESCRIPTION
## Summary

Security audit finding: when a migration is initiated but never finalized and both channel copies are subsequently challenged and closed after timeout, `ChannelClosed` can be emitted for the same `channelId` on both chains with the same state version but with **opposite `homeLedger`/`nonHomeLedger` orientation** in `finalState`.

### Root cause

`initiateMigration()` on the new home chain swaps `homeLedger` ↔ `nonHomeLedger` before storing (to maintain the invariant that `homeLedger` always represents the current chain). As a result, `meta.lastState` on the new home chain is in opposite orientation from what was signed. `closeChannel()` emits `ChannelClosed(channelId, meta.lastState)`, so the two chains emit the same event with flipped ledger fields.

### Impact

- **On-chain**: none. Each chain pays from its own locally stored allocations; accounting is correct.
- **Off-chain**: off-chain consumers, indexers, or SDKs that key `ChannelClosed` by `channelId` alone, persist `finalState`, or derive migration outcome from the close event without considering the emitting chain will encounter ambiguous or contradictory data.

### Fixes

**`contracts/SECURITY.md`** — added a new prose subsection "ChannelClosed event orientation during abandoned migration" inside the existing "Cross-chain Operation Ordering" section.

**`protocol-description.md`** — updated the "Implementation Notes" section under migration.