### PR TITLE
MF-L05: docs(contracts): document informational events not guaranteed to emit

### DIFF
--- a/contracts/SECURITY.md
+++ b/contracts/SECURITY.md
@@ -595,3 +595,24 @@ Critically, DISPUTED entries still consume a step. Without this, an actor could 
 > **Bounded purge iteration** (complements invariant 22): `_purgeEscrowDeposits(maxSteps)` inspects at most `maxSteps` queue entries per call. Every inspected entry, regardless of disposition (skipped, purged, or halting), counts against the budget. The per-operation automatic budget is `MAX_DEPOSIT_ESCROW_STEPS = 64`.
 
 ---
+
+## Informational Events
+
+Several `ChannelHub` events are **informational** — they are emitted on a best-effort basis when a specific dedicated function path is taken, but are not guaranteed to fire for every logical occurrence of the operation they name. A newer signed state that supersedes an intermediate cross-chain step can be enforced directly through a standard channel operation (deposit, withdraw, checkpoint, challenge), bypassing the dedicated function and therefore skipping its event. This is intentional: for example, `MIGRATING_IN` channels are treated as fully operational home-chain channels, and similarly, channel states involved in escrow flows can be advanced by any valid newer state.
+
+External consumers — indexers, SDKs, analytics — **must not treat these events as exhaustive signals**. The canonical, always-guaranteed terminal events for each cross-chain flow (`MigrationOutFinalized`, `EscrowDepositInitiated`, `EscrowWithdrawalFinalized`, etc.) remain reliable.
+
+The following events are informational:
+
+| Event | When it may be skipped |
+| --- | --- |
+| `MigrationInFinalized` | A `MIGRATING_IN` channel transitions to `OPERATING` via any standard operation (deposit, withdraw, checkpoint, challenge) rather than explicit `finalizeMigration()` |
+| `MigrationOutInitiated` | A newer `MIGRATING_OUT` signed state is enforced on the old home channel that is the successor of the explicit initiation state |
+| `EscrowDepositFinalized` | The non-home channel advances past escrow finalization via a newer signed state |
+| `EscrowDepositFinalizedOnHome` | The home channel advances past the escrow finalization acknowledgement via a newer signed state |
+| `EscrowWithdrawalInitiatedOnHome` | The home channel advances past the escrow withdrawal initiation acknowledgement via a newer signed state |
+| `EscrowWithdrawalFinalizedOnHome` | The home channel advances past the escrow withdrawal finalization acknowledgement via a newer signed state |
+
+The Nitronode does not rely on any of these informational events for its state machine. For migration, the Nitronode watches `MigrationInInitiated` (the on-chain request establishing the new home chain) and `MigrationOutFinalized` (the unconditional completion signal on the old home chain). Both are guaranteed events.
+
+---

--- a/contracts/src/ChannelHub.sol
+++ b/contracts/src/ChannelHub.sol
@@ -76,18 +76,46 @@ contract ChannelHub is ReentrancyGuard {
     event EscrowDepositInitiated(bytes32 indexed escrowId, bytes32 indexed channelId, State state);
     event EscrowDepositInitiatedOnHome(bytes32 indexed escrowId, bytes32 indexed channelId, State state);
     event EscrowDepositChallenged(bytes32 indexed escrowId, State state, uint64 challengeExpireAt);
+
+    /// @dev Informational event: emitted only when finalizeEscrowDeposit() is called on the non-home chain via its
+    /// dedicated function path. It is not emitted if a newer state is enforced on the channel that supersedes the
+    /// finalization. External consumers must not treat this as an exhaustive signal.
     event EscrowDepositFinalized(bytes32 indexed escrowId, bytes32 indexed channelId, State state);
+
+    /// @dev Informational event: emitted only when the home-chain channel advances through the dedicated
+    /// finalizeEscrowDeposit() path. It is not emitted if the channel state is advanced by a newer signed state that
+    /// supersedes the escrow finalization. External consumers must not treat this as an exhaustive signal.
     event EscrowDepositFinalizedOnHome(bytes32 indexed escrowId, bytes32 indexed channelId, State state);
 
     event EscrowWithdrawalInitiated(bytes32 indexed escrowId, bytes32 indexed channelId, State state);
+
+    /// @dev Informational event: emitted only when initiateEscrowWithdrawal() advances the home-chain channel via its
+    /// dedicated function path. It is not emitted if a newer signed state supersedes the initiation on that channel.
+    /// External consumers must not treat this as an exhaustive signal.
     event EscrowWithdrawalInitiatedOnHome(bytes32 indexed escrowId, bytes32 indexed channelId, State state);
+
     event EscrowWithdrawalChallenged(bytes32 indexed escrowId, State state, uint64 challengeExpireAt);
     event EscrowWithdrawalFinalized(bytes32 indexed escrowId, bytes32 indexed channelId, State state);
+
+    /// @dev Informational event: emitted only when finalizeEscrowWithdrawal() advances the home-chain channel via its
+    /// dedicated function path. It is not emitted if a newer signed state supersedes the finalization on that channel.
+    /// External consumers must not treat this as an exhaustive signal.
     event EscrowWithdrawalFinalizedOnHome(bytes32 indexed escrowId, bytes32 indexed channelId, State state);
 
+    /// @dev Informational event: emitted only when initiateMigration() is called on the old home chain via its
+    /// dedicated function path. It is not emitted if a newer signed state (e.g. FINALIZE_MIGRATION) is enforced
+    /// directly on the channel, bypassing the explicit initiation path. External consumers must not treat this as
+    /// an exhaustive signal.
     event MigrationOutInitiated(bytes32 indexed channelId, State state);
+
     event MigrationInInitiated(bytes32 indexed channelId, State state);
     event MigrationOutFinalized(bytes32 indexed channelId, State state);
+
+    /// @dev Informational event: emitted only when finalizeMigration() is called explicitly on the new home chain.
+    /// A MIGRATING_IN channel may transition to OPERATING through any standard channel operation (deposit, withdraw,
+    /// checkpoint, challenge) built on top of a FINALIZE_MIGRATION state, in which case this event is not emitted.
+    /// External consumers must not treat this as an exhaustive signal; the canonical migration completion signal is
+    /// MigrationOutFinalized, which is always emitted unconditionally on the old home chain.
     event MigrationInFinalized(bytes32 indexed channelId, State state);
 
     event ValidatorRegistered(uint8 indexed validatorId, ISignatureValidator indexed validator);

--- a/protocol-description.md
+++ b/protocol-description.md
@@ -710,6 +710,25 @@ Subsequent operations accept both tiers, filtered by the bitmask stored at creat
 
 ---
 
+## Informational Events
+
+Several `ChannelHub` events are **informational** — emitted on a best-effort basis when a specific dedicated function path is taken, but not guaranteed to fire for every logical occurrence of the operation they name. Because the protocol allows any newer valid signed state to be enforced directly (e.g. a standard deposit or checkpoint on a `MIGRATING_IN` channel), intermediate cross-chain states can be bypassed without calling their dedicated functions, and therefore without emitting their events.
+
+External consumers such as indexers, SDKs, and analytics tooling **must not treat these events as exhaustive signals**. The canonical terminal events for each cross-chain flow remain reliable and are always emitted.
+
+The following events are informational:
+
+* **`MigrationInFinalized`** — not emitted if a `MIGRATING_IN` channel transitions to `OPERATING` via any standard operation (deposit, withdraw, checkpoint, challenge) rather than an explicit `finalizeMigration()` call. The canonical migration completion signal is `MigrationOutFinalized`, which is always emitted unconditionally on the old home chain.
+* **`MigrationOutInitiated`** — not emitted if a newer signed state is enforced on the old home channel that supersedes the explicit initiation state.
+* **`EscrowDepositFinalized`** — not emitted if the non-home channel advances past escrow finalization via a newer signed state.
+* **`EscrowDepositFinalizedOnHome`** — not emitted if the home channel advances past the escrow finalization acknowledgement via a newer signed state.
+* **`EscrowWithdrawalInitiatedOnHome`** — not emitted if the home channel advances past the escrow withdrawal initiation acknowledgement via a newer signed state.
+* **`EscrowWithdrawalFinalizedOnHome`** — not emitted if the home channel advances past the escrow withdrawal finalization acknowledgement via a newer signed state.
+
+The Nitronode does not rely on any of these informational events for its state machine. For migration, the Nitronode watches `MigrationInInitiated` (the on-chain signal establishing the new home chain) and `MigrationOutFinalized` (the unconditional completion signal on the old home chain).
+
+---
+
 ## Mental model
 
 * Off-chain protocol **decides what should happen**.


### PR DESCRIPTION
## Problem

Several `ChannelHub` events — `MigrationInFinalized`, `MigrationOutInitiated`, `EscrowDepositFinalized`, `EscrowDepositFinalizedOnHome`, `EscrowWithdrawalInitiatedOnHome`, `EscrowWithdrawalFinalizedOnHome` — are not guaranteed to be emitted for every logical occurrence of the operation they name.

This is by design: the protocol allows any newer valid signed state to be enforced through a standard channel operation (deposit, withdraw, checkpoint, challenge), bypassing dedicated function paths and therefore skipping their events. For example, a `MIGRATING_IN` channel can transition to `OPERATING` via a deposit without calling `finalizeMigration()`, so `MigrationInFinalized` is never emitted in that path.

An audit finding flagged this as ambiguous event semantics for external consumers who might treat these events as reliable signals.

## Solution

Added explicit documentation clarifying that these are **informational events** — emitted on a best-effort basis when the specific dedicated function path is taken, but not guaranteed to fire for every occurrence of the operation they represent.

- **`contracts/src/ChannelHub.sol`**: Added `@dev` NatSpec comments above each of the 6 informational events explaining when each may be skipped and that external consumers must not treat them as exhaustive signals.
- **`contracts/SECURITY.md`**: Added a new "Informational Events" section with a summary and a table of all 6 events with their skip conditions, plus a note that the Nitronode relies on `MigrationInInitiated` and `MigrationOutFinalized` (both guaranteed) for the migration flow.
- **`protocol-description.md`**: Added a matching "Informational Events" section before "Mental model" with bullet-point descriptions of each event and the same Nitronode note.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated protocol documentation to clarify that certain informational events (including migration and escrow-related signals) are best-effort and may not be emitted when newer states are enforced through standard operations. Integrators should treat these events as non-exhaustive and rely on guaranteed canonical events as primary signals for critical state transitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/layer-3/nitrolite/pull/756)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->