### PR TITLE
MF2-I03: reject reused home channel ID explicitly

### DIFF
--- a/nitronode/api/channel_v1/request_creation.go
+++ b/nitronode/api/channel_v1/request_creation.go
@@ -128,14 +128,19 @@ func (h *Handler) RequestCreation(c *rpc.Context) {
 			return rpc.Errorf("incoming state home_channel_id is invalid")
 		}
 
-		if currentState.HomeChannelID != nil {
-			isFinal := currentState.IsFinal()
-			if !isFinal {
-				return rpc.Errorf("channel is already initialized")
-			}
-			if isFinal && strings.EqualFold(*incomingState.HomeChannelID, *currentState.HomeChannelID) {
-				return rpc.Errorf("cannot use same home channel id")
-			}
+		// Reject reuse of an already-known channel ID. Enforced at the handler rather than
+		// relying on the channels.channel_id primary key, so the invariant holds even when
+		// the prior state has no HomeChannelID (e.g., after a ChallengeRescue squash).
+		existingChannel, err := tx.GetChannelByID(homeChannelID)
+		if err != nil {
+			return rpc.Errorf("failed to check existing channel: %v", err)
+		}
+		if existingChannel != nil {
+			return rpc.Errorf("cannot use same home channel id")
+		}
+
+		if currentState.HomeChannelID != nil && !currentState.IsFinal() {
+			return rpc.Errorf("channel is already initialized")
 		}
 
 		logger.Debug("processing channel creation request", "incomingVersion", incomingState.Version)

--- a/nitronode/api/channel_v1/request_creation.go
+++ b/nitronode/api/channel_v1/request_creation.go
@@ -141,7 +141,7 @@ func (h *Handler) RequestCreation(c *rpc.Context) {
 		// the prior state has no HomeChannelID (e.g., after a ChallengeRescue squash).
 		existingChannel, err := tx.GetChannelByID(homeChannelID)
 		if err != nil {
-			return rpc.Errorf("failed to check existing channel: %v", err)
+			return rpc.Errorf("failed to look up channel by computed id: %v", err)
 		}
 		if existingChannel != nil {
 			return rpc.Errorf("cannot use same home channel id")

--- a/nitronode/api/channel_v1/request_creation_test.go
+++ b/nitronode/api/channel_v1/request_creation_test.go
@@ -93,6 +93,7 @@ func TestRequestCreation_Success(t *testing.T) {
 	mockTxStore.On("LockUserState", userWallet, asset).Return(decimal.Zero, nil).Once()
 	mockTxStore.On("HasNonClosedHomeChannel", userWallet, asset).Return(false, nil).Once()
 	mockTxStore.On("GetLastUserState", userWallet, asset, false).Return(nil, nil).Once()
+	mockTxStore.On("GetChannelByID", mock.AnythingOfType("string")).Return((*core.Channel)(nil), nil).Once()
 	mockStatePacker.On("PackState", mock.Anything).Return(packedState, nil)
 	mockTxStore.On("CreateChannel", mock.MatchedBy(func(channel core.Channel) bool {
 		return channel.UserWallet == userWallet &&
@@ -248,6 +249,7 @@ func TestRequestCreation_Acknowledgement_Success(t *testing.T) {
 	mockTxStore.On("LockUserState", userWallet, asset).Return(decimal.Zero, nil).Once()
 	mockTxStore.On("HasNonClosedHomeChannel", userWallet, asset).Return(false, nil).Once()
 	mockTxStore.On("GetLastUserState", userWallet, asset, false).Return(nil, nil).Once()
+	mockTxStore.On("GetChannelByID", mock.AnythingOfType("string")).Return((*core.Channel)(nil), nil).Once()
 	mockStatePacker.On("PackState", mock.Anything).Return(packedState, nil)
 	mockTxStore.On("CreateChannel", mock.MatchedBy(func(channel core.Channel) bool {
 		return channel.UserWallet == userWallet &&
@@ -617,6 +619,124 @@ func TestRequestCreation_NonClosedChannelRejection(t *testing.T) {
 	mockTxStore.AssertExpectations(t)
 	// GetLastUserState, CreateChannel, StoreUserState must NOT be called.
 	mockTxStore.AssertNotCalled(t, "GetLastUserState", mock.Anything, mock.Anything, mock.Anything)
+	mockTxStore.AssertNotCalled(t, "CreateChannel", mock.Anything)
+	mockTxStore.AssertNotCalled(t, "StoreUserState", mock.Anything, mock.Anything)
+}
+
+// TestRequestCreation_RejectReusedHomeChannelID covers the case where the user's last
+// state has no HomeChannelID (e.g., it is a ChallengeRescue squash on a fresh epoch),
+// but the computed channel ID matches a previously stored channel record. The handler
+// must reject the request explicitly rather than deferring the duplicate detection to
+// the channels.channel_id primary key in CreateChannel.
+func TestRequestCreation_RejectReusedHomeChannelID(t *testing.T) {
+	mockTxStore := new(MockStore)
+	mockMemoryStore := new(MockMemoryStore)
+	mockAssetStore := new(MockAssetStore)
+	mockSigner := NewMockSigner()
+	nodeSigner, _ := core.NewChannelDefaultSigner(mockSigner)
+	nodeAddress := mockSigner.PublicKey().Address().String()
+	mockStatePacker := new(MockStatePacker)
+
+	handler := &Handler{
+		stateAdvancer: core.NewStateAdvancerV1(mockAssetStore),
+		statePacker:   mockStatePacker,
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockTxStore)
+		},
+		memoryStore:      mockMemoryStore,
+		nodeSigner:       nodeSigner,
+		nodeAddress:      nodeAddress,
+		minChallenge:     uint32(3600),
+		maxChallenge:     uint32(604800),
+		metrics:          metrics.NewNoopRuntimeMetricExporter(),
+		maxSessionKeyIDs: 256,
+		actionGateway:    &MockActionGateway{},
+	}
+
+	userSigner := NewMockSigner()
+	userWallet := userSigner.PublicKey().Address().String()
+	asset := "USDC"
+	tokenAddress := "0xTokenAddress"
+	blockchainID := uint64(1)
+	nonce := uint64(7)
+	challenge := uint32(86400)
+
+	homeChannelID, err := core.GetHomeChannelID(nodeAddress, userWallet, asset, nonce, challenge, "0x03")
+	require.NoError(t, err)
+
+	// Simulate the post-rescue ledger head: a state whose HomeChannelID is nil because
+	// it was issued by issueChallengeRescue() after the prior home channel was closed.
+	rescueHead := core.State{
+		Asset:         asset,
+		UserWallet:    userWallet,
+		Epoch:         1,
+		Version:       1,
+		HomeChannelID: nil,
+	}
+
+	// Channel record from the closed epoch still lives in the channels table.
+	priorChannel := &core.Channel{
+		ChannelID:    homeChannelID,
+		UserWallet:   userWallet,
+		Asset:        asset,
+		Type:         core.ChannelTypeHome,
+		BlockchainID: blockchainID,
+		TokenAddress: tokenAddress,
+		Status:       core.ChannelStatusClosed,
+		Nonce:        nonce,
+	}
+
+	mockMemoryStore.On("IsAssetSupported", asset, tokenAddress, blockchainID).Return(true, nil).Once()
+	mockTxStore.On("LockUserState", userWallet, asset).Return(decimal.Zero, nil).Once()
+	mockTxStore.On("HasNonClosedHomeChannel", userWallet, asset).Return(false, nil).Once()
+	mockTxStore.On("GetLastUserState", userWallet, asset, false).Return(rescueHead, nil).Once()
+	mockTxStore.On("GetChannelByID", mock.AnythingOfType("string")).Return(priorChannel, nil).Once()
+
+	reqPayload := rpc.ChannelsV1RequestCreationRequest{
+		State: rpc.StateV1{
+			ID:            core.GetStateID(userWallet, asset, 2, 1),
+			UserWallet:    userWallet,
+			Asset:         asset,
+			Epoch:         "2",
+			Version:       "1",
+			HomeChannelID: &homeChannelID,
+			Transition:    rpc.TransitionV1{Amount: "0"},
+			HomeLedger: rpc.LedgerV1{
+				TokenAddress: tokenAddress,
+				BlockchainID: "1",
+				UserBalance:  "0",
+				UserNetFlow:  "0",
+				NodeBalance:  "0",
+				NodeNetFlow:  "0",
+			},
+		},
+		ChannelDefinition: rpc.ChannelDefinitionV1{
+			Nonce:                 strconv.FormatUint(nonce, 10),
+			Challenge:             challenge,
+			ApprovedSigValidators: "0x03",
+		},
+	}
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.Message{
+			RequestID: 1,
+			Method:    rpc.ChannelsV1RequestCreationMethod.String(),
+			Payload:   payload,
+		},
+	}
+
+	handler.RequestCreation(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.Error(t, respErr)
+	assert.Contains(t, respErr.Error(), "cannot use same home channel id")
+
+	mockTxStore.AssertExpectations(t)
 	mockTxStore.AssertNotCalled(t, "CreateChannel", mock.Anything)
 	mockTxStore.AssertNotCalled(t, "StoreUserState", mock.Anything, mock.Anything)
 }

--- a/nitronode/api/channel_v1/request_creation_test.go
+++ b/nitronode/api/channel_v1/request_creation_test.go
@@ -1001,3 +1001,112 @@ func TestRequestCreation_RejectReusedHomeChannelID(t *testing.T) {
 	mockTxStore.AssertNotCalled(t, "CreateChannel", mock.Anything)
 	mockTxStore.AssertNotCalled(t, "StoreUserState", mock.Anything, mock.Anything)
 }
+
+// TestRequestCreation_ChannelAlreadyInitialized covers the guard that rejects a creation
+// request when the user's prior state still has a non-nil, non-final HomeChannelID and
+// the computed channel ID is not yet stored. This is the in-flight-channel case: the
+// previous lifecycle has not been finalized off-chain, so a new creation must not start.
+func TestRequestCreation_ChannelAlreadyInitialized(t *testing.T) {
+	mockTxStore := new(MockStore)
+	mockMemoryStore := new(MockMemoryStore)
+	mockAssetStore := new(MockAssetStore)
+	mockSigner := NewMockSigner()
+	nodeSigner, _ := core.NewChannelDefaultSigner(mockSigner)
+	nodeAddress := mockSigner.PublicKey().Address().String()
+	mockStatePacker := new(MockStatePacker)
+
+	handler := &Handler{
+		stateAdvancer: core.NewStateAdvancerV1(mockAssetStore),
+		statePacker:   mockStatePacker,
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockTxStore)
+		},
+		memoryStore:      mockMemoryStore,
+		nodeSigner:       nodeSigner,
+		nodeAddress:      nodeAddress,
+		minChallenge:     uint32(3600),
+		maxChallenge:     uint32(604800),
+		metrics:          metrics.NewNoopRuntimeMetricExporter(),
+		maxSessionKeyIDs: 256,
+		actionGateway:    &MockActionGateway{},
+	}
+
+	userSigner := NewMockSigner()
+	userWallet := userSigner.PublicKey().Address().String()
+	asset := "USDC"
+	tokenAddress := "0xTokenAddress"
+	blockchainID := uint64(1)
+	priorNonce := uint64(7)
+	newNonce := uint64(8)
+	challenge := uint32(86400)
+
+	priorHomeChannelID, err := core.GetHomeChannelID(nodeAddress, userWallet, asset, priorNonce, challenge, "0x03")
+	require.NoError(t, err)
+	newHomeChannelID, err := core.GetHomeChannelID(nodeAddress, userWallet, asset, newNonce, challenge, "0x03")
+	require.NoError(t, err)
+
+	// Prior state: in-flight channel — HomeChannelID set, transition is not Finalize.
+	priorState := core.State{
+		Asset:         asset,
+		UserWallet:    userWallet,
+		Epoch:         1,
+		Version:       1,
+		HomeChannelID: &priorHomeChannelID,
+		Transition:    core.Transition{Type: core.TransitionTypeHomeDeposit},
+	}
+
+	mockMemoryStore.On("IsAssetSupported", asset, tokenAddress, blockchainID).Return(true, nil).Once()
+	mockTxStore.On("LockUserState", userWallet, asset).Return(decimal.Zero, nil).Once()
+	mockTxStore.On("HasNonClosedHomeChannel", userWallet, asset).Return(false, nil).Once()
+	mockTxStore.On("GetLastUserState", userWallet, asset, false).Return(priorState, nil).Once()
+	// New nonce → fresh channel ID, no row yet in channels.
+	mockTxStore.On("GetChannelByID", mock.AnythingOfType("string")).Return((*core.Channel)(nil), nil).Once()
+
+	reqPayload := rpc.ChannelsV1RequestCreationRequest{
+		State: rpc.StateV1{
+			ID:            core.GetStateID(userWallet, asset, 2, 1),
+			UserWallet:    userWallet,
+			Asset:         asset,
+			Epoch:         "2",
+			Version:       "1",
+			HomeChannelID: &newHomeChannelID,
+			Transition:    rpc.TransitionV1{Amount: "0"},
+			HomeLedger: rpc.LedgerV1{
+				TokenAddress: tokenAddress,
+				BlockchainID: "1",
+				UserBalance:  "0",
+				UserNetFlow:  "0",
+				NodeBalance:  "0",
+				NodeNetFlow:  "0",
+			},
+		},
+		ChannelDefinition: rpc.ChannelDefinitionV1{
+			Nonce:                 strconv.FormatUint(newNonce, 10),
+			Challenge:             challenge,
+			ApprovedSigValidators: "0x03",
+		},
+	}
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.Message{
+			RequestID: 1,
+			Method:    rpc.ChannelsV1RequestCreationMethod.String(),
+			Payload:   payload,
+		},
+	}
+
+	handler.RequestCreation(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.Error(t, respErr)
+	assert.Contains(t, respErr.Error(), "channel is already initialized")
+
+	mockTxStore.AssertExpectations(t)
+	mockTxStore.AssertNotCalled(t, "CreateChannel", mock.Anything)
+	mockTxStore.AssertNotCalled(t, "StoreUserState", mock.Anything, mock.Anything)
+}


### PR DESCRIPTION
## Summary
- After a challenged channel close, `issueChallengeRescue()` emits a fresh-epoch state with `HomeChannelID == nil`. The same-home-channel-id check in `request_creation()` was gated on `currentState.HomeChannelID != nil`, so when the ledger head was a post-rescue state the explicit reject was skipped and the invariant fell back to the `channels.channel_id` primary key on `CreateChannel`.
- No direct funds risk — duplicate creation still aborts on the PK collision inside the transaction — but the user-facing error is opaque (`failed to create channel: duplicate key`) and the business rule lives in the storage layer instead of the handler.
- Patch looks up the channel by computed `homeChannelID` before `CreateChannel` and rejects with `cannot use same home channel id` regardless of prior-state shape. The `channel is already initialized` guard for non-final prior states with a non-nil `HomeChannelID` is preserved.

## Test plan
- [x] `go test ./nitronode/api/channel_v1/...`
- [x] `go vet ./nitronode/api/channel_v1/...`
- [x] New regression `TestRequestCreation_RejectReusedHomeChannelID` covers post-rescue head (`HomeChannelID == nil`) with a prior channel record still in `channels` — must return `cannot use same home channel id` before reaching `CreateChannel`/`StoreUserState`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)