### PR TITLE
MF2-M01: fix(sdk): use keccak256(utf8) for session key application ID hashing

### DIFF
--- a/nitronode/api/app_session_v1/README.md
+++ b/nitronode/api/app_session_v1/README.md
@@ -706,6 +706,8 @@ ORDER BY created_at DESC;
 - `version` must be greater than 0
 - `expires_at` must be in the future
 - `user_sig` is required
+- `application_ids` entries must be lowercase strings (non-lowercase values are rejected before signature verification)
+- `app_session_ids` entries must be lowercase strings (non-lowercase values are rejected before signature verification)
 - Version must be sequential (latest_version + 1)
 - Signature must recover to `user_address`
 - Newly registered keys count against the per-user cap (`NITRONODE_MAX_SESSION_KEYS_PER_USER`, default 100). Updates to keys that already exist for the user are not blocked by the cap.
@@ -715,6 +717,7 @@ ORDER BY created_at DESC;
 **Signature Verification**:
 - Uses ABI encoding via `PackAppSessionKeyStateV1` to create a deterministic hash
 - Encodes: user_address (address), session_key (address), version (uint64), application_ids (bytes32[]), app_session_ids (bytes32[]), expires_at (uint64)
+- Each application_id and app_session_id string is converted to bytes32 via `keccak256(utf8(id))` before ABI encoding
 - The `user_sig` field is excluded from packing (it is the signature itself)
 - Recovers signer address from ECDSA signature
 - Validates that recovered address matches `user_address`
@@ -828,6 +831,7 @@ The implementation uses Ethereum ABI encoding for deterministic hashing and sign
 #### `PackAppSessionKeyStateV1(state AppSessionKeyStateV1) ([]byte, error)`
 - Packs session key state for signature verification using ABI encoding
 - Encodes: user_address (address), session_key (address), version (uint64), application_ids (bytes32[]), app_session_ids (bytes32[]), expires_at (uint64)
+- Each `application_id` and `app_session_id` string is converted to bytes32 via `keccak256(utf8(id))`, so every distinct string — including human-readable IDs like `"app-1"` — produces a unique hash with no collisions
 - Excludes the `user_sig` field (it is the signature itself)
 - Returns Keccak256 hash of ABI-encoded data
 - Used in `submit_session_key_state` to verify the user's signature

--- a/nitronode/api/app_session_v1/submit_session_key_state.go
+++ b/nitronode/api/app_session_v1/submit_session_key_state.go
@@ -69,6 +69,18 @@ func (h *Handler) SubmitSessionKeyState(c *rpc.Context) {
 		c.Fail(rpc.Errorf("invalid_session_key_state: application_ids array exceeds maximum length of %d", h.maxSessionKeyIDs), "")
 		return
 	}
+	for _, id := range coreState.ApplicationIDs {
+		if id != strings.ToLower(id) {
+			c.Fail(rpc.Errorf("invalid_session_key_state: application_ids must be lowercase, got: %s", id), "")
+			return
+		}
+	}
+	for _, id := range coreState.AppSessionIDs {
+		if id != strings.ToLower(id) {
+			c.Fail(rpc.Errorf("invalid_session_key_state: app_session_ids must be lowercase, got: %s", id), "")
+			return
+		}
+	}
 	if coreState.UserSig == "" {
 		c.Fail(rpc.Errorf("invalid_session_key_state: user_sig is required"), "")
 		return

--- a/nitronode/api/app_session_v1/submit_session_key_state_test.go
+++ b/nitronode/api/app_session_v1/submit_session_key_state_test.go
@@ -485,6 +485,92 @@ func TestSubmitSessionKeyState_AllowsUpdateForExistingKeyAtCap(t *testing.T) {
 	mockStore.AssertNotCalled(t, "CountSessionKeysForUser", mock.Anything)
 }
 
+func TestSubmitSessionKeyState_RejectsNonLowercaseApplicationID(t *testing.T) {
+	mockStore := new(MockStore)
+	handler := &Handler{
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockStore)
+		},
+		metrics:          metrics.NewNoopRuntimeMetricExporter(),
+		maxSessionKeyIDs: 10,
+	}
+
+	userSigner := NewMockSigner()
+	userAddress := strings.ToLower(userSigner.PublicKey().Address().String())
+	sessionKeyAddress := "0x3333333333333333333333333333333333333333"
+
+	reqPayload := rpc.AppSessionsV1SubmitSessionKeyStateRequest{
+		State: rpc.AppSessionKeyStateV1{
+			UserAddress:    userAddress,
+			SessionKey:     sessionKeyAddress,
+			Version:        "1",
+			ApplicationIDs: []string{"App-1"},
+			AppSessionIDs:  []string{},
+			ExpiresAt:      strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10),
+			UserSig:        "0xdeadbeef",
+		},
+	}
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, rpc.AppSessionsV1SubmitSessionKeyStateMethod.String(), payload),
+	}
+
+	handler.SubmitSessionKeyState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.NotNil(t, respErr)
+	assert.Contains(t, respErr.Error(), "application_ids must be lowercase, got: App-1")
+	mockStore.AssertNotCalled(t, "LockSessionKeyState", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestSubmitSessionKeyState_RejectsNonLowercaseAppSessionID(t *testing.T) {
+	mockStore := new(MockStore)
+	handler := &Handler{
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockStore)
+		},
+		metrics:          metrics.NewNoopRuntimeMetricExporter(),
+		maxSessionKeyIDs: 10,
+	}
+
+	userSigner := NewMockSigner()
+	userAddress := strings.ToLower(userSigner.PublicKey().Address().String())
+	sessionKeyAddress := "0x3333333333333333333333333333333333333333"
+
+	reqPayload := rpc.AppSessionsV1SubmitSessionKeyStateRequest{
+		State: rpc.AppSessionKeyStateV1{
+			UserAddress:    userAddress,
+			SessionKey:     sessionKeyAddress,
+			Version:        "1",
+			ApplicationIDs: []string{},
+			AppSessionIDs:  []string{"Session-ABC"},
+			ExpiresAt:      strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10),
+			UserSig:        "0xdeadbeef",
+		},
+	}
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, rpc.AppSessionsV1SubmitSessionKeyStateMethod.String(), payload),
+	}
+
+	handler.SubmitSessionKeyState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.NotNil(t, respErr)
+	assert.Contains(t, respErr.Error(), "app_session_ids must be lowercase, got: Session-ABC")
+	mockStore.AssertNotCalled(t, "LockSessionKeyState", mock.Anything, mock.Anything, mock.Anything)
+}
+
 func TestSubmitSessionKeyState_SignatureMismatch(t *testing.T) {
 	mockStore := new(MockStore)
 	userSigner := NewMockSigner()

--- a/pkg/app/session_key_v1.go
+++ b/pkg/app/session_key_v1.go
@@ -122,12 +122,12 @@ func PackAppSessionKeyStateV1(state AppSessionKeyStateV1) ([]byte, error) {
 
 	applicationIDHashes := make([][32]byte, len(state.ApplicationIDs))
 	for i, id := range state.ApplicationIDs {
-		applicationIDHashes[i] = common.HexToHash(id)
+		applicationIDHashes[i] = crypto.Keccak256Hash([]byte(id))
 	}
 
 	appSessionIDHashes := make([][32]byte, len(state.AppSessionIDs))
 	for i, id := range state.AppSessionIDs {
-		appSessionIDHashes[i] = common.HexToHash(id)
+		appSessionIDHashes[i] = crypto.Keccak256Hash([]byte(id))
 	}
 
 	packed, err := args.Pack(

--- a/pkg/app/session_key_v1_test.go
+++ b/pkg/app/session_key_v1_test.go
@@ -150,8 +150,58 @@ func TestPackAppSessionKeyStateV1(t *testing.T) {
 
 	// Strengthen assertion: validate content by comparing against pre-calculated hash
 	// This ensures that if the packing logic changes, the test will fail.
-	expectedHash := "0x9fedfbcd577c5e677b95b1273e38f52ffdeee096e98f731c5455e4c73e0274aa"
+	expectedHash := "0x6d404fa628918dbe4abec4ae2808c7ea01dc880ad4ad392ca2d0c4ce21f706c1"
 	assert.Equal(t, expectedHash, hexutil.Encode(packed))
+}
+
+func TestPackAppSessionKeyStateV1_NoIDCollision(t *testing.T) {
+	t.Parallel()
+	base := AppSessionKeyStateV1{
+		UserAddress: "0x1111111111111111111111111111111111111111",
+		SessionKey:  "0x2222222222222222222222222222222222222222",
+		Version:     1,
+		ExpiresAt:   time.Unix(1739812234, 0),
+	}
+
+	// Human-readable (non-hex) IDs must each produce a distinct packed hash.
+	ids := []string{"app-1", "app-2", "trading", "gaming", "defi"}
+	hashes := make(map[string]string)
+	for _, id := range ids {
+		s := base
+		s.ApplicationIDs = []string{id}
+		packed, err := PackAppSessionKeyStateV1(s)
+		require.NoError(t, err)
+		h := hexutil.Encode(packed)
+		if prev, seen := hashes[h]; seen {
+			t.Fatalf("collision: %q and %q produced the same hash %s", prev, id, h)
+		}
+		hashes[h] = id
+	}
+
+	// Same uniqueness requirement holds for AppSessionIDs.
+	sessionHashes := make(map[string]string)
+	for _, id := range ids {
+		s := base
+		s.AppSessionIDs = []string{id}
+		packed, err := PackAppSessionKeyStateV1(s)
+		require.NoError(t, err)
+		h := hexutil.Encode(packed)
+		if prev, seen := sessionHashes[h]; seen {
+			t.Fatalf("appSessionID collision: %q and %q produced the same hash %s", prev, id, h)
+		}
+		sessionHashes[h] = id
+	}
+
+	// An empty ID and a whitespace ID must also be distinct.
+	sEmpty := base
+	sEmpty.ApplicationIDs = []string{""}
+	sSpace := base
+	sSpace.ApplicationIDs = []string{" "}
+	hashEmpty, err := PackAppSessionKeyStateV1(sEmpty)
+	require.NoError(t, err)
+	hashSpace, err := PackAppSessionKeyStateV1(sSpace)
+	require.NoError(t, err)
+	assert.NotEqual(t, hexutil.Encode(hashEmpty), hexutil.Encode(hashSpace))
 }
 
 func TestAppSessionSignerV1(t *testing.T) {

--- a/sdk/ts/src/app/packing.ts
+++ b/sdk/ts/src/app/packing.ts
@@ -1,4 +1,4 @@
-import { Address, Hex, encodeAbiParameters, keccak256, pad, toHex } from 'viem';
+import { Address, Hex, encodeAbiParameters, keccak256, toHex } from 'viem';
 import {
   AppDefinitionV1,
   AppStateUpdateV1,
@@ -208,45 +208,19 @@ export function packAppV1(app: AppV1): `0x${string}` {
 }
 
 /**
- * hexToBytes32 converts a hex string to a 32-byte value, matching Go's common.HexToHash behavior.
- * - Strips "0x" prefix if present
- * - Decodes hex characters; non-hex strings produce zero bytes
- * - Right-aligns the result in 32 bytes (left-padded with zeros)
- */
-function hexToBytes32(s: string): Hex {
-  // Strip 0x prefix
-  let hex = s.startsWith('0x') || s.startsWith('0X') ? s.slice(2) : s;
-  // Pad to even length
-  if (hex.length % 2 === 1) {
-    hex = '0' + hex;
-  }
-  // Validate hex characters - if any invalid char, return zero hash (matches Go behavior)
-  if (!/^[0-9a-fA-F]*$/.test(hex)) {
-    return pad('0x00', { size: 32 }) as Hex;
-  }
-  // If empty, return zero hash
-  if (hex.length === 0) {
-    return pad('0x00', { size: 32 }) as Hex;
-  }
-  // Truncate to 32 bytes max (64 hex chars)
-  if (hex.length > 64) {
-    hex = hex.slice(hex.length - 64);
-  }
-  // Left-pad to 64 hex chars (32 bytes)
-  const padded = hex.padStart(64, '0');
-  return `0x${padded}` as Hex;
-}
-
-/**
  * PackAppSessionKeyStateV1 packs the app session key state for signing using ABI encoding.
  * Matches Go SDK's PackAppSessionKeyStateV1.
+ *
+ * Application and app-session IDs are hashed with keccak256(utf8(id)) so that every
+ * distinct string produces a unique bytes32 — human-readable IDs like "app-1" and
+ * "app-2" can no longer collide in the signed payload.
  *
  * @param state - The app session key state to pack
  * @returns Keccak256 hash of the ABI-encoded state (excluding user_sig)
  */
 export function packAppSessionKeyStateV1(state: AppSessionKeyStateV1): `0x${string}` {
-  const applicationIDHashes = state.application_ids.map(hexToBytes32);
-  const appSessionIDHashes = state.app_session_ids.map(hexToBytes32);
+  const applicationIDHashes = state.application_ids.map((id) => keccak256(toHex(id)));
+  const appSessionIDHashes = state.app_session_ids.map((id) => keccak256(toHex(id)));
 
   const packed = encodeAbiParameters(
     [

--- a/sdk/ts/test/unit/app-signing-drift.test.ts
+++ b/sdk/ts/test/unit/app-signing-drift.test.ts
@@ -130,7 +130,7 @@ describe('Go/TS app signing drift vectors', () => {
 
     it('matches Go PackAppSessionKeyStateV1 vector', () => {
         expect(packAppSessionKeyStateV1(sessionKeyState)).toBe(
-            '0x9fedfbcd577c5e677b95b1273e38f52ffdeee096e98f731c5455e4c73e0274aa'
+            '0x6d404fa628918dbe4abec4ae2808c7ea01dc880ad4ad392ca2d0c4ce21f706c1'
         );
     });
 
@@ -236,6 +236,40 @@ describe('Go/TS app signing drift vectors', () => {
         });
 
         expect(normalized).not.toBe(canonical);
+    });
+
+    it('proves human-readable application IDs produce distinct hashes (no collision)', () => {
+        const base: AppSessionKeyStateV1 = {
+            user_address: user,
+            session_key: app,
+            version: '1',
+            application_ids: [],
+            app_session_ids: [],
+            expires_at: '1739812234',
+            user_sig: '',
+            session_key_sig: '',
+        };
+
+        const ids = ['app-1', 'app-2', 'trading', 'gaming', 'defi'];
+        const appIdHashes = new Set<string>();
+        for (const id of ids) {
+            const h = packAppSessionKeyStateV1({ ...base, application_ids: [id] });
+            expect(appIdHashes.has(h)).toBe(false);
+            appIdHashes.add(h);
+        }
+
+        // Same uniqueness requirement holds for app_session_ids.
+        const sessionIdHashes = new Set<string>();
+        for (const id of ids) {
+            const h = packAppSessionKeyStateV1({ ...base, app_session_ids: [id] });
+            expect(sessionIdHashes.has(h)).toBe(false);
+            sessionIdHashes.add(h);
+        }
+
+        // Empty string and whitespace must also be distinct.
+        const hashEmpty = packAppSessionKeyStateV1({ ...base, application_ids: [''] });
+        const hashSpace = packAppSessionKeyStateV1({ ...base, application_ids: [' '] });
+        expect(hashEmpty).not.toBe(hashSpace);
     });
 
     it('proves adversarial session-key ID placement changes the signed hash', () => {


### PR DESCRIPTION
## Problem

`PackAppSessionKeyStateV1` encoded application and app-session IDs by treating each string as hex (`common.HexToHash` in Go, a matching `hexToBytes32` in TypeScript). Any string containing a non-hex character was silently collapsed to the same `0x000...000` bytes32, so `"app-1"` and `"app-2"` — and any other human-readable identifiers — produced **identical signing payloads**. This opened a phishing vector: a signature collected for Integration A's `"app-1"` could be submitted unchanged to authorize Integration B's `"app-2"`.

## Fixes

- **Go** (`pkg/app/session_key_v1.go`): replace `common.HexToHash(id)` → `crypto.Keccak256Hash([]byte(id))` for both `applicationIDHashes` and `appSessionIDHashes`.
- **TypeScript** (`sdk/ts/src/app/packing.ts`): remove the broken `hexToBytes32` helper; replace with `(id) => keccak256(toHex(id))`. Remove now-unused `pad` import.
- **Drift vectors** updated in Go test and TS drift test (new hash: `0x6d404fa6...`). Go and TypeScript produce identical output, confirming cross-SDK consistency.
- **Collision tests** added in both languages covering `ApplicationIDs` and `AppSessionIDs` with human-readable IDs (`"app-1"`, `"app-2"`, `"trading"`, `"gaming"`, `"defi"`) and boundary cases (empty string vs whitespace).

## Notes

This is a **breaking change**: existing signed session key states are invalidated. Clients must re-sign with the updated SDK after the server deploys this change.