### PR TITLE
MF-L03: docs: document home chain migration as not yet active off-chain

### DIFF
--- a/nitronode/README.md
+++ b/nitronode/README.md
@@ -141,6 +141,16 @@ nitronode/
 export GOCACHE=/tmp/gocache && go test -v ./...
 ```
 
+## Protocol Features Not Yet Active
+
+The following protocol operations are fully specified in [protocol-description.md](../protocol-description.md) and implemented in the `ChannelHub` smart contract, but are **not yet active in the Nitronode off-chain implementation**. Submitting these transition types via `channels.v1.submit_state` returns an error.
+
+| Feature | Transition types | Status |
+|---------|-----------------|--------|
+| Home chain migration | `migrate` | Off-chain flow not implemented. On-chain `initiateMigration()` / `finalizeMigration()` are functional. Event handlers for `MigrationInInitiated`, `MigrationOutFinalized`, etc. are stubs. |
+| Cross-chain escrow deposit | `mutual_lock`, `escrow_lock`, `escrow_deposit` | Off-chain flow implemented, but not fully tested. |
+| Cross-chain escrow withdrawal | `escrow_withdraw` | Off-chain flow implemented, but not fully tested. |
+
 ## Documentation
 
 - [Nitrolite Protocol Overview](../protocol-description.md)

--- a/nitronode/store/database/db_store.go
+++ b/nitronode/store/database/db_store.go
@@ -229,7 +229,14 @@ func (s *DBStore) EnsureNoOngoingStateTransitions(wallet, asset string) error {
 		}
 
 	case core.TransitionTypeMigrate:
-		// Verify last_state.version == home_channel.state_version
+		// NOTE: Migration flows are not yet active off-chain. This case is currently unreachable
+		// because submit_state.go rejects TransitionTypeMigrate before EnsureNoOngoingStateTransitions
+		// is called. When migration is implemented, this check must be extended: verifying that
+		// last_state.version == home_channel.state_version confirms only that the preparation state
+		// was enforced on the OLD home chain. A complete gate must also confirm that
+		// initiateMigration() was submitted on the NEW home chain (i.e. a MIGRATING_IN channel
+		// exists with a matching state version), matching the MigrationInInitiated lifecycle step
+		// documented in protocol-description.md.
 		if result.HomeChannelVersion == nil || result.StateVersion != *result.HomeChannelVersion {
 			return fmt.Errorf("home chain migration is still ongoing")
 		}

--- a/protocol-description.md
+++ b/protocol-description.md
@@ -434,6 +434,8 @@ Migration enables moving the channel's "home" security chain from one blockchain
 
 Like other cross-chain operations, migration is **two-phase** and **optimistic**.
 
+> **NOTE:** Home chain migration is **not yet active in the Nitronode off-chain implementation**. The on-chain `ChannelHub` contract fully implements both `initiateMigration()` and `finalizeMigration()`, and the migration protocol is fully specified below. The Nitronode off-chain flow — including the `migrate` transition type, two-chain event coordination, and the `MigrationInInitiated` / `MigrationOutFinalized` lifecycle — has not yet been implemented. Submitting a `migrate` transition via the `channels.v1.submit_state` RPC method returns an error. This section documents the intended design for future implementation.
+
 ---
 
 ### Preparation phase (INITIATE_MIGRATION)


### PR DESCRIPTION
## Summary

- Validates audit finding ACK/MF-L03: `EnsureNoOngoingStateTransitions()` for `TransitionTypeMigrate` only checks that the preparation state version matches the old home channel — it does not verify that `initiateMigration()` was submitted on the new home chain. The gap is real but currently unreachable, as `submit_state.go` rejects all `migrate` transitions before that check is reached.
- Adds a `NOTE` to `protocol-description.md` (migration section) marking the off-chain flow as not yet active.
- Expands the `TransitionTypeMigrate` comment in `db_store.go` to record what a complete gate must verify when the feature is eventually enabled.
- Adds a "Protocol Features Not Yet Active" table to `nitronode/README.md` covering migration and cross-chain escrow flows.