### PR TITLE
MF2-C02: bound ledger values to Solidity uint256/int256 ranges

### DIFF
--- a/nitronode/api/app_session_v1/submit_deposit_state_test.go
+++ b/nitronode/api/app_session_v1/submit_deposit_state_test.go
@@ -196,6 +196,7 @@ func TestSubmitDepositState_Success(t *testing.T) {
 	mockStore.On("GetLastUserState", participant1, asset, false).Return(currentUserState, nil).Once()
 	mockStore.On("EnsureNoOngoingStateTransitions", participant1, asset).Return(nil).Once()
 	mockAssetStore.On("GetAssetDecimals", asset).Return(uint8(6), nil)
+	mockAssetStore.On("GetTokenDecimals", uint64(1), "0xTokenAddress").Return(uint8(6), nil).Maybe()
 	mockStore.On("GetApp", "test-app").Return(&app.AppInfoV1{
 		App: app.AppV1{ID: "test-app", OwnerWallet: "0x0000000000000000000000000000000000000001"},
 	}, nil).Maybe()
@@ -545,6 +546,7 @@ func TestSubmitDepositState_QuorumNotMet(t *testing.T) {
 	mockStore.On("GetLastUserState", participant1, asset, false).Return(currentUserState, nil).Once()
 	mockStore.On("EnsureNoOngoingStateTransitions", participant1, asset).Return(nil).Once()
 	mockAssetStore.On("GetAssetDecimals", asset).Return(uint8(6), nil)
+	mockAssetStore.On("GetTokenDecimals", uint64(1), "0xTokenAddress").Return(uint8(6), nil).Maybe()
 	mockStore.On("GetApp", "test-app").Return(&app.AppInfoV1{
 		App: app.AppV1{ID: "test-app", OwnerWallet: "0x0000000000000000000000000000000000000001"},
 	}, nil).Maybe()
@@ -692,6 +694,7 @@ func TestSubmitDepositState_AppRegistryDisabled(t *testing.T) {
 	mockStore.On("GetLastUserState", participant1, asset, false).Return(currentUserState, nil).Once()
 	mockStore.On("EnsureNoOngoingStateTransitions", participant1, asset).Return(nil).Once()
 	mockAssetStore.On("GetAssetDecimals", asset).Return(uint8(6), nil)
+	mockAssetStore.On("GetTokenDecimals", uint64(1), "0xTokenAddress").Return(uint8(6), nil).Maybe()
 	mockStore.On("GetAppSession", appSessionID).Return(existingAppSession, nil).Once()
 	mockStore.On("GetParticipantAllocations", appSessionID).Return(
 		map[string]map[string]decimal.Decimal{}, nil,
@@ -837,6 +840,7 @@ func TestSubmitDepositState_DuplicateAllocation_Rejected(t *testing.T) {
 	mockStore.On("GetLastUserState", participant1, asset, false).Return(currentUserState, nil).Once()
 	mockStore.On("EnsureNoOngoingStateTransitions", participant1, asset).Return(nil).Once()
 	mockAssetStore.On("GetAssetDecimals", asset).Return(uint8(6), nil)
+	mockAssetStore.On("GetTokenDecimals", uint64(1), "0xTokenAddress").Return(uint8(6), nil).Maybe()
 	mockStore.On("GetParticipantAllocations", appSessionID).Return(
 		map[string]map[string]decimal.Decimal{}, nil,
 	).Once()
@@ -970,6 +974,7 @@ func TestSubmitDepositState_InvalidDecimalPrecision_Rejected(t *testing.T) {
 	mockStore.On("GetLastUserState", participant1, asset, false).Return(currentUserState, nil).Once()
 	mockStore.On("EnsureNoOngoingStateTransitions", participant1, asset).Return(nil).Once()
 	mockAssetStore.On("GetAssetDecimals", asset).Return(uint8(6), nil)
+	mockAssetStore.On("GetTokenDecimals", uint64(1), "0xTokenAddress").Return(uint8(6), nil).Maybe()
 	mockStore.On("GetParticipantAllocations", appSessionID).Return(
 		map[string]map[string]decimal.Decimal{}, nil,
 	).Once()

--- a/pkg/blockchain/evm/blockchain_client.go
+++ b/pkg/blockchain/evm/blockchain_client.go
@@ -251,7 +251,7 @@ func (c *BlockchainClient) Deposit(token string, amount decimal.Decimal) (string
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to get token decimals for token %s", token)
 	}
-	amountBig, err := core.DecimalToBigInt(amount, decimals)
+	amountBig, err := core.DecimalToUint256(amount, decimals)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to convert amount %s to big.Int", amount.String())
 	}
@@ -280,7 +280,7 @@ func (c *BlockchainClient) Withdraw(to, token string, amount decimal.Decimal) (s
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to get token decimals for token %s", token)
 	}
-	amountBig, err := core.DecimalToBigInt(amount, decimals)
+	amountBig, err := core.DecimalToUint256(amount, decimals)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to convert amount %s to big.Int", amount.String())
 	}
@@ -315,7 +315,7 @@ func (c *BlockchainClient) Approve(asset string, amount decimal.Decimal) (string
 		return "", errors.Wrapf(err, "failed to get token decimals for %s", asset)
 	}
 
-	amountBig, err := core.DecimalToBigInt(amount, decimals)
+	amountBig, err := core.DecimalToUint256(amount, decimals)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to convert amount %s to big.Int", amount.String())
 	}
@@ -375,7 +375,7 @@ func (c *BlockchainClient) Create(def core.ChannelDefinition, initCCS core.State
 		}
 
 		if contractState.HomeLedger.Token == (common.Address{}) {
-			value, err := core.DecimalToBigInt(initCCS.Transition.Amount, contractState.HomeLedger.Decimals)
+			value, err := core.DecimalToUint256(initCCS.Transition.Amount, contractState.HomeLedger.Decimals)
 			if err != nil {
 				return "", errors.Wrap(err, "failed to convert native deposit amount to wei")
 			}
@@ -468,7 +468,7 @@ func (c *BlockchainClient) Checkpoint(candidate core.State) (string, error) {
 		}
 
 		if contractCandidate.HomeLedger.Token == (common.Address{}) {
-			value, valueErr := core.DecimalToBigInt(candidate.Transition.Amount, contractCandidate.HomeLedger.Decimals)
+			value, valueErr := core.DecimalToUint256(candidate.Transition.Amount, contractCandidate.HomeLedger.Decimals)
 			if valueErr != nil {
 				return "", errors.Wrap(valueErr, "failed to convert native deposit amount to wei")
 			}

--- a/pkg/blockchain/evm/locking_client.go
+++ b/pkg/blockchain/evm/locking_client.go
@@ -1,8 +1,6 @@
 package evm
 
 import (
-	"math/big"
-
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
@@ -223,10 +221,4 @@ func (c *LockingClient) GetBalance(user string) (decimal.Decimal, error) {
 	}
 
 	return decimal.NewFromBigInt(balance, -int32(c.tokenDecimals)), nil
-}
-
-// decimalToBigInt converts a decimal amount to *big.Int given token decimals.
-func decimalToBigInt(amount decimal.Decimal, decimals int32) *big.Int {
-	shifted := amount.Shift(decimals)
-	return shifted.BigInt()
 }

--- a/pkg/blockchain/evm/locking_client.go
+++ b/pkg/blockchain/evm/locking_client.go
@@ -100,7 +100,7 @@ func (c *LockingClient) Lock(targetWalletAddress string, amount decimal.Decimal)
 		return "", errors.New("transaction signer not configured")
 	}
 
-	amountBig, err := core.DecimalToBigInt(amount, c.tokenDecimals)
+	amountBig, err := core.DecimalToUint256(amount, c.tokenDecimals)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to convert amount with decimal precision")
 	}
@@ -182,7 +182,7 @@ func (c *LockingClient) ApproveToken(amount decimal.Decimal) (string, error) {
 		return "", errors.New("transaction signer not configured")
 	}
 
-	amountBig, err := core.DecimalToBigInt(amount, c.tokenDecimals)
+	amountBig, err := core.DecimalToUint256(amount, c.tokenDecimals)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to convert amount with decimal precision")
 	}

--- a/pkg/blockchain/evm/utils.go
+++ b/pkg/blockchain/evm/utils.go
@@ -163,24 +163,24 @@ func coreStateToContractState(state core.State, tokenGetter func(blockchainID ui
 func coreLedgerToContractLedger(ledger core.Ledger, decimals uint8) (Ledger, error) {
 	tokenAddr := common.HexToAddress(ledger.TokenAddress)
 
-	userAllocation, err := core.DecimalToBigInt(ledger.UserBalance, decimals)
+	userAllocation, err := core.DecimalToUint256(ledger.UserBalance, decimals)
 	if err != nil {
-		return Ledger{}, errors.Wrap(err, "failed to convert user balance to big.Int")
+		return Ledger{}, errors.Wrap(err, "failed to convert user balance to uint256")
 	}
 
-	userNetFlow, err := core.DecimalToBigInt(ledger.UserNetFlow, decimals)
+	userNetFlow, err := core.DecimalToInt256(ledger.UserNetFlow, decimals)
 	if err != nil {
-		return Ledger{}, errors.Wrap(err, "failed to convert user net flow to big.Int")
+		return Ledger{}, errors.Wrap(err, "failed to convert user net flow to int256")
 	}
 
-	nodeAllocation, err := core.DecimalToBigInt(ledger.NodeBalance, decimals)
+	nodeAllocation, err := core.DecimalToUint256(ledger.NodeBalance, decimals)
 	if err != nil {
-		return Ledger{}, errors.Wrap(err, "failed to convert node balance to big.Int")
+		return Ledger{}, errors.Wrap(err, "failed to convert node balance to uint256")
 	}
 
-	nodeNetFlow, err := core.DecimalToBigInt(ledger.NodeNetFlow, decimals)
+	nodeNetFlow, err := core.DecimalToInt256(ledger.NodeNetFlow, decimals)
 	if err != nil {
-		return Ledger{}, errors.Wrap(err, "failed to convert node net flow to big.Int")
+		return Ledger{}, errors.Wrap(err, "failed to convert node net flow to int256")
 	}
 
 	return Ledger{

--- a/pkg/blockchain/evm/utils_test.go
+++ b/pkg/blockchain/evm/utils_test.go
@@ -169,6 +169,45 @@ func TestCoreLedgerToContractLedger_Success(t *testing.T) {
 	require.Equal(t, expectedNodeNetFlow, result.NodeNetFlow)
 }
 
+func TestCoreLedgerToContractLedger_RejectsOutOfRangeValues(t *testing.T) {
+	t.Parallel()
+
+	tokenAddr := "0x1234567890123456789012345678901234567890"
+	overflow256 := new(big.Int).Lsh(big.NewInt(1), 256) // 2^256
+	overflow255 := new(big.Int).Lsh(big.NewInt(1), 255) // 2^255
+
+	newBaseLedger := func() core.Ledger {
+		return core.Ledger{
+			BlockchainID: 1,
+			TokenAddress: tokenAddr,
+			UserBalance:  decimal.Zero,
+			UserNetFlow:  decimal.Zero,
+			NodeBalance:  decimal.Zero,
+			NodeNetFlow:  decimal.Zero,
+		}
+	}
+
+	t.Run("user_balance_overflows_uint256", func(t *testing.T) {
+		t.Parallel()
+		ledger := newBaseLedger()
+		ledger.UserBalance = decimal.NewFromBigInt(overflow256, 0)
+
+		_, err := coreLedgerToContractLedger(ledger, 0)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "uint256")
+	})
+
+	t.Run("user_net_flow_overflows_int256", func(t *testing.T) {
+		t.Parallel()
+		ledger := newBaseLedger()
+		ledger.UserNetFlow = decimal.NewFromBigInt(overflow255, 0)
+
+		_, err := coreLedgerToContractLedger(ledger, 0)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "int256")
+	})
+}
+
 // ========= contractLedgerToCoreLedger Tests =========
 
 func TestContractLedgerToCoreLedger_Success(t *testing.T) {

--- a/pkg/core/state_advancer.go
+++ b/pkg/core/state_advancer.go
@@ -175,7 +175,11 @@ func (v *StateAdvancerV1) ValidateAdvancement(currentState, proposedState State)
 	if err := expectedState.HomeLedger.Equal(proposedState.HomeLedger); err != nil {
 		return fmt.Errorf("home ledger mismatch: %w", err)
 	}
-	if err := proposedState.HomeLedger.Validate(); err != nil {
+	homeDecimals, err := v.assetStore.GetTokenDecimals(proposedState.HomeLedger.BlockchainID, proposedState.HomeLedger.TokenAddress)
+	if err != nil {
+		return fmt.Errorf("failed to get home token decimals: %w", err)
+	}
+	if err := proposedState.HomeLedger.Validate(homeDecimals); err != nil {
 		return fmt.Errorf("invalid home ledger: %w", err)
 	}
 
@@ -197,7 +201,11 @@ func (v *StateAdvancerV1) ValidateAdvancement(currentState, proposedState State)
 		if err := expectedState.EscrowLedger.Equal(*proposedState.EscrowLedger); err != nil {
 			return fmt.Errorf("escrow ledger mismatch: %w", err)
 		}
-		if err := proposedState.EscrowLedger.Validate(); err != nil {
+		escrowDecimals, err := v.assetStore.GetTokenDecimals(proposedState.EscrowLedger.BlockchainID, proposedState.EscrowLedger.TokenAddress)
+		if err != nil {
+			return fmt.Errorf("failed to get escrow token decimals: %w", err)
+		}
+		if err := proposedState.EscrowLedger.Validate(escrowDecimals); err != nil {
 			return fmt.Errorf("invalid escrow ledger: %w", err)
 		}
 

--- a/pkg/core/state_advancer_test.go
+++ b/pkg/core/state_advancer_test.go
@@ -244,10 +244,10 @@ func TestValidateAdvancement_RejectsInvalidAmount(t *testing.T) {
 	}
 }
 
-// TestValidateAdvancement_RejectsOverflowDeposit regression-tests the bug
-// described in YNU-XXX: a home_deposit whose scaled amount exceeds uint256
-// would previously be accepted offchain while the signed payload truncated to
-// the low 256 bits. ValidateAdvancement now rejects such states before storage.
+// TestValidateAdvancement_RejectsOverflowDeposit ensures a home_deposit whose
+// scaled amount exceeds uint256 is rejected before storage. Without the bound
+// check, the offchain ledger would record the full amount while the signed
+// payload truncates to the low 256 bits.
 func TestValidateAdvancement_RejectsOverflowDeposit(t *testing.T) {
 	t.Parallel()
 
@@ -315,4 +315,57 @@ func TestValidateAdvancement_RejectsOverflowNetFlow(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid home ledger")
 	assert.Contains(t, err.Error(), "int256")
+}
+
+// TestValidateAdvancement_RejectsOverflowEscrowLedger covers the escrow branch
+// of the bound check: a state whose EscrowLedger already carries an out-of-range
+// UserBalance is rejected even when the home ledger and the new transition are
+// otherwise valid.
+func TestValidateAdvancement_RejectsOverflowEscrowLedger(t *testing.T) {
+	t.Parallel()
+
+	store := newMockAssetStore()
+	store.AddToken(1, "0xHomeToken", 0)
+	store.AddToken(2, "0xEscrowToken", 0)
+	advancer := NewStateAdvancerV1(store)
+
+	userWallet := "0xUser"
+	asset := "USDC"
+	homeChanID := "0xHomeChannelId"
+	escrowChanID := "0xEscrowChannelId"
+	sig := "0xSig"
+
+	// 2^256, one above the uint256 range.
+	overflow := new(big.Int).Lsh(big.NewInt(1), 256)
+	overflowDec := decimal.NewFromBigInt(overflow, 0)
+
+	current := NewVoidState(asset, userWallet)
+	current.HomeChannelID = &homeChanID
+	current.EscrowChannelID = &escrowChanID
+	current.ID = GetStateID(userWallet, asset, 0, 0)
+	current.HomeLedger.TokenAddress = "0xHomeToken"
+	current.HomeLedger.BlockchainID = 1
+	// Last transition is acknowledgement so NextState carries the escrow ledger
+	// forward and the new transition is not constrained.
+	current.Transition = *NewTransition(TransitionTypeAcknowledgement, "0x0", "0x0", decimal.Zero)
+	// Escrow balances sum to net flows so the equality check passes; the
+	// uint256 bound is what should reject the state.
+	current.EscrowLedger = &Ledger{
+		BlockchainID: 2,
+		TokenAddress: "0xEscrowToken",
+		UserBalance:  overflowDec,
+		UserNetFlow:  overflowDec,
+		NodeBalance:  decimal.Zero,
+		NodeNetFlow:  decimal.Zero,
+	}
+
+	proposed := current.NextState()
+	_, err := proposed.ApplyHomeDepositTransition(decimal.NewFromInt(1))
+	require.NoError(t, err)
+	proposed.UserSig = &sig
+
+	err = advancer.ValidateAdvancement(*current, *proposed)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid escrow ledger")
+	assert.Contains(t, err.Error(), "uint256")
 }

--- a/pkg/core/state_advancer_test.go
+++ b/pkg/core/state_advancer_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/shopspring/decimal"
@@ -241,4 +242,77 @@ func TestValidateAdvancement_RejectsInvalidAmount(t *testing.T) {
 			})
 		}
 	}
+}
+
+// TestValidateAdvancement_RejectsOverflowDeposit regression-tests the bug
+// described in YNU-XXX: a home_deposit whose scaled amount exceeds uint256
+// would previously be accepted offchain while the signed payload truncated to
+// the low 256 bits. ValidateAdvancement now rejects such states before storage.
+func TestValidateAdvancement_RejectsOverflowDeposit(t *testing.T) {
+	t.Parallel()
+
+	store := newMockAssetStore()
+	store.AddToken(1, "0xToken", 0) // decimals=0 so amount maps 1:1 to scaled
+	advancer := NewStateAdvancerV1(store)
+
+	userWallet := "0xUser"
+	asset := "USDC"
+	chanID := "0xHomeChannelId"
+	sig := "0xSig"
+
+	current := NewVoidState(asset, userWallet)
+	current.HomeChannelID = &chanID
+	current.ID = GetStateID(userWallet, asset, 0, 0)
+	current.HomeLedger.TokenAddress = "0xToken"
+	current.HomeLedger.BlockchainID = 1
+
+	// scaled = 2^256, one above the uint256 range.
+	overflow := new(big.Int).Lsh(big.NewInt(1), 256)
+	amount := decimal.NewFromBigInt(overflow, 0)
+
+	proposed := current.NextState()
+	_, err := proposed.ApplyHomeDepositTransition(amount)
+	require.NoError(t, err)
+	proposed.UserSig = &sig
+
+	err = advancer.ValidateAdvancement(*current, *proposed)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid home ledger")
+	assert.Contains(t, err.Error(), "uint256")
+}
+
+// TestValidateAdvancement_RejectsOverflowNetFlow checks that net-flow values
+// exceeding the int256 range are rejected. Reached by combining balances that
+// fit uint256 with a net flow that would overflow int256 (the signed type).
+func TestValidateAdvancement_RejectsOverflowNetFlow(t *testing.T) {
+	t.Parallel()
+
+	store := newMockAssetStore()
+	store.AddToken(1, "0xToken", 0)
+	advancer := NewStateAdvancerV1(store)
+
+	userWallet := "0xUser"
+	asset := "USDC"
+	chanID := "0xHomeChannelId"
+	sig := "0xSig"
+
+	current := NewVoidState(asset, userWallet)
+	current.HomeChannelID = &chanID
+	current.ID = GetStateID(userWallet, asset, 0, 0)
+	current.HomeLedger.TokenAddress = "0xToken"
+	current.HomeLedger.BlockchainID = 1
+
+	// 2^255, one above max int256
+	overInt := new(big.Int).Lsh(big.NewInt(1), 255)
+	amount := decimal.NewFromBigInt(overInt, 0)
+
+	proposed := current.NextState()
+	_, err := proposed.ApplyHomeDepositTransition(amount)
+	require.NoError(t, err)
+	proposed.UserSig = &sig
+
+	err = advancer.ValidateAdvancement(*current, *proposed)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid home ledger")
+	assert.Contains(t, err.Error(), "int256")
 }

--- a/pkg/core/state_packer.go
+++ b/pkg/core/state_packer.go
@@ -12,6 +12,64 @@ type StatePackerV1 struct {
 	assetStore AssetStore
 }
 
+// contractLedger mirrors the Solidity Ledger struct used inside the signed state
+// payload. Allocation fields are encoded as uint256 and must fit [0, 2^256-1];
+// net-flow fields are encoded as int256 and must fit [-2^255, 2^255-1].
+type contractLedger struct {
+	ChainId        uint64
+	Token          common.Address
+	Decimals       uint8
+	UserAllocation *big.Int
+	UserNetFlow    *big.Int
+	NodeAllocation *big.Int
+	NodeNetFlow    *big.Int
+}
+
+// Validate guards against any caller that constructs a contractLedger without
+// going through the bounds-checking decimal helpers, so values that would be
+// silently truncated by ABI encoding are rejected before signing.
+func (l contractLedger) Validate() error {
+	if err := checkUint256(l.UserAllocation); err != nil {
+		return fmt.Errorf("user allocation: %w", err)
+	}
+	if err := checkUint256(l.NodeAllocation); err != nil {
+		return fmt.Errorf("node allocation: %w", err)
+	}
+	if err := checkInt256(l.UserNetFlow); err != nil {
+		return fmt.Errorf("user net flow: %w", err)
+	}
+	if err := checkInt256(l.NodeNetFlow); err != nil {
+		return fmt.Errorf("node net flow: %w", err)
+	}
+	return nil
+}
+
+func checkUint256(v *big.Int) error {
+	if v == nil {
+		return fmt.Errorf("value is nil")
+	}
+	if v.Sign() < 0 {
+		return fmt.Errorf("value %s is negative", v.String())
+	}
+	if v.BitLen() > 256 {
+		return fmt.Errorf("value %s exceeds uint256 max (2^256-1)", v.String())
+	}
+	return nil
+}
+
+func checkInt256(v *big.Int) error {
+	if v == nil {
+		return fmt.Errorf("value is nil")
+	}
+	if v.Cmp(maxInt256) > 0 {
+		return fmt.Errorf("value %s exceeds int256 max (2^255-1)", v.String())
+	}
+	if v.Cmp(minInt256) < 0 {
+		return fmt.Errorf("value %s below int256 min (-2^255)", v.String())
+	}
+	return nil
+}
+
 func NewStatePackerV1(assetStore AssetStore) *StatePackerV1 {
 	return &StatePackerV1{
 		assetStore: assetStore,
@@ -62,36 +120,26 @@ func (p *StatePackerV1) packSigningData(state State) (common.Hash, []byte, error
 		{Type: ledgerType},  // nonHomeState
 	}
 
-	type contractLedger struct {
-		ChainId        uint64
-		Token          common.Address
-		Decimals       uint8
-		UserAllocation *big.Int
-		UserNetFlow    *big.Int
-		NodeAllocation *big.Int
-		NodeNetFlow    *big.Int
-	}
-
 	homeDecimals, err := p.assetStore.GetTokenDecimals(state.HomeLedger.BlockchainID, state.HomeLedger.TokenAddress)
 	if err != nil {
 		return common.Hash{}, nil, err
 	}
 
-	userBalanceBI, err := DecimalToBigInt(state.HomeLedger.UserBalance, homeDecimals)
+	userBalanceBI, err := DecimalToUint256(state.HomeLedger.UserBalance, homeDecimals)
 	if err != nil {
-		return common.Hash{}, nil, err
+		return common.Hash{}, nil, fmt.Errorf("home user balance: %w", err)
 	}
-	userNetFlowBI, err := DecimalToBigInt(state.HomeLedger.UserNetFlow, homeDecimals)
+	userNetFlowBI, err := DecimalToInt256(state.HomeLedger.UserNetFlow, homeDecimals)
 	if err != nil {
-		return common.Hash{}, nil, err
+		return common.Hash{}, nil, fmt.Errorf("home user net flow: %w", err)
 	}
-	nodeBalanceBI, err := DecimalToBigInt(state.HomeLedger.NodeBalance, homeDecimals)
+	nodeBalanceBI, err := DecimalToUint256(state.HomeLedger.NodeBalance, homeDecimals)
 	if err != nil {
-		return common.Hash{}, nil, err
+		return common.Hash{}, nil, fmt.Errorf("home node balance: %w", err)
 	}
-	nodeNetFlowBI, err := DecimalToBigInt(state.HomeLedger.NodeNetFlow, homeDecimals)
+	nodeNetFlowBI, err := DecimalToInt256(state.HomeLedger.NodeNetFlow, homeDecimals)
 	if err != nil {
-		return common.Hash{}, nil, err
+		return common.Hash{}, nil, fmt.Errorf("home node net flow: %w", err)
 	}
 
 	homeLedger := contractLedger{
@@ -112,21 +160,21 @@ func (p *StatePackerV1) packSigningData(state State) (common.Hash, []byte, error
 			return common.Hash{}, nil, err
 		}
 
-		escrowUserBalanceBI, err := DecimalToBigInt(state.EscrowLedger.UserBalance, escrowDecimals)
+		escrowUserBalanceBI, err := DecimalToUint256(state.EscrowLedger.UserBalance, escrowDecimals)
 		if err != nil {
-			return common.Hash{}, nil, err
+			return common.Hash{}, nil, fmt.Errorf("escrow user balance: %w", err)
 		}
-		escrowUserNetFlowBI, err := DecimalToBigInt(state.EscrowLedger.UserNetFlow, escrowDecimals)
+		escrowUserNetFlowBI, err := DecimalToInt256(state.EscrowLedger.UserNetFlow, escrowDecimals)
 		if err != nil {
-			return common.Hash{}, nil, err
+			return common.Hash{}, nil, fmt.Errorf("escrow user net flow: %w", err)
 		}
-		escrowNodeBalanceBI, err := DecimalToBigInt(state.EscrowLedger.NodeBalance, escrowDecimals)
+		escrowNodeBalanceBI, err := DecimalToUint256(state.EscrowLedger.NodeBalance, escrowDecimals)
 		if err != nil {
-			return common.Hash{}, nil, err
+			return common.Hash{}, nil, fmt.Errorf("escrow node balance: %w", err)
 		}
-		escrowNodeNetFlowBI, err := DecimalToBigInt(state.EscrowLedger.NodeNetFlow, escrowDecimals)
+		escrowNodeNetFlowBI, err := DecimalToInt256(state.EscrowLedger.NodeNetFlow, escrowDecimals)
 		if err != nil {
-			return common.Hash{}, nil, err
+			return common.Hash{}, nil, fmt.Errorf("escrow node net flow: %w", err)
 		}
 
 		nonHomeLedger = contractLedger{
@@ -148,6 +196,13 @@ func (p *StatePackerV1) packSigningData(state State) (common.Hash, []byte, error
 			NodeAllocation: big.NewInt(0),
 			NodeNetFlow:    big.NewInt(0),
 		}
+	}
+
+	if err := homeLedger.Validate(); err != nil {
+		return common.Hash{}, nil, fmt.Errorf("invalid home ledger for signing: %w", err)
+	}
+	if err := nonHomeLedger.Validate(); err != nil {
+		return common.Hash{}, nil, fmt.Errorf("invalid escrow ledger for signing: %w", err)
 	}
 
 	intent := TransitionToIntent(state.Transition)

--- a/pkg/core/state_packer_test.go
+++ b/pkg/core/state_packer_test.go
@@ -1,11 +1,13 @@
 package core
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPackState(t *testing.T) {
@@ -101,5 +103,62 @@ func TestPackState(t *testing.T) {
 		expectedPackedState := "0x3e9dd25a843e3a234c278c6f3fab3983949e2404b276cacb3c47ada06e00f74b0000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000022000000000000000000000000000000000000000000000000000000000000000180000000000000000000000000000000000000000000000000000000000000002756774c79382894c7bdc8e9fe73285e1650c10c820b05a8bba7d0aace4adb92a000000000000000000000000000000000000000000000000000000000000002a00000000000000000000000090b7e285ab6cf4e3a2487669dba3e339db8a332000000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000011e1a300000000000000000000000000000000000000000000000000000000000bebc2010000000000000000000000000000000000000000000000000000000000000000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffa0a1f010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
 		packedHex := hexutil.Encode(packed)
 		assert.Equal(t, expectedPackedState, packedHex, "Packed state should match expected value")
+	})
+}
+
+// TestPackState_RejectsOutOfRangeValues guards against ABI silently truncating
+// values to the low 256 bits. Each subtest sets a ledger field beyond its
+// Solidity type range and expects PackState to error.
+func TestPackState_RejectsOutOfRangeValues(t *testing.T) {
+	t.Parallel()
+
+	channelID := "0x3e9dd25a843e3a234c278c6f3fab3983949e2404b276cacb3c47ada06e00f74b"
+	overflow256 := new(big.Int).Lsh(big.NewInt(1), 256) // 2^256
+	overflow255 := new(big.Int).Lsh(big.NewInt(1), 255) // 2^255
+
+	newBaseState := func() State {
+		return State{
+			Version:       1,
+			Asset:         "test",
+			HomeChannelID: &channelID,
+			Transition:    *NewTransition(TransitionTypeHomeDeposit, "tx", "acct", decimal.NewFromInt(1)),
+			HomeLedger: Ledger{
+				BlockchainID: 42,
+				TokenAddress: "0x90b7E285ab6cf4e3A2487669dba3E339dB8a3320",
+				UserBalance:  decimal.Zero,
+				UserNetFlow:  decimal.Zero,
+				NodeBalance:  decimal.Zero,
+				NodeNetFlow:  decimal.Zero,
+			},
+		}
+	}
+
+	t.Run("user_balance_overflows_uint256", func(t *testing.T) {
+		t.Parallel()
+		store := newMockAssetStore()
+		store.AddToken(42, "0x90b7E285ab6cf4e3A2487669dba3E339dB8a3320", 0)
+
+		state := newBaseState()
+		state.HomeLedger.UserBalance = decimal.NewFromBigInt(overflow256, 0)
+		state.HomeLedger.UserNetFlow = decimal.NewFromBigInt(overflow256, 0)
+
+		_, err := NewStatePackerV1(store).PackState(state)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "uint256")
+	})
+
+	t.Run("user_net_flow_overflows_int256", func(t *testing.T) {
+		t.Parallel()
+		store := newMockAssetStore()
+		store.AddToken(42, "0x90b7E285ab6cf4e3A2487669dba3E339dB8a3320", 0)
+
+		state := newBaseState()
+		// balance fits uint256 but net flow exceeds int256
+		state.HomeLedger.UserBalance = decimal.NewFromBigInt(overflow255, 0)
+		state.HomeLedger.UserNetFlow = decimal.NewFromBigInt(overflow255, 0)
+
+		_, err := NewStatePackerV1(store).PackState(state)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "int256")
 	})
 }

--- a/pkg/core/state_packer_test.go
+++ b/pkg/core/state_packer_test.go
@@ -116,6 +116,9 @@ func TestPackState_RejectsOutOfRangeValues(t *testing.T) {
 	overflow256 := new(big.Int).Lsh(big.NewInt(1), 256) // 2^256
 	overflow255 := new(big.Int).Lsh(big.NewInt(1), 255) // 2^255
 
+	homeToken := "0x90b7E285ab6cf4e3A2487669dba3E339dB8a3320"
+	escrowToken := "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+
 	newBaseState := func() State {
 		return State{
 			Version:       1,
@@ -124,7 +127,7 @@ func TestPackState_RejectsOutOfRangeValues(t *testing.T) {
 			Transition:    *NewTransition(TransitionTypeHomeDeposit, "tx", "acct", decimal.NewFromInt(1)),
 			HomeLedger: Ledger{
 				BlockchainID: 42,
-				TokenAddress: "0x90b7E285ab6cf4e3A2487669dba3E339dB8a3320",
+				TokenAddress: homeToken,
 				UserBalance:  decimal.Zero,
 				UserNetFlow:  decimal.Zero,
 				NodeBalance:  decimal.Zero,
@@ -133,31 +136,71 @@ func TestPackState_RejectsOutOfRangeValues(t *testing.T) {
 		}
 	}
 
+	newEscrowLedger := func() *Ledger {
+		return &Ledger{
+			BlockchainID: 4242,
+			TokenAddress: escrowToken,
+			UserBalance:  decimal.Zero,
+			UserNetFlow:  decimal.Zero,
+			NodeBalance:  decimal.Zero,
+			NodeNetFlow:  decimal.Zero,
+		}
+	}
+
+	newStore := func() *mockAssetStore {
+		store := newMockAssetStore()
+		store.AddToken(42, homeToken, 0)
+		store.AddToken(4242, escrowToken, 0)
+		return store
+	}
+
 	t.Run("user_balance_overflows_uint256", func(t *testing.T) {
 		t.Parallel()
-		store := newMockAssetStore()
-		store.AddToken(42, "0x90b7E285ab6cf4e3A2487669dba3E339dB8a3320", 0)
 
 		state := newBaseState()
 		state.HomeLedger.UserBalance = decimal.NewFromBigInt(overflow256, 0)
 		state.HomeLedger.UserNetFlow = decimal.NewFromBigInt(overflow256, 0)
 
-		_, err := NewStatePackerV1(store).PackState(state)
+		_, err := NewStatePackerV1(newStore()).PackState(state)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "uint256")
 	})
 
 	t.Run("user_net_flow_overflows_int256", func(t *testing.T) {
 		t.Parallel()
-		store := newMockAssetStore()
-		store.AddToken(42, "0x90b7E285ab6cf4e3A2487669dba3E339dB8a3320", 0)
 
 		state := newBaseState()
 		// balance fits uint256 but net flow exceeds int256
 		state.HomeLedger.UserBalance = decimal.NewFromBigInt(overflow255, 0)
 		state.HomeLedger.UserNetFlow = decimal.NewFromBigInt(overflow255, 0)
 
-		_, err := NewStatePackerV1(store).PackState(state)
+		_, err := NewStatePackerV1(newStore()).PackState(state)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "int256")
+	})
+
+	t.Run("escrow_user_balance_overflows_uint256", func(t *testing.T) {
+		t.Parallel()
+
+		state := newBaseState()
+		state.EscrowLedger = newEscrowLedger()
+		state.EscrowLedger.UserBalance = decimal.NewFromBigInt(overflow256, 0)
+		state.EscrowLedger.UserNetFlow = decimal.NewFromBigInt(overflow256, 0)
+
+		_, err := NewStatePackerV1(newStore()).PackState(state)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "uint256")
+	})
+
+	t.Run("escrow_user_net_flow_overflows_int256", func(t *testing.T) {
+		t.Parallel()
+
+		state := newBaseState()
+		state.EscrowLedger = newEscrowLedger()
+		state.EscrowLedger.UserBalance = decimal.NewFromBigInt(overflow255, 0)
+		state.EscrowLedger.UserNetFlow = decimal.NewFromBigInt(overflow255, 0)
+
+		_, err := NewStatePackerV1(newStore()).PackState(state)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "int256")
 	})

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -600,7 +600,12 @@ func (l1 Ledger) Equal(l2 Ledger) error {
 	return nil
 }
 
-func (l Ledger) Validate() error {
+// Validate checks ledger invariants and ensures all four scaled values fit the
+// Solidity ABI ranges used for signing and onchain calls. Balances must fit
+// uint256 ([0, 2^256-1]); net flows must fit int256 ([-2^255, 2^255-1]).
+// assetDecimals is the token's decimal exponent, used to scale decimal values
+// to their smallest onchain units before the range check.
+func (l Ledger) Validate(assetDecimals uint8) error {
 	if l.TokenAddress == "" {
 		return fmt.Errorf("invalid token address")
 	}
@@ -617,6 +622,19 @@ func (l Ledger) Validate() error {
 	sumNetFlows := l.UserNetFlow.Add(l.NodeNetFlow)
 	if !sumBalances.Equal(sumNetFlows) {
 		return fmt.Errorf("ledger balances do not match net flows: balances=%s, net_flows=%s", sumBalances.String(), sumNetFlows.String())
+	}
+
+	if _, err := DecimalToUint256(l.UserBalance, assetDecimals); err != nil {
+		return fmt.Errorf("user balance out of uint256 range: %w", err)
+	}
+	if _, err := DecimalToUint256(l.NodeBalance, assetDecimals); err != nil {
+		return fmt.Errorf("node balance out of uint256 range: %w", err)
+	}
+	if _, err := DecimalToInt256(l.UserNetFlow, assetDecimals); err != nil {
+		return fmt.Errorf("user net flow out of int256 range: %w", err)
+	}
+	if _, err := DecimalToInt256(l.NodeNetFlow, assetDecimals); err != nil {
+		return fmt.Errorf("node net flow out of int256 range: %w", err)
 	}
 
 	return nil

--- a/pkg/core/types_test.go
+++ b/pkg/core/types_test.go
@@ -370,26 +370,26 @@ func TestLedger_Equal_Validate(t *testing.T) {
 	}
 	l2 := l1
 	assert.NoError(t, l1.Equal(l2))
-	assert.NoError(t, l1.Validate())
+	assert.NoError(t, l1.Validate(6))
 
 	l2.TokenAddress = "0xOther"
 	assert.Error(t, l1.Equal(l2))
 
 	lInvalid := l1
 	lInvalid.TokenAddress = ""
-	assert.Error(t, lInvalid.Validate())
+	assert.Error(t, lInvalid.Validate(6))
 
 	lInvalid = l1
 	lInvalid.BlockchainID = 0
-	assert.Error(t, lInvalid.Validate())
+	assert.Error(t, lInvalid.Validate(6))
 
 	lInvalid = l1
 	lInvalid.UserBalance = decimal.NewFromInt(-1)
-	assert.Error(t, lInvalid.Validate())
+	assert.Error(t, lInvalid.Validate(6))
 
 	lInvalid = l1
 	lInvalid.UserNetFlow = decimal.NewFromInt(999) // Mismatch
-	assert.Error(t, lInvalid.Validate())
+	assert.Error(t, lInvalid.Validate(6))
 }
 
 func TestTransactionType_String(t *testing.T) {

--- a/pkg/core/utils.go
+++ b/pkg/core/utils.go
@@ -7,9 +7,16 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
+	ethmath "github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/shopspring/decimal"
 )
+
+// maxInt256 = 2^255 - 1, the largest value representable as Solidity int256.
+var maxInt256 = new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 255), big.NewInt(1))
+
+// minInt256 = -2^255, the smallest value representable as Solidity int256.
+var minInt256 = new(big.Int).Neg(new(big.Int).Lsh(big.NewInt(1), 255))
 
 const (
 	// ChannelHubVersion is the version of the ChannelHub contract that this code is compatible with.
@@ -85,22 +92,54 @@ func ValidateDecimalPrecision(amount decimal.Decimal, maxDecimals uint8) error {
 	return nil
 }
 
-// DecimalToBigInt converts a decimal.Decimal amount to *big.Int scaled to the token's smallest unit.
-// For example, 1.23 USDC (6 decimals) becomes 1230000.
-// This is used when preparing amounts for smart contract calls.
-func DecimalToBigInt(amount decimal.Decimal, decimals uint8) (*big.Int, error) {
-	// 1. Calculate the multiplier (e.g., 10^6)
+// decimalToBigInt scales a decimal amount to the token's smallest unit and
+// returns an unbounded *big.Int. Internal helper for DecimalToUint256 /
+// DecimalToInt256; callers outside this file must use the bounded variants so
+// values exceeding the Solidity ABI range are rejected rather than silently
+// truncated.
+func decimalToBigInt(amount decimal.Decimal, decimals uint8) (*big.Int, error) {
 	multiplier := decimal.New(1, int32(decimals))
-
-	// 2. Scale the amount
 	scaled := amount.Mul(multiplier)
 
 	if !scaled.IsInteger() {
 		return nil, fmt.Errorf("amount %s exceeds maximum decimal precision: max %d decimals allowed", amount.String(), decimals)
 	}
 
-	// 4. Safe to convert
 	return scaled.BigInt(), nil
+}
+
+// DecimalToUint256 scales amount to the token's smallest unit and rejects values
+// outside the Solidity uint256 range [0, 2^256 - 1]. Use for allocation/balance
+// fields that are ABI-encoded as uint256 prior to signing or onchain submission.
+func DecimalToUint256(amount decimal.Decimal, decimals uint8) (*big.Int, error) {
+	scaled, err := decimalToBigInt(amount, decimals)
+	if err != nil {
+		return nil, err
+	}
+	if scaled.Sign() < 0 {
+		return nil, fmt.Errorf("amount %s is negative, expected uint256 range [0, 2^256-1]", amount.String())
+	}
+	if scaled.Cmp(ethmath.MaxBig256) > 0 {
+		return nil, fmt.Errorf("amount %s exceeds uint256 max (2^256-1)", amount.String())
+	}
+	return scaled, nil
+}
+
+// DecimalToInt256 scales amount to the token's smallest unit and rejects values
+// outside the Solidity int256 range [-2^255, 2^255 - 1]. Use for net-flow fields
+// that are ABI-encoded as int256 prior to signing or onchain submission.
+func DecimalToInt256(amount decimal.Decimal, decimals uint8) (*big.Int, error) {
+	scaled, err := decimalToBigInt(amount, decimals)
+	if err != nil {
+		return nil, err
+	}
+	if scaled.Cmp(maxInt256) > 0 {
+		return nil, fmt.Errorf("amount %s exceeds int256 max (2^255-1)", amount.String())
+	}
+	if scaled.Cmp(minInt256) < 0 {
+		return nil, fmt.Errorf("amount %s below int256 min (-2^255)", amount.String())
+	}
+	return scaled, nil
 }
 
 // getHomeChannelID is the internal implementation that generates a unique identifier for a primary channel

--- a/pkg/core/utils_test.go
+++ b/pkg/core/utils_test.go
@@ -370,7 +370,7 @@ func TestDecimalToBigInt(t *testing.T) {
 			amount, err := decimal.NewFromString(tt.amount)
 			assert.NoError(t, err, "Test setup error: invalid amount string")
 
-			result, err := DecimalToBigInt(amount, tt.decimals)
+			result, err := decimalToBigInt(amount, tt.decimals)
 			assert.NoError(t, err)
 
 			expected, ok := new(big.Int).SetString(tt.expected, 10)
@@ -386,7 +386,7 @@ func TestDecimalToBigInt_NegativeAmounts(t *testing.T) {
 	t.Run("negative_usdc", func(t *testing.T) {
 		t.Parallel()
 		amount := decimal.NewFromFloat(-1.23)
-		result, err := DecimalToBigInt(amount, 6)
+		result, err := decimalToBigInt(amount, 6)
 		assert.NoError(t, err)
 		expected := big.NewInt(-1230000)
 		assert.Equal(t, expected.String(), result.String(), "Negative amounts should be handled correctly")
@@ -395,7 +395,7 @@ func TestDecimalToBigInt_NegativeAmounts(t *testing.T) {
 	t.Run("negative_eth", func(t *testing.T) {
 		t.Parallel()
 		amount := decimal.NewFromFloat(-0.5)
-		result, err := DecimalToBigInt(amount, 18)
+		result, err := decimalToBigInt(amount, 18)
 		assert.NoError(t, err)
 		expected, _ := new(big.Int).SetString("-500000000000000000", 10)
 		assert.Equal(t, expected.String(), result.String(), "Negative ETH amount should convert correctly")
@@ -404,7 +404,7 @@ func TestDecimalToBigInt_NegativeAmounts(t *testing.T) {
 	t.Run("negative_zero", func(t *testing.T) {
 		t.Parallel()
 		amount := decimal.NewFromInt(0)
-		result, err := DecimalToBigInt(amount, 6)
+		result, err := decimalToBigInt(amount, 6)
 		assert.NoError(t, err)
 		expected := big.NewInt(0)
 		assert.Equal(t, expected.String(), result.String(), "Zero should always be zero")
@@ -418,7 +418,7 @@ func TestDecimalToBigInt_EdgeCases(t *testing.T) {
 		// Test with a very large amount
 		amount, err := decimal.NewFromString("999999999999999999.123456")
 		assert.NoError(t, err)
-		result, err := DecimalToBigInt(amount, 6)
+		result, err := decimalToBigInt(amount, 6)
 		assert.NoError(t, err)
 		// 999999999999999999.123456 * 10^6 = 999999999999999999123456
 		expected, ok := new(big.Int).SetString("999999999999999999123456", 10)
@@ -430,7 +430,7 @@ func TestDecimalToBigInt_EdgeCases(t *testing.T) {
 		t.Parallel()
 		// Test with an amount that has more decimals than supported
 		amount := decimal.NewFromFloat(0.0000001) // 7 decimals
-		_, err := DecimalToBigInt(amount, 6)      // Only 6 decimal precision
+		_, err := decimalToBigInt(amount, 6)      // Only 6 decimal precision
 		// This should return an error because the amount has more decimal places than allowed
 		// After scaling: 0.0000001 * 10^6 = 0.1, which still has a fractional part
 		assert.Error(t, err, "Amount with more decimals than supported should return an error")
@@ -441,7 +441,7 @@ func TestDecimalToBigInt_EdgeCases(t *testing.T) {
 		t.Parallel()
 		// Test with maximum uint8 value for decimals (not practical, but edge case)
 		amount := decimal.NewFromInt(1)
-		result, err := DecimalToBigInt(amount, 255)
+		result, err := decimalToBigInt(amount, 255)
 		assert.NoError(t, err)
 		// 1 * 10^255 should work
 		expected := new(big.Int).Exp(big.NewInt(10), big.NewInt(255), nil)
@@ -453,7 +453,7 @@ func TestDecimalToBigInt_EdgeCases(t *testing.T) {
 		// Test that we don't lose precision during conversion
 		amount, err := decimal.NewFromString("123.456789")
 		assert.NoError(t, err)
-		result, err := DecimalToBigInt(amount, 6)
+		result, err := decimalToBigInt(amount, 6)
 		assert.NoError(t, err)
 		// 123.456789 * 10^6 = 123456789
 		expected := big.NewInt(123456789)
@@ -471,7 +471,7 @@ func TestDecimalToBigInt_RoundTrip(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Convert to big.Int
-		bigIntValue, err := DecimalToBigInt(amount, 6)
+		bigIntValue, err := decimalToBigInt(amount, 6)
 		assert.NoError(t, err)
 		// Convert back to decimal
 		divisor := decimal.New(1, 6) // 10^6
@@ -722,5 +722,111 @@ func TestGetStateTransitionsHash(t *testing.T) {
 			"0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",                         // 20-byte address
 			decimal.NewFromInt(-100)))
 		assert.NoError(t, err)
+	})
+}
+
+func TestDecimalToUint256(t *testing.T) {
+	t.Parallel()
+
+	// 2^256 - 1, max uint256
+	maxUint256, ok := new(big.Int).SetString("115792089237316195423570985008687907853269984665640564039457584007913129639935", 10)
+	require.True(t, ok)
+	// 2^256, one above the limit
+	overflow := new(big.Int).Add(maxUint256, big.NewInt(1))
+
+	t.Run("zero", func(t *testing.T) {
+		t.Parallel()
+		got, err := DecimalToUint256(decimal.Zero, 18)
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), got.Int64())
+	})
+
+	t.Run("small_positive", func(t *testing.T) {
+		t.Parallel()
+		amount := decimal.NewFromInt(1234)
+		got, err := DecimalToUint256(amount, 0)
+		require.NoError(t, err)
+		assert.Equal(t, int64(1234), got.Int64())
+	})
+
+	t.Run("max_uint256_accepted", func(t *testing.T) {
+		t.Parallel()
+		amount := decimal.NewFromBigInt(maxUint256, 0)
+		got, err := DecimalToUint256(amount, 0)
+		require.NoError(t, err)
+		assert.Equal(t, 0, got.Cmp(maxUint256))
+	})
+
+	t.Run("one_over_uint256_rejected", func(t *testing.T) {
+		t.Parallel()
+		amount := decimal.NewFromBigInt(overflow, 0)
+		_, err := DecimalToUint256(amount, 0)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeds uint256 max")
+	})
+
+	t.Run("scaling_pushes_over_uint256", func(t *testing.T) {
+		t.Parallel()
+		// value at uint256 max with 1 extra decimal of scale exceeds the range.
+		amount := decimal.NewFromBigInt(maxUint256, 0)
+		_, err := DecimalToUint256(amount, 1)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeds uint256 max")
+	})
+
+	t.Run("negative_rejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := DecimalToUint256(decimal.NewFromInt(-1), 0)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "negative")
+	})
+}
+
+func TestDecimalToInt256(t *testing.T) {
+	t.Parallel()
+
+	maxInt, ok := new(big.Int).SetString("57896044618658097711785492504343953926634992332820282019728792003956564819967", 10) // 2^255 - 1
+	require.True(t, ok)
+	minInt := new(big.Int).Neg(new(big.Int).Lsh(big.NewInt(1), 255)) // -2^255
+	overMax := new(big.Int).Add(maxInt, big.NewInt(1))
+	underMin := new(big.Int).Sub(minInt, big.NewInt(1))
+
+	t.Run("zero", func(t *testing.T) {
+		t.Parallel()
+		got, err := DecimalToInt256(decimal.Zero, 18)
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), got.Int64())
+	})
+
+	t.Run("max_int256_accepted", func(t *testing.T) {
+		t.Parallel()
+		amount := decimal.NewFromBigInt(maxInt, 0)
+		got, err := DecimalToInt256(amount, 0)
+		require.NoError(t, err)
+		assert.Equal(t, 0, got.Cmp(maxInt))
+	})
+
+	t.Run("min_int256_accepted", func(t *testing.T) {
+		t.Parallel()
+		amount := decimal.NewFromBigInt(minInt, 0)
+		got, err := DecimalToInt256(amount, 0)
+		require.NoError(t, err)
+		assert.Equal(t, 0, got.Cmp(minInt))
+	})
+
+	t.Run("one_over_max_rejected", func(t *testing.T) {
+		t.Parallel()
+		amount := decimal.NewFromBigInt(overMax, 0)
+		_, err := DecimalToInt256(amount, 0)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeds int256 max")
+	})
+
+	t.Run("one_under_min_rejected", func(t *testing.T) {
+		t.Parallel()
+		amount := decimal.NewFromBigInt(underMin, 0)
+		_, err := DecimalToInt256(amount, 0)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "below int256 min")
 	})
 }


### PR DESCRIPTION
## Summary

Reject ledger states whose scaled values fall outside the Solidity ABI ranges used for signing and onchain calls. A caller could otherwise submit a `home_deposit` whose raw amount is `2^256 + X`; the node would store the inflated offchain balance, but the signed EVM message and onchain calldata would only carry the low 256 bits, allowing the inflated balance to drain the node vault through a normal `transfer_send`.

- New `core.DecimalToUint256` / `core.DecimalToInt256` wrap the (now private) scaling helper and enforce `[0, 2^256-1]` and `[-2^255, 2^255-1]` respectively.
- `Ledger.Validate` now takes `assetDecimals` and bound-checks every scaled field.
- `StateAdvancerV1` looks up token decimals from the asset store and passes them in, so inflated state is rejected before the DB write.
- `StatePackerV1` promotes `contractLedger` to package scope, runs a `Validate()` guard on it before signing, and uses the bounded helpers when converting decimals.
- `coreLedgerToContractLedger` and the remaining `DepositToNode` / `Withdraw` / `Approve` / native deposit `Value` paths swap to `DecimalToUint256`, so onchain submission is gated by the same check.

Defense in depth: every layer that materialises a `*big.Int` from a ledger decimal now refuses out-of-range values, instead of relying on a single chokepoint.

## Test plan

- [x] `go vet ./...`
- [x] `go test ./...`
- [x] New unit tests in `pkg/core/utils_test.go` for `DecimalToUint256` / `DecimalToInt256` boundaries (max, max+1, negative, scaling-induced overflow).
- [x] `pkg/core/state_packer_test.go::TestPackState_RejectsOutOfRangeValues` — packer-level regression for both uint256 and int256 fields.
- [x] `pkg/core/state_advancer_test.go::TestValidateAdvancement_RejectsOverflowDeposit` — `home_deposit` with amount `2^256` is rejected before DB write.
- [x] `pkg/core/state_advancer_test.go::TestValidateAdvancement_RejectsOverflowNetFlow` — net flow `2^255` is rejected.
- [x] Existing `app_session_v1` deposit-state tests updated to stub the new `GetTokenDecimals` call now made by the advancer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)