### PR TITLE
MF2-M02: accept pre-finalize escrow version in ongoing check

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -532,7 +532,14 @@ api:
                 - message: channel_not_found
                   description: The specified channel was not found
             - name: get_escrow_channel
-              description: Retrieve current on-chain escrow channel information
+              description: |
+                Retrieve current on-chain escrow channel information.
+
+                Note: when the escrow channel has been closed by the on-chain
+                purge queue (no signed FINALIZE_ESCROW_DEPOSIT was received
+                before expiry), `state_version` on the returned channel reflects
+                the initiate version (N) and does not advance to the finalize
+                version (N+1).
               request:
                 - field_name: escrow_channel_id
                   type: string

--- a/nitronode/api/channel_v1/get_escrow_channel.go
+++ b/nitronode/api/channel_v1/get_escrow_channel.go
@@ -6,6 +6,11 @@ import (
 )
 
 // GetEscrowChannel retrieves current on-chain escrow channel information.
+//
+// Note: when the escrow channel has been closed by the on-chain purge queue
+// (no signed FINALIZE_ESCROW_DEPOSIT was received before expiry), StateVersion
+// on the returned channel reflects the initiate version (N) and does not
+// advance to the finalize version (N+1).
 func (h *Handler) GetEscrowChannel(c *rpc.Context) {
 	var req rpc.ChannelsV1GetEscrowChannelRequest
 	if err := c.Request.Payload.Translate(&req); err != nil {

--- a/nitronode/store/database/db_store.go
+++ b/nitronode/store/database/db_store.go
@@ -245,9 +245,13 @@ func (s *DBStore) EnsureNoOngoingStateTransitions(wallet, asset string) error {
 // Validation logic by latest signed transition type:
 //   - escrow_lock / mutual_lock: always considered ongoing (no finalization yet)
 //   - escrow_deposit: considered settled when the on-chain escrow channel version
-//     equals the signed state version (finalize landed) or is exactly one behind
-//     (initiate state; finalize or on-chain purge has not landed yet, but the purge
-//     queue makes it terminal — do not block receiver-side state issuance)
+//     equals the signed state version (finalize landed). When the chain is exactly
+//     one behind, the signed N+1 finalize state lives off-chain and is gated on
+//     the escrow channel status: allowed for Open (protocol-intended steady state
+//     before the purge queue fires) and Closed (post-purge or post-finalize);
+//     blocked for Challenged (on-chain resolution still racing — finalize tx may
+//     not land, escrow chain may settle at INITIATE, and replaying N+1 later
+//     could violate engine invariants).
 //   - escrow_withdraw: considered ongoing while the on-chain escrow channel state
 //     version has not caught up with the signed state version
 //   - any other transition: not an escrow operation, allow
@@ -258,6 +262,7 @@ func (s *DBStore) EnsureNoOngoingEscrowOperation(wallet, asset string) error {
 		TransitionType       core.TransitionType
 		StateVersion         uint64
 		EscrowChannelVersion *uint64
+		EscrowChannelStatus  *core.ChannelStatus
 	}
 
 	var result escrowCheck
@@ -265,7 +270,8 @@ func (s *DBStore) EnsureNoOngoingEscrowOperation(wallet, asset string) error {
 		SELECT
 			s.transition_type as transition_type,
 			s.version as state_version,
-			ec.state_version as escrow_channel_version
+			ec.state_version as escrow_channel_version,
+			ec.status as escrow_channel_status
 		FROM channel_states s
 		LEFT JOIN channels ec ON ec.channel_id = s.escrow_channel_id
 		WHERE s.user_wallet = ?
@@ -292,12 +298,33 @@ func (s *DBStore) EnsureNoOngoingEscrowOperation(wallet, asset string) error {
 
 	case core.TransitionTypeEscrowDeposit:
 		// Accept escrow channel at signed state version (finalize landed) or one
-		// behind (initiate state; finalize/purge has not landed yet, but is terminal
-		// per on-chain purge queue, so do not block receiver-side state issuance).
+		// behind (signed N+1 finalize sits off-chain; on-chain still at INITIATE
+		// version N). The one-behind branch is status-gated: Open is the protocol-
+		// intended steady state until the purge queue fires, Closed covers post-
+		// purge and post-finalize. Challenged is blocked because the on-chain
+		// resolution is still racing — finalize may not land in time, the escrow
+		// chain may settle at INITIATE, and replaying N+1 later could violate
+		// engine invariants.
 		// Compare via *v + 1 == StateVersion to avoid uint underflow when version is 0.
-		if result.EscrowChannelVersion == nil ||
-			(*result.EscrowChannelVersion != result.StateVersion &&
-				*result.EscrowChannelVersion+1 != result.StateVersion) {
+		if result.EscrowChannelVersion == nil {
+			return fmt.Errorf("escrow deposit finalization is still ongoing")
+		}
+		onChain := *result.EscrowChannelVersion
+		signed := result.StateVersion
+		switch {
+		case onChain == signed:
+			// finalize already landed or signed state is older — allow
+		case onChain+1 == signed:
+			if result.EscrowChannelStatus == nil {
+				return fmt.Errorf("escrow deposit finalization is still ongoing")
+			}
+			switch *result.EscrowChannelStatus {
+			case core.ChannelStatusOpen, core.ChannelStatusClosed:
+				// allow
+			default:
+				return fmt.Errorf("escrow deposit finalization is still ongoing")
+			}
+		default:
 			return fmt.Errorf("escrow deposit finalization is still ongoing")
 		}
 

--- a/nitronode/store/database/db_store.go
+++ b/nitronode/store/database/db_store.go
@@ -244,8 +244,12 @@ func (s *DBStore) EnsureNoOngoingStateTransitions(wallet, asset string) error {
 //
 // Validation logic by latest signed transition type:
 //   - escrow_lock / mutual_lock: always considered ongoing (no finalization yet)
-//   - escrow_deposit / escrow_withdraw: only considered ongoing when the on-chain
-//     escrow channel state version has not caught up with the signed state version
+//   - escrow_deposit: considered settled when the on-chain escrow channel version
+//     equals the signed state version (finalize landed) or is exactly one behind
+//     (initiate state; finalize or on-chain purge has not landed yet, but the purge
+//     queue makes it terminal — do not block receiver-side state issuance)
+//   - escrow_withdraw: considered ongoing while the on-chain escrow channel state
+//     version has not caught up with the signed state version
 //   - any other transition: not an escrow operation, allow
 func (s *DBStore) EnsureNoOngoingEscrowOperation(wallet, asset string) error {
 	wallet = strings.ToLower(wallet)
@@ -287,7 +291,13 @@ func (s *DBStore) EnsureNoOngoingEscrowOperation(wallet, asset string) error {
 		return fmt.Errorf("mutual lock is still ongoing")
 
 	case core.TransitionTypeEscrowDeposit:
-		if result.EscrowChannelVersion == nil || result.StateVersion != *result.EscrowChannelVersion {
+		// Accept escrow channel at signed state version (finalize landed) or one
+		// behind (initiate state; finalize/purge has not landed yet, but is terminal
+		// per on-chain purge queue, so do not block receiver-side state issuance).
+		// Compare via *v + 1 == StateVersion to avoid uint underflow when version is 0.
+		if result.EscrowChannelVersion == nil ||
+			(*result.EscrowChannelVersion != result.StateVersion &&
+				*result.EscrowChannelVersion+1 != result.StateVersion) {
 			return fmt.Errorf("escrow deposit finalization is still ongoing")
 		}
 

--- a/nitronode/store/database/db_store_test.go
+++ b/nitronode/store/database/db_store_test.go
@@ -1126,10 +1126,10 @@ func TestDBStore_EnsureNoOngoingEscrowOperation(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("EscrowDeposit - chain one version behind (finalize/purge pending) - allow", func(t *testing.T) {
-		// Signed finalize state is N+1; on-chain escrow channel may still be at
-		// initiate version N until finalize or purge lands. Purge queue makes
-		// this terminal, so receiver-side state issuance must not be blocked.
+	t.Run("EscrowDeposit - Open one-behind (pre-purge happy path) - allow", func(t *testing.T) {
+		// Signed finalize state is N+1; on-chain escrow channel is at initiate
+		// version N with Status=Open. This is the protocol-intended steady state
+		// until the purge queue fires, so receiver-side issuance must not block.
 		db, cleanup := SetupTestDB(t)
 		defer cleanup()
 
@@ -1141,6 +1141,26 @@ func TestDBStore_EnsureNoOngoingEscrowOperation(t *testing.T) {
 
 		err := store.EnsureNoOngoingEscrowOperation(wallet, asset)
 		require.NoError(t, err)
+	})
+
+	t.Run("EscrowDeposit - Challenged one-behind - block", func(t *testing.T) {
+		// Signed finalize state is N+1; on-chain channel is Challenged at N.
+		// Resolution is racing (finalize tx may not land, escrow chain may settle
+		// at INITIATE) — block receiver-side issuance until status clears.
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+
+		store := NewDBStore(db)
+		require.NoError(t, store.CreateChannel(homeChannel))
+		challengedEscrow := newEscrowChannel(1)
+		challengedEscrow.Status = core.ChannelStatusChallenged
+		require.NoError(t, store.CreateChannel(challengedEscrow))
+
+		storeState(t, store, newSignedState(2, core.TransitionTypeEscrowDeposit, true))
+
+		err := store.EnsureNoOngoingEscrowOperation(wallet, asset)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "escrow deposit finalization is still ongoing")
 	})
 
 	t.Run("EscrowDeposit - chain more than one version behind - block", func(t *testing.T) {

--- a/nitronode/store/database/db_store_test.go
+++ b/nitronode/store/database/db_store_test.go
@@ -1126,7 +1126,10 @@ func TestDBStore_EnsureNoOngoingEscrowOperation(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("EscrowDeposit - chain not synced - block", func(t *testing.T) {
+	t.Run("EscrowDeposit - chain one version behind (finalize/purge pending) - allow", func(t *testing.T) {
+		// Signed finalize state is N+1; on-chain escrow channel may still be at
+		// initiate version N until finalize or purge lands. Purge queue makes
+		// this terminal, so receiver-side state issuance must not be blocked.
 		db, cleanup := SetupTestDB(t)
 		defer cleanup()
 
@@ -1137,8 +1140,40 @@ func TestDBStore_EnsureNoOngoingEscrowOperation(t *testing.T) {
 		storeState(t, store, newSignedState(2, core.TransitionTypeEscrowDeposit, true))
 
 		err := store.EnsureNoOngoingEscrowOperation(wallet, asset)
+		require.NoError(t, err)
+	})
+
+	t.Run("EscrowDeposit - chain more than one version behind - block", func(t *testing.T) {
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+
+		store := NewDBStore(db)
+		require.NoError(t, store.CreateChannel(homeChannel))
+		require.NoError(t, store.CreateChannel(newEscrowChannel(0)))
+
+		storeState(t, store, newSignedState(2, core.TransitionTypeEscrowDeposit, true))
+
+		err := store.EnsureNoOngoingEscrowOperation(wallet, asset)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "escrow deposit finalization is still ongoing")
+	})
+
+	t.Run("EscrowDeposit - chain version after purge close - allow", func(t *testing.T) {
+		// Simulates HandleEscrowDepositsPurged: channel marked Closed but
+		// StateVersion preserved at initiate (N) while signed state is finalize (N+1).
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+
+		store := NewDBStore(db)
+		require.NoError(t, store.CreateChannel(homeChannel))
+		purgedEscrow := newEscrowChannel(1)
+		purgedEscrow.Status = core.ChannelStatusClosed
+		require.NoError(t, store.CreateChannel(purgedEscrow))
+
+		storeState(t, store, newSignedState(2, core.TransitionTypeEscrowDeposit, true))
+
+		err := store.EnsureNoOngoingEscrowOperation(wallet, asset)
+		require.NoError(t, err)
 	})
 
 	t.Run("EscrowWithdraw - chain caught up - allow", func(t *testing.T) {

--- a/sdk/go/channel.go
+++ b/sdk/go/channel.go
@@ -755,6 +755,11 @@ func (c *Client) GetHomeChannel(ctx context.Context, wallet, asset string) (*cor
 //   - Channel information for the escrow channel
 //   - Error if the request fails
 //
+// Note: when the escrow channel has been closed by the on-chain purge queue
+// (no signed FINALIZE_ESCROW_DEPOSIT was received before expiry), StateVersion
+// on the returned channel reflects the initiate version (N) and does not advance
+// to the finalize version (N+1).
+//
 // Example:
 //
 //	channel, err := client.GetEscrowChannel(ctx, "0x1234...")

--- a/sdk/ts/src/client.ts
+++ b/sdk/ts/src/client.ts
@@ -1279,6 +1279,11 @@ export class Client {
   /**
    * GetEscrowChannel retrieves escrow channel information for a specific channel ID.
    *
+   * Note: when the escrow channel has been closed by the on-chain purge queue
+   * (no signed FINALIZE_ESCROW_DEPOSIT was received before expiry), `stateVersion`
+   * on the returned channel reflects the initiate version (N) and does not advance
+   * to the finalize version (N+1).
+   *
    * @param escrowChannelId - The escrow channel ID to query
    * @returns Channel information for the escrow channel
    *


### PR DESCRIPTION
## Summary
- `EnsureNoOngoingEscrowOperation` now status-gates the one-behind branch for `TransitionTypeEscrowDeposit`. The signed N+1 finalize state sits off-chain while the on-chain channel stays at INITIATE version N until the purge queue fires; that is the protocol-intended steady state, so we cannot require `Closed`. The branch now allows status ∈ {Open, Closed} and blocks otherwise.
- Fixes the stall reported in MF2-M02: `HandleEscrowDepositsPurged` marks the escrow channel `Closed` while preserving `StateVersion` at the initiate version, which previously caused `EnsureNoOngoingEscrowOperation` to report `escrow deposit finalization is still ongoing` and block transfer receives and app-session releases.
- Addresses #discussion_r3264742604: `Challenged` one-behind is now blocked. Co-signed N+1 is value-binding between parties, but on-chain resolution is still racing — finalize tx may not land, the escrow chain may settle at INITIATE, and replaying N+1 later could violate engine invariants. Stacking receiver-side state on N+1 in that window risks encumbering a credit that may rewind.
- Comparison uses `*v + 1 == StateVersion` to avoid uint underflow when version is 0.
- No change to `HandleEscrowDepositsPurged` or `StateVersion` handling. Other transitions (escrow_lock, mutual_lock, escrow_withdraw) untouched.

## Test plan
- [x] `go vet ./nitronode/store/database/...`
- [x] `go test ./nitronode/store/database/... -count=1`
- [x] `TestDBStore_EnsureNoOngoingEscrowOperation` cases:
  - chain caught up → allow
  - Open one-behind (pre-purge happy path) → allow
  - Closed one-behind (post-purge) → allow
  - Challenged one-behind → block
  - chain more than one version behind → block
  - escrow channel missing from DB → block
