### PR TITLE
MF2-I02: fix: add SESSION_KEY_AUTH_TYPEHASH to session key authorization payload

### DIFF
--- a/contracts/signature-validators.md
+++ b/contracts/signature-validators.md
@@ -191,7 +191,8 @@ bytes sigBody = abi.encode(SessionKeyAuthorization, bytes sessionKeySignature)
 
 **Two checks:**
 
-1. Participant authorized the session key: `authData = abi.encode(SESSION_KEY_AUTH_TYPEHASH, sessionKey, metadataHash)` where `SESSION_KEY_AUTH_TYPEHASH = keccak256("Nitrolite.SessionKey(address sessionKey,bytes32 metadataHash)")`
+1. Participant authorized the session key: `authData = abi.encode(SESSION_KEY_AUTH_TYPEHASH, sessionKey, metadataHash)`
+   where `SESSION_KEY_AUTH_TYPEHASH = keccak256("Nitrolite.SessionKey(address sessionKey,bytes32 metadataHash)")`
 2. Session key signed the state
 
 Both use EIP-191 first, then raw ECDSA if that fails.

--- a/contracts/signature-validators.md
+++ b/contracts/signature-validators.md
@@ -191,7 +191,7 @@ bytes sigBody = abi.encode(SessionKeyAuthorization, bytes sessionKeySignature)
 
 **Two checks:**
 
-1. Participant authorized the session key: `authData = abi.encode(sessionKey, metadataHash)`
+1. Participant authorized the session key: `authData = abi.encode(SESSION_KEY_AUTH_TYPEHASH, sessionKey, metadataHash)` where `SESSION_KEY_AUTH_TYPEHASH = keccak256("Nitrolite.SessionKey(address sessionKey,bytes32 metadataHash)")`
 2. Session key signed the state
 
 Both use EIP-191 first, then raw ECDSA if that fails.

--- a/contracts/src/sigValidators/SessionKeyValidator.sol
+++ b/contracts/src/sigValidators/SessionKeyValidator.sol
@@ -10,6 +10,10 @@ import {
 import {EcdsaSignatureUtils} from "./EcdsaSignatureUtils.sol";
 import {Utils} from "../Utils.sol";
 
+/// @dev Type hash for `SessionKeyAuthorization`, included in the authorization payload to prevent
+///      reuse of unrelated `abi.encode(address, bytes32)` signatures as session-key authorizations.
+bytes32 constant SESSION_KEY_AUTH_TYPEHASH = keccak256("Nitrolite.SessionKey(address sessionKey,bytes32 metadataHash)");
+
 /**
  * @notice Authorization struct for delegating signing authority to a session key
  * @dev The participant signs this authorization to allow the session key to sign on their behalf
@@ -25,6 +29,7 @@ struct SessionKeyAuthorization {
 
 function toSigningData(SessionKeyAuthorization memory skAuth) pure returns (bytes memory) {
     return abi.encode(
+        SESSION_KEY_AUTH_TYPEHASH,
         skAuth.sessionKey,
         skAuth.metadataHash
         // omit authSignature

--- a/contracts/test/ChannelHub_Node.t.sol
+++ b/contracts/test/ChannelHub_Node.t.sol
@@ -8,8 +8,7 @@ import {ChannelHub} from "../src/ChannelHub.sol";
 
 contract ChannelHubTest_depositToNode is ChannelHubTest_Base {
     // TODO:
-
-    }
+}
 
 contract ChannelHubTest_withdrawFromNode is ChannelHubTest_Base {
     RevertingEthReceiver public revertingReceiver;

--- a/contracts/test/Utils.t.sol
+++ b/contracts/test/Utils.t.sol
@@ -198,14 +198,14 @@ contract UtilsTest is Test {
         bytes memory encoded = toSigningData(auth);
 
         console.log("SessionKeyAuthorization signing data:");
-        // 0x0000000000000000000000003fba6f40f2cd5b4d833e0305061b88f029ea504459c85ca0f1634dd72294eec96f6d613893a9d3add6943b6f32f9cf7df0858239
+        // 0x251773da8b8949935ef07284d20cc8605ad7d6f4cf6b5e040ce07dae857f0b6c0000000000000000000000003fba6f40f2cd5b4d833e0305061b88f029ea504459c85ca0f1634dd72294eec96f6d613893a9d3add6943b6f32f9cf7df0858239
         console.logBytes(encoded);
 
         // 0x5C372EBfC9029aFe7F7506a4d9586604A40e117F
         uint256 privKey = 0xefc7c391f4ce326e149bb9943658998227094eb3e0acc92c343241e22fbc7624;
         bytes memory authSignature = TestUtils.signEip191(vm, privKey, encoded);
         console.log("Auth signature:");
-        // 0x0dd14906d8d4dc22ffe48c6fbec99323e1fd149c71fdd9a5fafbc584eed1e9cb00f4e761bb12a7b7271f760ee77f58a7feb9c89b7d70f1e07fcfa60846a74bd41b
+        // 0x287f031625a7a3ac8329d7746c5370c30ffad9857b6e0d022296af4bcad9ca4e0b1b680c3231f5508a1a01406697349afedff09b44c4a26a7881aa262c8bbcee1b
         console.logBytes(authSignature);
 
         auth.authSignature = authSignature;

--- a/contracts/test/sigValidators/SessionKeyValidator.t.sol
+++ b/contracts/test/sigValidators/SessionKeyValidator.t.sol
@@ -221,6 +221,13 @@ contract SessionKeyValidatorTest_validateSignature is SessionKeyValidatorTest_Ba
 
         bytes memory encoded = toSigningData(skAuth);
 
+        // Verify full 96-byte golden value: typehash || padded address || metadataHash.
+        bytes memory expected = hex"251773da8b8949935ef07284d20cc8605ad7d6f4cf6b5e040ce07dae857f0b6c"
+            hex"000000000000000000000000deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+            hex"abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
+        assertEq(encoded.length, 96);
+        assertEq(encoded, expected);
+
         // Verify typehash is the first 32 bytes of the encoded payload.
         bytes32 typehashWord;
         assembly {

--- a/contracts/test/sigValidators/SessionKeyValidator.t.sol
+++ b/contracts/test/sigValidators/SessionKeyValidator.t.sol
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.30;
 
-import {Test} from "forge-std/Test.sol";
+import {Test, console} from "forge-std/Test.sol";
 
 import {TestUtils} from "../TestUtils.sol";
 
 import {
     SessionKeyValidator,
     SessionKeyAuthorization,
+    SESSION_KEY_AUTH_TYPEHASH,
     toSigningData
 } from "../../src/sigValidators/SessionKeyValidator.sol";
 import {ValidationResult, VALIDATION_SUCCESS, VALIDATION_FAILURE} from "../../src/interfaces/ISignatureValidator.sol";
@@ -207,6 +208,34 @@ contract SessionKeyValidatorTest_validateSignature is SessionKeyValidatorTest_Ba
 
         ValidationResult result = validator.validateSignature(CHANNEL_ID, SIGNING_DATA, signature, user);
         assertEq(ValidationResult.unwrap(result), ValidationResult.unwrap(VALIDATION_FAILURE));
+    }
+
+    function test_log_toSigningData() public pure {
+        address FIXED_SESSION_KEY = address(0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF);
+        bytes32 FIXED_METADATA_HASH =
+        bytes32(uint256(0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890));
+
+
+        SessionKeyAuthorization memory skAuth = SessionKeyAuthorization({
+            sessionKey: FIXED_SESSION_KEY, metadataHash: FIXED_METADATA_HASH, authSignature: ""
+        });
+
+        bytes memory encoded = toSigningData(skAuth);
+
+        // Verify typehash is the first 32 bytes of the encoded payload.
+        bytes32 typehashWord;
+        assembly {
+            typehashWord := mload(add(encoded, 32))
+        }
+        assertEq(typehashWord, SESSION_KEY_AUTH_TYPEHASH);
+
+        console.log("SESSION_KEY_AUTH_TYPEHASH:");
+        // 0x251773da8b8949935ef07284d20cc8605ad7d6f4cf6b5e040ce07dae857f0b6c
+        console.logBytes32(SESSION_KEY_AUTH_TYPEHASH);
+
+        console.log("toSigningData output (96 bytes: typehash || sessionKey || metadataHash):");
+        // 0x251773da8b8949935ef07284d20cc8605ad7d6f4cf6b5e040ce07dae857f0b6c000000000000000000000000deadbeefdeadbeefdeadbeefdeadbeefdeadbeefabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890
+        console.logBytes(encoded);
     }
 }
 

--- a/contracts/test/sigValidators/SessionKeyValidator.t.sol
+++ b/contracts/test/sigValidators/SessionKeyValidator.t.sol
@@ -213,8 +213,7 @@ contract SessionKeyValidatorTest_validateSignature is SessionKeyValidatorTest_Ba
     function test_log_toSigningData() public pure {
         address FIXED_SESSION_KEY = address(0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF);
         bytes32 FIXED_METADATA_HASH =
-        bytes32(uint256(0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890));
-
+            bytes32(uint256(0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890));
 
         SessionKeyAuthorization memory skAuth = SessionKeyAuthorization({
             sessionKey: FIXED_SESSION_KEY, metadataHash: FIXED_METADATA_HASH, authSignature: ""

--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -379,10 +379,17 @@ types:
           description: Unix timestamp in seconds indicating when the session key expires
         - name: user_sig
           type: string
-          description: User's signature over the session key metadata to authorize the registration/update of the session key
+          description: >
+            User's EIP-191 signature over abi.encode(SESSION_KEY_AUTH_TYPEHASH, session_key, metadata_hash),
+            where SESSION_KEY_AUTH_TYPEHASH = keccak256("Nitrolite.SessionKey(address sessionKey,bytes32 metadataHash)")
+            and metadata_hash = keccak256(abi.encode(user_address, version, assets[], expires_at)).
+            Authorizes the delegation of signing authority to the session key.
         - name: session_key_sig
           type: string
-          description: Session-key holder's signature over PackChannelKeyStateV1(session_key, metadata_hash) — the same packed bytes user_sig signs, where metadata_hash binds user_address — proving possession of the key being registered. Required on every submit to prevent registration of keys the submitter does not control.
+          description: >
+            Session-key holder's EIP-191 signature over the same payload as user_sig —
+            abi.encode(SESSION_KEY_AUTH_TYPEHASH, session_key, metadata_hash) — proving possession of the key
+            being registered. Required on every submit to prevent registration of keys the submitter does not control.
 
   - app_session_key_state:
       description: Represents the state of an app session key

--- a/docs/protocol/cryptography.md
+++ b/docs/protocol/cryptography.md
@@ -93,9 +93,12 @@ A participant MAY delegate signing authority to a session key.
 
 The authorization is constructed as follows:
 
-1. The participant signs a message containing:
-   - the session key address
-   - authorization metadata hash (`keccak256` over the canonically encoded authorization metadata structure)
+1. The participant signs an authorization payload constructed as:
+   `abi.encode(SESSION_KEY_AUTH_TYPEHASH, sessionKey, metadataHash)`
+   where `SESSION_KEY_AUTH_TYPEHASH = keccak256("Nitrolite.SessionKey(address sessionKey,bytes32 metadataHash)")`,
+   `sessionKey` is the address of the delegated key, and `metadataHash` is the `keccak256` hash of the
+   canonically encoded authorization metadata structure. The type hash prefix prevents unrelated
+   64-byte signed values from being reused as session-key authorizations.
 2. The authorization signature is produced using the participant's primary key
 3. The session key MAY then produce signatures on behalf of the participant within the authorized scope
 

--- a/pkg/core/channel_signer.go
+++ b/pkg/core/channel_signer.go
@@ -178,7 +178,7 @@ func (s *ChannelSigValidator) Recover(data, sig []byte) (string, error) {
 		}
 
 		// Step 1: Verify participant authorized this session key
-		// authMessage = _toSigningData(skAuth) = abi.encode(skAuth.sessionKey, skAuth.metadataHash)
+		// authMessage = toSigningData(skAuth) = abi.encode(SESSION_KEY_AUTH_TYPEHASH, sessionKey, metadataHash)
 		packedAuth, err := PackChannelKeyStateV1(skAuth.SessionKey.Hex(), skAuth.MetadataHash)
 		if err != nil {
 			return "", fmt.Errorf("failed to pack auth data: %w", err)

--- a/pkg/core/session_key.go
+++ b/pkg/core/session_key.go
@@ -72,16 +72,21 @@ func (s *ChannelSessionKeySignerV1) Type() ChannelSignerType {
 	return ChannelSignerType_SessionKey
 }
 
-// PackChannelKeyStateV1 packs the session key state for signing using ABI encoding.
-// This is used to generate a deterministic hash that the user signs when registering/updating a session key.
-// The user_sig field is excluded from packing since it is the signature itself.
+// SessionKeyAuthTypehash is the type hash prepended to the session key authorization payload.
+// It matches the Solidity constant SESSION_KEY_AUTH_TYPEHASH and
+// prevents unrelated abi.encode(address, bytes32) signatures from being reused as authorizations.
+var SessionKeyAuthTypehash = crypto.Keccak256Hash([]byte("Nitrolite.SessionKey(address sessionKey,bytes32 metadataHash)"))
+
+// PackChannelKeyStateV1 packs the session key authorization payload for signing using ABI encoding.
 func PackChannelKeyStateV1(sessionKey string, metadataHash common.Hash) ([]byte, error) {
 	args := abi.Arguments{
+		{Type: abi.Type{T: abi.FixedBytesTy, Size: 32}}, // SESSION_KEY_AUTH_TYPEHASH
 		{Type: abi.Type{T: abi.AddressTy}},              // session_key
 		{Type: abi.Type{T: abi.FixedBytesTy, Size: 32}}, // hashed metadata
 	}
 
 	packed, err := args.Pack(
+		SessionKeyAuthTypehash,
 		common.HexToAddress(sessionKey),
 		metadataHash,
 	)

--- a/pkg/core/session_key_test.go
+++ b/pkg/core/session_key_test.go
@@ -208,6 +208,28 @@ func TestGenerateSessionKeyStateIDV1(t *testing.T) {
 	assert.NotEqual(t, id1, id3)
 }
 
+// TestPackChannelKeyStateV1_Typehash verifies the SessionKeyAuthTypehash matches the
+// Solidity constant SESSION_KEY_AUTH_TYPEHASH in SessionKeyValidator.sol so that
+// off-chain authorization payloads are accepted on-chain.
+func TestPackChannelKeyStateV1_Typehash(t *testing.T) {
+	t.Parallel()
+	expected := common.HexToHash("0x251773da8b8949935ef07284d20cc8605ad7d6f4cf6b5e040ce07dae857f0b6c")
+	assert.Equal(t, expected, SessionKeyAuthTypehash)
+}
+
+func TestPackChannelKeyStateV1(t *testing.T) {
+	t.Parallel()
+	sessionKey := "0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF"
+	metadataHash := common.HexToHash("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
+
+	packed, err := PackChannelKeyStateV1(sessionKey, metadataHash)
+	require.NoError(t, err)
+	assert.Len(t, packed, 96, "payload must be 96 bytes: typehash || padded address || metadataHash")
+
+	expected := common.FromHex("0x251773da8b8949935ef07284d20cc8605ad7d6f4cf6b5e040ce07dae857f0b6c000000000000000000000000deadbeefdeadbeefdeadbeefdeadbeefdeadbeefabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
+	assert.Equal(t, expected, packed)
+}
+
 func TestEncodeDecodeChannelSessionKeySignature(t *testing.T) {
 	t.Parallel()
 	skAuth := channelSessionKeyAuthorization{

--- a/sdk/ts/src/core/utils.ts
+++ b/sdk/ts/src/core/utils.ts
@@ -437,12 +437,23 @@ export function getChannelSessionKeyAuthMetadataHashV1(
 }
 
 /**
- * Packs a channel session key state for signing.
- * Matches Go SDK's PackChannelKeyStateV1.
+ * Type hash for SessionKeyAuthorization, matching the Solidity constant
+ * SESSION_KEY_AUTH_TYPEHASH in SessionKeyValidator.sol.
+ * Prepended to the authorization payload to prevent reuse of unrelated
+ * abi.encode(address, bytes32) signatures as session-key authorizations.
+ */
+export const SESSION_KEY_AUTH_TYPEHASH: Hex = keccak256(
+    toHex('Nitrolite.SessionKey(address sessionKey,bytes32 metadataHash)')
+);
+
+/**
+ * Packs a channel session key authorization payload for signing.
+ * Matches Go SDK's PackChannelKeyStateV1 and Solidity's toSigningData(SessionKeyAuthorization).
+ * The payload is abi.encode(SESSION_KEY_AUTH_TYPEHASH, sessionKey, metadataHash) — 96 bytes total.
  *
  * @param sessionKey - The session key address
  * @param metadataHash - The metadata hash from getChannelSessionKeyAuthMetadataHashV1
- * @returns ABI-encoded (sessionKey, metadataHash) ready for EIP-191 signing
+ * @returns ABI-encoded (typehash, sessionKey, metadataHash) ready for EIP-191 signing
  */
 export function packChannelKeyStateV1(
   sessionKey: Address,
@@ -450,10 +461,11 @@ export function packChannelKeyStateV1(
 ): `0x${string}` {
   return encodeAbiParameters(
     [
+      { type: 'bytes32' },  // SESSION_KEY_AUTH_TYPEHASH
       { type: 'address' },  // session_key
       { type: 'bytes32' },  // hashed metadata
     ],
-    [sessionKey, metadataHash]
+    [SESSION_KEY_AUTH_TYPEHASH, sessionKey, metadataHash]
   );
 }
 

--- a/sdk/ts/src/core/utils.ts
+++ b/sdk/ts/src/core/utils.ts
@@ -443,7 +443,7 @@ export function getChannelSessionKeyAuthMetadataHashV1(
  * abi.encode(address, bytes32) signatures as session-key authorizations.
  */
 export const SESSION_KEY_AUTH_TYPEHASH: Hex = keccak256(
-    toHex('Nitrolite.SessionKey(address sessionKey,bytes32 metadataHash)')
+  toHex('Nitrolite.SessionKey(address sessionKey,bytes32 metadataHash)')
 );
 
 /**

--- a/sdk/ts/test/unit/__snapshots__/public-api-drift.test.ts.snap
+++ b/sdk/ts/test/unit/__snapshots__/public-api-drift.test.ts.snap
@@ -1955,6 +1955,11 @@ exports[`SDK public runtime API drift guard keeps root TypeScript public API sig
     ],
   },
   {
+    "kind": "const",
+    "name": "SESSION_KEY_AUTH_TYPEHASH",
+    "type": "\`0x\${string}\`",
+  },
+  {
     "kind": "interface",
     "name": "SessionKey",
     "properties": [
@@ -2577,6 +2582,7 @@ exports[`SDK public runtime API drift guard keeps root runtime exports intention
   "NodeV1PingMethod",
   "RPCClient",
   "RPCError",
+  "SESSION_KEY_AUTH_TYPEHASH",
   "StateAdvancerV1",
   "StatePackerV1",
   "TransactionType",

--- a/sdk/ts/test/unit/core/utils.test.ts
+++ b/sdk/ts/test/unit/core/utils.test.ts
@@ -7,6 +7,8 @@ import {
   generateChannelMetadata,
   transitionToIntent,
   getStateTransitionHash,
+  SESSION_KEY_AUTH_TYPEHASH,
+  packChannelKeyStateV1,
 } from '../../../src/core/utils';
 import {
   TransitionType,
@@ -551,4 +553,30 @@ describe('getStateTransitionHash', () => {
     const hash = getStateTransitionHash(transition);
     expect(hash).toBeDefined();
   });
+});
+
+describe('SESSION_KEY_AUTH_TYPEHASH', () => {
+    // Golden value cross-checked against Solidity: keccak256("Nitrolite.SessionKey(address sessionKey,bytes32 metadataHash)")
+    // Verified by running Solidity test test_log_toSigningData in SessionKeyValidator.t.sol.
+    const EXPECTED = '0x251773da8b8949935ef07284d20cc8605ad7d6f4cf6b5e040ce07dae857f0b6c';
+
+    test('matches_solidity_constant', () => {
+        expect(SESSION_KEY_AUTH_TYPEHASH).toBe(EXPECTED);
+    });
+});
+
+describe('packChannelKeyStateV1', () => {
+    const sessionKey = '0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF' as `0x${string}`;
+    const metadataHash = '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890' as `0x${string}`;
+    // abi.encode(SESSION_KEY_AUTH_TYPEHASH, sessionKey, metadataHash)
+    const EXPECTED =
+        '0x' +
+        '251773da8b8949935ef07284d20cc8605ad7d6f4cf6b5e040ce07dae857f0b6c' + // typehash
+        '000000000000000000000000deadbeefdeadbeefdeadbeefdeadbeefdeadbeef' + // address padded
+        'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890';  // metadataHash
+
+    test('golden_value', () => {
+        const packed = packChannelKeyStateV1(sessionKey, metadataHash);
+        expect(packed.toLowerCase()).toBe(EXPECTED);
+    });
 });


### PR DESCRIPTION
Implements the fix for the MF2-I02 audit finding: `SessionKeyValidator.toSigningData()` produced a bare `abi.encode(address, bytes32)` payload with no type tag, making it possible to reuse an unrelated 64-byte signed value as a session-key authorization.

## Changes

- **Solidity** (`contracts/src/sigValidators/SessionKeyValidator.sol`): added `SESSION_KEY_AUTH_TYPEHASH = keccak256("Nitrolite.SessionKey(address sessionKey,bytes32 metadataHash)")` and prepended it as the first word of `toSigningData()`. Payload is now 96 bytes instead of 64.
- **Go** (`pkg/core/session_key.go`): exported `SessionKeyAuthTypehash` var; updated `PackChannelKeyStateV1` to match.
- **TypeScript** (`sdk/ts/src/core/utils.ts`): exported `SESSION_KEY_AUTH_TYPEHASH` constant; updated `packChannelKeyStateV1` to match.
- **Tests**: cross-language golden-value tests verify the typehash (`0x251773da8b8949935ef07284d20cc8605ad7d6f4cf6b5e040ce07dae857f0b6c`) and the full 96-byte encoded output against each other.
- **Docs**: updated `contracts/signature-validators.md` validation logic description.

## Breaking change

Existing `authSignature` values signed with the old format are invalid after this change. Session key registrations must be re-signed.

## Note

This branch does not include the `requestCreation` ActionGateway guard from the base branch (MF2-L01). That guard must be preserved when merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced session key authorization with SESSION_KEY_AUTH_TYPEHASH included in authorization payloads.

* **Tests**
  * Added validation tests for SESSION_KEY_AUTH_TYPEHASH constant and payload encoding across Solidity, Go, and TypeScript implementations.

* **Documentation**
  * Updated SessionKeyValidator authorization payload format documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/layer-3/nitrolite/pull/767?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->