### PR TITLE
fix(sdk): use keccak256(utf8) for session key application ID hashing

### DIFF
--- a/pkg/app/session_key_v1.go
+++ b/pkg/app/session_key_v1.go
@@ -122,12 +122,12 @@ func PackAppSessionKeyStateV1(state AppSessionKeyStateV1) ([]byte, error) {
 
 	applicationIDHashes := make([][32]byte, len(state.ApplicationIDs))
 	for i, id := range state.ApplicationIDs {
-		applicationIDHashes[i] = common.HexToHash(id)
+		applicationIDHashes[i] = crypto.Keccak256Hash([]byte(id))
 	}
 
 	appSessionIDHashes := make([][32]byte, len(state.AppSessionIDs))
 	for i, id := range state.AppSessionIDs {
-		appSessionIDHashes[i] = common.HexToHash(id)
+		appSessionIDHashes[i] = crypto.Keccak256Hash([]byte(id))
 	}
 
 	packed, err := args.Pack(

--- a/pkg/app/session_key_v1_test.go
+++ b/pkg/app/session_key_v1_test.go
@@ -150,8 +150,58 @@ func TestPackAppSessionKeyStateV1(t *testing.T) {
 
 	// Strengthen assertion: validate content by comparing against pre-calculated hash
 	// This ensures that if the packing logic changes, the test will fail.
-	expectedHash := "0x9fedfbcd577c5e677b95b1273e38f52ffdeee096e98f731c5455e4c73e0274aa"
+	expectedHash := "0x6d404fa628918dbe4abec4ae2808c7ea01dc880ad4ad392ca2d0c4ce21f706c1"
 	assert.Equal(t, expectedHash, hexutil.Encode(packed))
+}
+
+func TestPackAppSessionKeyStateV1_NoIDCollision(t *testing.T) {
+	t.Parallel()
+	base := AppSessionKeyStateV1{
+		UserAddress: "0x1111111111111111111111111111111111111111",
+		SessionKey:  "0x2222222222222222222222222222222222222222",
+		Version:     1,
+		ExpiresAt:   time.Unix(1739812234, 0),
+	}
+
+	// Human-readable (non-hex) IDs must each produce a distinct packed hash.
+	ids := []string{"app-1", "app-2", "trading", "gaming", "defi"}
+	hashes := make(map[string]string)
+	for _, id := range ids {
+		s := base
+		s.ApplicationIDs = []string{id}
+		packed, err := PackAppSessionKeyStateV1(s)
+		require.NoError(t, err)
+		h := hexutil.Encode(packed)
+		if prev, seen := hashes[h]; seen {
+			t.Fatalf("collision: %q and %q produced the same hash %s", prev, id, h)
+		}
+		hashes[h] = id
+	}
+
+	// Same uniqueness requirement holds for AppSessionIDs.
+	sessionHashes := make(map[string]string)
+	for _, id := range ids {
+		s := base
+		s.AppSessionIDs = []string{id}
+		packed, err := PackAppSessionKeyStateV1(s)
+		require.NoError(t, err)
+		h := hexutil.Encode(packed)
+		if prev, seen := sessionHashes[h]; seen {
+			t.Fatalf("appSessionID collision: %q and %q produced the same hash %s", prev, id, h)
+		}
+		sessionHashes[h] = id
+	}
+
+	// An empty ID and a whitespace ID must also be distinct.
+	sEmpty := base
+	sEmpty.ApplicationIDs = []string{""}
+	sSpace := base
+	sSpace.ApplicationIDs = []string{" "}
+	hashEmpty, err := PackAppSessionKeyStateV1(sEmpty)
+	require.NoError(t, err)
+	hashSpace, err := PackAppSessionKeyStateV1(sSpace)
+	require.NoError(t, err)
+	assert.NotEqual(t, hexutil.Encode(hashEmpty), hexutil.Encode(hashSpace))
 }
 
 func TestAppSessionSignerV1(t *testing.T) {

--- a/sdk/ts/src/app/packing.ts
+++ b/sdk/ts/src/app/packing.ts
@@ -1,4 +1,4 @@
-import { Address, Hex, encodeAbiParameters, keccak256, pad, toHex } from 'viem';
+import { Address, Hex, encodeAbiParameters, keccak256, toHex } from 'viem';
 import {
   AppDefinitionV1,
   AppStateUpdateV1,
@@ -208,45 +208,19 @@ export function packAppV1(app: AppV1): `0x${string}` {
 }
 
 /**
- * hexToBytes32 converts a hex string to a 32-byte value, matching Go's common.HexToHash behavior.
- * - Strips "0x" prefix if present
- * - Decodes hex characters; non-hex strings produce zero bytes
- * - Right-aligns the result in 32 bytes (left-padded with zeros)
- */
-function hexToBytes32(s: string): Hex {
-  // Strip 0x prefix
-  let hex = s.startsWith('0x') || s.startsWith('0X') ? s.slice(2) : s;
-  // Pad to even length
-  if (hex.length % 2 === 1) {
-    hex = '0' + hex;
-  }
-  // Validate hex characters - if any invalid char, return zero hash (matches Go behavior)
-  if (!/^[0-9a-fA-F]*$/.test(hex)) {
-    return pad('0x00', { size: 32 }) as Hex;
-  }
-  // If empty, return zero hash
-  if (hex.length === 0) {
-    return pad('0x00', { size: 32 }) as Hex;
-  }
-  // Truncate to 32 bytes max (64 hex chars)
-  if (hex.length > 64) {
-    hex = hex.slice(hex.length - 64);
-  }
-  // Left-pad to 64 hex chars (32 bytes)
-  const padded = hex.padStart(64, '0');
-  return `0x${padded}` as Hex;
-}
-
-/**
  * PackAppSessionKeyStateV1 packs the app session key state for signing using ABI encoding.
  * Matches Go SDK's PackAppSessionKeyStateV1.
+ *
+ * Application and app-session IDs are hashed with keccak256(utf8(id)) so that every
+ * distinct string produces a unique bytes32 — human-readable IDs like "app-1" and
+ * "app-2" can no longer collide in the signed payload.
  *
  * @param state - The app session key state to pack
  * @returns Keccak256 hash of the ABI-encoded state (excluding user_sig)
  */
 export function packAppSessionKeyStateV1(state: AppSessionKeyStateV1): `0x${string}` {
-  const applicationIDHashes = state.application_ids.map(hexToBytes32);
-  const appSessionIDHashes = state.app_session_ids.map(hexToBytes32);
+  const applicationIDHashes = state.application_ids.map((id) => keccak256(toHex(id)));
+  const appSessionIDHashes = state.app_session_ids.map((id) => keccak256(toHex(id)));
 
   const packed = encodeAbiParameters(
     [

--- a/sdk/ts/test/unit/app-signing-drift.test.ts
+++ b/sdk/ts/test/unit/app-signing-drift.test.ts
@@ -130,7 +130,7 @@ describe('Go/TS app signing drift vectors', () => {
 
     it('matches Go PackAppSessionKeyStateV1 vector', () => {
         expect(packAppSessionKeyStateV1(sessionKeyState)).toBe(
-            '0x9fedfbcd577c5e677b95b1273e38f52ffdeee096e98f731c5455e4c73e0274aa'
+            '0x6d404fa628918dbe4abec4ae2808c7ea01dc880ad4ad392ca2d0c4ce21f706c1'
         );
     });
 
@@ -236,6 +236,40 @@ describe('Go/TS app signing drift vectors', () => {
         });
 
         expect(normalized).not.toBe(canonical);
+    });
+
+    it('proves human-readable application IDs produce distinct hashes (no collision)', () => {
+        const base: AppSessionKeyStateV1 = {
+            user_address: user,
+            session_key: app,
+            version: '1',
+            application_ids: [],
+            app_session_ids: [],
+            expires_at: '1739812234',
+            user_sig: '',
+            session_key_sig: '',
+        };
+
+        const ids = ['app-1', 'app-2', 'trading', 'gaming', 'defi'];
+        const appIdHashes = new Set<string>();
+        for (const id of ids) {
+            const h = packAppSessionKeyStateV1({ ...base, application_ids: [id] });
+            expect(appIdHashes.has(h)).toBe(false);
+            appIdHashes.add(h);
+        }
+
+        // Same uniqueness requirement holds for app_session_ids.
+        const sessionIdHashes = new Set<string>();
+        for (const id of ids) {
+            const h = packAppSessionKeyStateV1({ ...base, app_session_ids: [id] });
+            expect(sessionIdHashes.has(h)).toBe(false);
+            sessionIdHashes.add(h);
+        }
+
+        // Empty string and whitespace must also be distinct.
+        const hashEmpty = packAppSessionKeyStateV1({ ...base, application_ids: [''] });
+        const hashSpace = packAppSessionKeyStateV1({ ...base, application_ids: [' '] });
+        expect(hashEmpty).not.toBe(hashSpace);
     });
 
     it('proves adversarial session-key ID placement changes the signed hash', () => {


### PR DESCRIPTION
## Problem

`PackAppSessionKeyStateV1` encoded application and app-session IDs by treating each string as hex (`common.HexToHash` in Go, a matching `hexToBytes32` in TypeScript). Any string containing a non-hex character was silently collapsed to the same `0x000...000` bytes32, so `"app-1"` and `"app-2"` — and any other human-readable identifiers — produced **identical signing payloads**. This opened a phishing vector: a signature collected for Integration A's `"app-1"` could be submitted unchanged to authorize Integration B's `"app-2"`.

## Fixes

- **Go** (`pkg/app/session_key_v1.go`): replace `common.HexToHash(id)` → `crypto.Keccak256Hash([]byte(id))` for both `applicationIDHashes` and `appSessionIDHashes`.
- **TypeScript** (`sdk/ts/src/app/packing.ts`): remove the broken `hexToBytes32` helper; replace with `(id) => keccak256(toHex(id))`. Remove now-unused `pad` import.
- **Drift vectors** updated in Go test and TS drift test (new hash: `0x6d404fa6...`). Go and TypeScript produce identical output, confirming cross-SDK consistency.
- **Collision tests** added in both languages covering `ApplicationIDs` and `AppSessionIDs` with human-readable IDs (`"app-1"`, `"app-2"`, `"trading"`, `"gaming"`, `"defi"`) and boundary cases (empty string vs whitespace).

## Notes

This is a **breaking change**: existing signed session key states are invalidated. Clients must re-sign with the updated SDK after the server deploys this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session key signatures now use cryptographic hashing for application and session identifiers to prevent potential hash collisions in the signed payload.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/layer-3/nitrolite/pull/760)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->