### PR TITLE
MF2-H03: guard challenge_rescue against post-Finalize close

### DIFF
--- a/nitronode/event_handlers/service.go
+++ b/nitronode/event_handlers/service.go
@@ -313,9 +313,15 @@ func (s *EventHandlerService) HandleHomeChannelChallenged(ctx context.Context, t
 // Once closed, no further state updates are possible for this channel.
 //
 // Additionally, when the closing path was a challenge resolution (channel was Challenged
-// and the closing state is not a finalize), the handler issues a single ChallengeRescue
-// state for the user that squashes the sum of receiver-state credits accrued during the
-// challenge window into an off-channel ledger entry tied to the closed channel's ID.
+// and no node-signed Finalize state exists for it), the handler issues a single
+// ChallengeRescue state for the user that squashes the sum of receiver-state credits
+// accrued during the challenge window into an off-channel ledger entry tied to the
+// closed channel's ID. When a node-signed Finalize already exists, the cooperative-close
+// path has already advanced the user to a fresh epoch via NextState(), and any receiver
+// credits accumulated post-Finalize live at (epoch+1, version=0..N) with HomeChannelID=nil
+// — issuing a rescue at (epoch+1, version=1) would either overwrite the lone receiver
+// credit or collide on deterministic state ID with an existing row, so the rescue is
+// skipped entirely in that case.
 func (s *EventHandlerService) HandleHomeChannelClosed(ctx context.Context, tx core.ChannelHubEventHandlerStore, event *core.HomeChannelClosedEvent) error {
 	logger := log.FromContext(ctx)
 	chanID := event.ChannelID
@@ -362,8 +368,23 @@ func (s *EventHandlerService) HandleHomeChannelClosed(ctx context.Context, tx co
 	}
 
 	if wasChallenged {
-		if err := s.issueChallengeRescue(ctx, tx, channel, event.StateVersion); err != nil {
+		// Post-Finalize cooperative close racing with an on-chain challenge: receiver
+		// credits issued after the Finalize live in a fresh epoch via NextState() and
+		// are not channel-attached, so the rescue path would either overwrite them or
+		// collide on deterministic state ID. Skip the rescue branch entirely.
+		finalized, err := tx.HasSignedFinalize(chanID)
+		if err != nil {
 			return err
+		}
+		if finalized {
+			logger.Info("skipping challenge_rescue for post-Finalize close",
+				"channelId", chanID,
+				"userWallet", channel.UserWallet,
+				"closureVersion", event.StateVersion)
+		} else {
+			if err := s.issueChallengeRescue(ctx, tx, channel, event.StateVersion); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/nitronode/event_handlers/service.go
+++ b/nitronode/event_handlers/service.go
@@ -377,7 +377,7 @@ func (s *EventHandlerService) HandleHomeChannelClosed(ctx context.Context, tx co
 			return err
 		}
 		if finalized {
-			logger.Info("skipping challenge_rescue for post-Finalize close",
+			logger.Debug("skipping challenge_rescue for post-Finalize close",
 				"channelId", chanID,
 				"userWallet", channel.UserWallet,
 				"closureVersion", event.StateVersion)

--- a/nitronode/event_handlers/service_test.go
+++ b/nitronode/event_handlers/service_test.go
@@ -1888,6 +1888,10 @@ func TestHandleHomeChannelClosed_PostFinalize_SkipsRescue(t *testing.T) {
 //
 // With the guard, HasSignedFinalize=true short-circuits the entire branch before any
 // of those DB calls fire. The mock asserts none of them are reached.
+//
+// Intentional twin of TestHandleHomeChannelClosed_PostFinalize_SkipsRescue: setup and
+// AssertNotCalled set are identical at the mock level; this case exists to document the
+// specific collision failure modes the guard prevents. Do not collapse the two.
 func TestHandleHomeChannelClosed_PostFinalize_CollisionRegression(t *testing.T) {
 	mockStore := new(MockStore)
 	ctx := log.SetContextLogger(context.Background(), log.NewNoopLogger())

--- a/nitronode/event_handlers/service_test.go
+++ b/nitronode/event_handlers/service_test.go
@@ -1611,6 +1611,7 @@ func TestHandleHomeChannelClosed_ChallengeRescue_Squash(t *testing.T) {
 	})).Return(nil)
 	mockStore.On("RefreshUserEnforcedBalance", userWallet, asset).Return(nil)
 	mockStore.On("UpdateStateSigsIfMissing", channelID, closureVersion, "", "").Return(nil)
+	mockStore.On("HasSignedFinalize", channelID).Return(false, nil)
 	mockStore.On("GetLastStateByChannelID", channelID, false).Return(prevState, nil)
 	mockStore.On("SumNetTransitionAmountAfterVersion", channelID, closureVersion, prevState.Epoch).Return(rescueAmount, nil)
 
@@ -1633,7 +1634,7 @@ func TestHandleHomeChannelClosed_ChallengeRescue_Squash(t *testing.T) {
 	require.True(t, rescueAmount.Equal(capturedState.Transition.Amount))
 	require.Nil(t, capturedState.HomeChannelID, "rescue state must be off-channel")
 	require.Equal(t, prevState.Epoch+1, capturedState.Epoch)
-	require.Equal(t, uint64(1), capturedState.Version)
+	require.Equal(t, uint64(0), capturedState.Version)
 	require.Nil(t, capturedState.NodeSig, "rescue state is stored unsigned, like a credit to a user with no open home channel")
 	require.True(t, rescueAmount.Equal(capturedState.HomeLedger.UserBalance))
 	require.Empty(t, capturedState.HomeLedger.TokenAddress)
@@ -1712,6 +1713,7 @@ func TestHandleHomeChannelClosed_ChallengeRescue_NoCredits(t *testing.T) {
 	})).Return(nil)
 	mockStore.On("RefreshUserEnforcedBalance", userWallet, asset).Return(nil)
 	mockStore.On("UpdateStateSigsIfMissing", channelID, closureVersion, "", "").Return(nil)
+	mockStore.On("HasSignedFinalize", channelID).Return(false, nil)
 	mockStore.On("GetLastStateByChannelID", channelID, false).Return(prevState, nil)
 	mockStore.On("SumNetTransitionAmountAfterVersion", channelID, closureVersion, prevState.Epoch).Return(decimal.Zero, nil)
 
@@ -1730,7 +1732,7 @@ func TestHandleHomeChannelClosed_ChallengeRescue_NoCredits(t *testing.T) {
 	require.True(t, capturedState.HomeLedger.UserBalance.IsZero())
 	require.Nil(t, capturedState.HomeChannelID)
 	require.Equal(t, prevState.Epoch+1, capturedState.Epoch)
-	require.Equal(t, uint64(1), capturedState.Version)
+	require.Equal(t, uint64(0), capturedState.Version)
 
 	mockStore.AssertExpectations(t)
 }
@@ -1790,6 +1792,7 @@ func TestHandleHomeChannelClosed_ChallengeRescue_NegativeNet_ClampsToZero(t *tes
 	mockStore.On("UpdateChannel", mock.Anything).Return(nil)
 	mockStore.On("RefreshUserEnforcedBalance", userWallet, asset).Return(nil)
 	mockStore.On("UpdateStateSigsIfMissing", channelID, closureVersion, "", "").Return(nil)
+	mockStore.On("HasSignedFinalize", channelID).Return(false, nil)
 	mockStore.On("GetLastStateByChannelID", channelID, false).Return(prevState, nil)
 	mockStore.On("SumNetTransitionAmountAfterVersion", channelID, closureVersion, prevState.Epoch).Return(decimal.NewFromInt(-49), nil)
 
@@ -1808,9 +1811,173 @@ func TestHandleHomeChannelClosed_ChallengeRescue_NegativeNet_ClampsToZero(t *tes
 	require.True(t, capturedState.HomeLedger.UserBalance.IsZero())
 	require.Nil(t, capturedState.HomeChannelID)
 	require.Equal(t, prevState.Epoch+1, capturedState.Epoch)
-	require.Equal(t, uint64(1), capturedState.Version)
+	require.Equal(t, uint64(0), capturedState.Version)
 
 	mockStore.AssertExpectations(t)
+}
+
+// TestHandleHomeChannelClosed_PostFinalize_SkipsRescue pins behavior for the
+// cooperative-close-racing-an-onchain-challenge path: the node has already signed a
+// Finalize state for this channel, and post-Finalize receiver credits live in a fresh
+// epoch via NextState() with HomeChannelID=nil. Issuing a rescue at (epoch+1, version=0)
+// in that case would either overwrite a lone receiver credit (silent balance loss) or
+// collide on deterministic state ID with an existing row (StoreUserState fails and rolls
+// back the close, leaving the channel stuck Challenged). The handler must short-circuit
+// the rescue branch entirely when HasSignedFinalize reports true.
+func TestHandleHomeChannelClosed_PostFinalize_SkipsRescue(t *testing.T) {
+	mockStore := new(MockStore)
+	ctx := log.SetContextLogger(context.Background(), log.NewNoopLogger())
+
+	service, _ := newTestEventHandlerService(t)
+
+	channelID := "0xHomeChannel123"
+	userWallet := "0x1234567890123456789012345678901234567890"
+	asset := "USDC"
+	closureVersion := uint64(7)
+	expiryTime := time.Now().Add(time.Hour)
+
+	channel := &core.Channel{
+		ChannelID:          channelID,
+		UserWallet:         userWallet,
+		Asset:              asset,
+		Type:               core.ChannelTypeHome,
+		Status:             core.ChannelStatusChallenged,
+		StateVersion:       5,
+		ChallengeExpiresAt: &expiryTime,
+	}
+
+	event := &core.HomeChannelClosedEvent{
+		ChannelID:    channelID,
+		StateVersion: closureVersion,
+	}
+
+	mockStore.On("GetChannelByID", channelID).Return(channel, nil)
+	mockStore.On("LockUserState", userWallet, asset).Return(decimal.Zero, nil)
+	mockStore.On("UpdateChannel", mock.MatchedBy(func(ch core.Channel) bool {
+		return ch.Status == core.ChannelStatusClosed &&
+			ch.StateVersion == closureVersion &&
+			ch.ChallengeExpiresAt == nil
+	})).Return(nil)
+	mockStore.On("RefreshUserEnforcedBalance", userWallet, asset).Return(nil)
+	mockStore.On("UpdateStateSigsIfMissing", channelID, closureVersion, "", "").Return(nil)
+	mockStore.On("HasSignedFinalize", channelID).Return(true, nil)
+
+	err := service.HandleHomeChannelClosed(ctx, mockStore, event)
+	require.NoError(t, err)
+
+	mockStore.AssertExpectations(t)
+	mockStore.AssertNotCalled(t, "GetLastStateByChannelID", mock.Anything, mock.Anything)
+	mockStore.AssertNotCalled(t, "SumNetTransitionAmountAfterVersion", mock.Anything, mock.Anything, mock.Anything)
+	mockStore.AssertNotCalled(t, "StoreUserState", mock.Anything, mock.Anything)
+	mockStore.AssertNotCalled(t, "RecordTransaction", mock.Anything, mock.Anything)
+}
+
+// TestHandleHomeChannelClosed_PostFinalize_CollisionRegression documents the exact
+// failure modes the guard prevents. Two post-Finalize receiver credits already exist on
+// the user's ledger at (epoch+1, version=0) and (epoch+1, version=1) — produced by the
+// normal NextState() path off the Finalize state with HomeChannelID=nil. Without the
+// guard the handler would:
+//   - call GetLastStateByChannelID(channelID), which only matches channel-attached
+//     rows and therefore returns the Finalize state at the original epoch,
+//   - call SumNetTransitionAmountAfterVersion(channelID, ...), which filters by
+//     home_channel_id and returns zero (post-Finalize credits have HomeChannelID=nil),
+//   - construct a rescue state at (Finalize.Epoch+1, version=0) with amount=0,
+//   - StoreUserState on that ID, which collides deterministically with the existing
+//     (epoch+1, version=0) row via GetStateID(wallet, asset, epoch, version) and
+//     rolls the transaction back, stranding the channel in Challenged.
+//
+// With the guard, HasSignedFinalize=true short-circuits the entire branch before any
+// of those DB calls fire. The mock asserts none of them are reached.
+func TestHandleHomeChannelClosed_PostFinalize_CollisionRegression(t *testing.T) {
+	mockStore := new(MockStore)
+	ctx := log.SetContextLogger(context.Background(), log.NewNoopLogger())
+
+	service, _ := newTestEventHandlerService(t)
+
+	channelID := "0xHomeChannelCollision"
+	userWallet := "0x1234567890123456789012345678901234567890"
+	asset := "USDC"
+	closureVersion := uint64(10)
+	expiryTime := time.Now().Add(time.Hour)
+
+	channel := &core.Channel{
+		ChannelID:          channelID,
+		UserWallet:         userWallet,
+		Asset:              asset,
+		Type:               core.ChannelTypeHome,
+		Status:             core.ChannelStatusChallenged,
+		StateVersion:       9,
+		ChallengeExpiresAt: &expiryTime,
+	}
+
+	event := &core.HomeChannelClosedEvent{
+		ChannelID:    channelID,
+		StateVersion: closureVersion,
+	}
+
+	mockStore.On("GetChannelByID", channelID).Return(channel, nil)
+	mockStore.On("LockUserState", userWallet, asset).Return(decimal.Zero, nil)
+	mockStore.On("UpdateChannel", mock.MatchedBy(func(ch core.Channel) bool {
+		return ch.Status == core.ChannelStatusClosed &&
+			ch.StateVersion == closureVersion &&
+			ch.ChallengeExpiresAt == nil
+	})).Return(nil)
+	mockStore.On("RefreshUserEnforcedBalance", userWallet, asset).Return(nil)
+	mockStore.On("UpdateStateSigsIfMissing", channelID, closureVersion, "", "").Return(nil)
+	mockStore.On("HasSignedFinalize", channelID).Return(true, nil)
+
+	err := service.HandleHomeChannelClosed(ctx, mockStore, event)
+	require.NoError(t, err, "post-Finalize close must succeed; rescue branch must be skipped")
+
+	mockStore.AssertExpectations(t)
+	// The collision-class operations must not be invoked once the guard fires.
+	mockStore.AssertNotCalled(t, "GetLastStateByChannelID", mock.Anything, mock.Anything)
+	mockStore.AssertNotCalled(t, "SumNetTransitionAmountAfterVersion", mock.Anything, mock.Anything, mock.Anything)
+	mockStore.AssertNotCalled(t, "StoreUserState", mock.Anything, mock.Anything)
+	mockStore.AssertNotCalled(t, "RecordTransaction", mock.Anything, mock.Anything)
+}
+
+// TestHandleHomeChannelClosed_PostFinalize_HasSignedFinalizeErr ensures errors from the
+// HasSignedFinalize lookup are surfaced rather than silently dropping the rescue guard.
+func TestHandleHomeChannelClosed_PostFinalize_HasSignedFinalizeErr(t *testing.T) {
+	mockStore := new(MockStore)
+	ctx := log.SetContextLogger(context.Background(), log.NewNoopLogger())
+
+	service, _ := newTestEventHandlerService(t)
+
+	channelID := "0xHomeChannel123"
+	userWallet := "0x1234567890123456789012345678901234567890"
+	asset := "USDC"
+	closureVersion := uint64(7)
+
+	channel := &core.Channel{
+		ChannelID:    channelID,
+		UserWallet:   userWallet,
+		Asset:        asset,
+		Type:         core.ChannelTypeHome,
+		Status:       core.ChannelStatusChallenged,
+		StateVersion: 5,
+	}
+
+	event := &core.HomeChannelClosedEvent{
+		ChannelID:    channelID,
+		StateVersion: closureVersion,
+	}
+
+	dbErr := errors.New("db down")
+	mockStore.On("GetChannelByID", channelID).Return(channel, nil)
+	mockStore.On("LockUserState", userWallet, asset).Return(decimal.Zero, nil)
+	mockStore.On("UpdateChannel", mock.Anything).Return(nil)
+	mockStore.On("RefreshUserEnforcedBalance", userWallet, asset).Return(nil)
+	mockStore.On("UpdateStateSigsIfMissing", channelID, closureVersion, "", "").Return(nil)
+	mockStore.On("HasSignedFinalize", channelID).Return(false, dbErr)
+
+	err := service.HandleHomeChannelClosed(ctx, mockStore, event)
+	require.ErrorIs(t, err, dbErr)
+
+	mockStore.AssertNotCalled(t, "GetLastStateByChannelID", mock.Anything, mock.Anything)
+	mockStore.AssertNotCalled(t, "SumNetTransitionAmountAfterVersion", mock.Anything, mock.Anything, mock.Anything)
+	mockStore.AssertNotCalled(t, "StoreUserState", mock.Anything, mock.Anything)
 }
 
 // TestHandleHomeChannelClosed_OpenChannel_NoRescue pins behavior for the normal

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -187,6 +187,12 @@ func NewVoidState(asset, userWallet string) *State {
 // state starts at version 0. Callers must guarantee no other (epoch+1, version=0) row
 // already exists for this (wallet, asset) — for the rescue path this is enforced by
 // only invoking it on non-Finalize challenge closes (see HandleHomeChannelClosed).
+//
+// Not a general-purpose constructor: the sole authorized callsite is
+// EventHandlerService.issueChallengeRescue, which gates invocation on
+// HasSignedFinalize=false. Adding a second callsite without an equivalent guard will
+// cause StoreUserState to fail with a deterministic GetStateID collision against an
+// existing (epoch+1, version=0) row.
 func NewChallengeRescueState(prev State, amount decimal.Decimal) (*State, error) {
 	if prev.HomeChannelID == nil {
 		return nil, fmt.Errorf("prev state has no home channel ID")

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -177,11 +177,16 @@ func NewVoidState(asset, userWallet string) *State {
 
 // NewChallengeRescueState constructs a fully-formed ChallengeRescue state derived from
 // prev — the user's last known state for the asset whose home channel is being closed
-// after a challenge. The rescue state opens a fresh epoch at version 1 with no home
+// after a challenge. The rescue state opens a fresh epoch at version 0 with no home
 // channel and no token/blockchain context (the closed channel is gone); it credits the
 // user the rescued amount as a standalone ledger entry referencing the closed channel
 // (taken from prev.HomeChannelID) via the transition's AccountID. The rescue state is
 // meant to be stored unsigned, like a credit to a user with no open home channel.
+//
+// Version 0 matches the NextState() post-final convention: any in-protocol fresh-epoch
+// state starts at version 0. Callers must guarantee no other (epoch+1, version=0) row
+// already exists for this (wallet, asset) — for the rescue path this is enforced by
+// only invoking it on non-Finalize challenge closes (see HandleHomeChannelClosed).
 func NewChallengeRescueState(prev State, amount decimal.Decimal) (*State, error) {
 	if prev.HomeChannelID == nil {
 		return nil, fmt.Errorf("prev state has no home channel ID")
@@ -195,7 +200,7 @@ func NewChallengeRescueState(prev State, amount decimal.Decimal) (*State, error)
 		Asset:      prev.Asset,
 		UserWallet: prev.UserWallet,
 		Epoch:      prev.Epoch + 1,
-		Version:    1,
+		Version:    0,
 		HomeLedger: Ledger{
 			UserBalance: amount,
 			UserNetFlow: decimal.Zero,

--- a/pkg/core/types_test.go
+++ b/pkg/core/types_test.go
@@ -215,7 +215,7 @@ func TestNewChallengeRescueState(t *testing.T) {
 		}
 	}
 
-	t.Run("Success - opens fresh epoch at version 1 with no channel context", func(t *testing.T) {
+	t.Run("Success - opens fresh epoch at version 0 with no channel context", func(t *testing.T) {
 		prev := makePrev()
 		amount := decimal.NewFromInt(42)
 
@@ -226,7 +226,7 @@ func TestNewChallengeRescueState(t *testing.T) {
 		assert.Equal(t, prev.Asset, rescue.Asset)
 		assert.Equal(t, prev.UserWallet, rescue.UserWallet)
 		assert.Equal(t, prev.Epoch+1, rescue.Epoch)
-		assert.Equal(t, uint64(1), rescue.Version)
+		assert.Equal(t, uint64(0), rescue.Version)
 		assert.Nil(t, rescue.HomeChannelID)
 		assert.Empty(t, rescue.HomeLedger.TokenAddress)
 		assert.Equal(t, uint64(0), rescue.HomeLedger.BlockchainID)


### PR DESCRIPTION
## Summary

- `HandleHomeChannelClosed` previously issued a challenge rescue for every channel that was `Challenged` before the on-chain close, including cooperative closes backed by a node-signed `Finalize`. In that path the rescue either silently overwrote a post-Finalize receiver credit at `(epoch+1, version=0)` or collided on deterministic `GetStateID` with an existing `(epoch+1, version=1)` credit — rolling back the close-event handler and leaving the channel stuck `Challenged`, which in turn blocked `request_creation` for the same `(wallet, asset)` pair.
- Guard the rescue branch with `HasSignedFinalize`. Mirrors the existing post-Finalize check in `HandleHomeChannelCheckpointed`.
- Align `NewChallengeRescueState` with the `NextState()` post-final convention: fresh-epoch state starts at version `0`, not `1`. The guard guarantees no other `(epoch+1, version=0)` row exists when the rescue actually runs.

## Failure modes prevented

Post-Finalize receiver credits are produced by `NextState()` in a fresh epoch with `HomeChannelID=nil`. Without the guard:

1. `GetLastStateByChannelID` only matches channel-attached rows → returns the Finalize state at the original epoch, missing the post-Finalize credits.
2. `SumNetTransitionAmountAfterVersion` filters by `home_channel_id` → returns zero.
3. `NewChallengeRescueState` builds a zero-amount rescue at `(Finalize.Epoch+1, version=1)`.
4. `StoreUserState` either overwrites the lone credit at `(epoch+1, version=0)` (silent balance loss) or collides with `(epoch+1, version=1)` and rolls back the entire close handler.

## Test plan

- [x] `go test ./pkg/core/...` — `TestNewChallengeRescueState` updated for version `0`.
- [x] `go test ./nitronode/event_handlers/... -run TestHandleHomeChannelClosed` — all rescue tests pass.
- [x] New `TestHandleHomeChannelClosed_PostFinalize_SkipsRescue` verifies the rescue branch fully short-circuits when `HasSignedFinalize` is true.
- [x] New `TestHandleHomeChannelClosed_PostFinalize_CollisionRegression` documents the two failure modes the guard prevents.
- [x] New `TestHandleHomeChannelClosed_PostFinalize_HasSignedFinalizeErr` confirms error propagation from the `HasSignedFinalize` lookup.
- [x] Existing rescue tests (`_Squash`, `_NoCredits`, `_NegativeNet_ClampsToZero`) updated for the new version=0 invariant and the added `HasSignedFinalize` mock.
- [x] `go vet ./nitronode/event_handlers/... ./pkg/core/...` clean.

## Follow-ups (separate tickets)

- Post-Finalize unsigned receiver credits at `(epoch+1, version=0..N)` with `HomeChannelID=nil` remain unsigned forever (`channel_v1/handler.go:130` skips node-sig when channel status is non-Open). Confirm `request_creation` folds them into the next signed ledger correctly; otherwise file a separate fix.
- Operator reconciliation for production channels already wedged at `Challenged` due to this bug pre-fix: needs a detection query (`Challenged` channels where `HasSignedFinalize=true`) and a one-shot flip to `Closed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)