### PR TITLE
fix: audit findings round final 2

### DIFF
--- a/contracts/SECURITY.md
+++ b/contracts/SECURITY.md
@@ -37,6 +37,20 @@ Given the 3 and 4, an invariant:
 Invariant:
 > No different states with the same `version` can exist for the same channel.
 
+---
+
+6. While a channel is in `CHALLENGED` (on-chain `DISPUTED`) status, the Node does not co-sign "receive" states for that channel. Incoming off-chain transfer credits and app-session release credits targeting the channel are appended as unsigned entries to the channel's state history (a per-channel queue). On challenge clearance, the off-chain head is signed by the Node and offered for user acknowledgement. On channel closure, a single `challenge_rescue` state is committed to the user's next epoch detached from the closed channel. Its amount is the net effect on the home-channel balance of transitions stored strictly above the closure version: receives (`transfer_receive`, `release`) contribute positively; sends (`transfer_send`, `commit`) contribute negatively; other transition kinds are excluded because they require onchain backing the chain did not enforce. Signed pre-challenge and unsigned during-challenge rows both contribute. The result is clamped at zero so an adversarial close at a version where the user's own balance was higher than the off-chain head cannot dock the user further; when no relevant transitions exist above closure, the rescue carries zero credit and serves only to advance the state chain off the closed channel.
+
+Invariant:
+> A channel in `CHALLENGED` status has no co-signed "receive" states; therefore, its dispute cannot be cleared by enforcing a receive-credit checkpoint.
+
+---
+
+7. While a channel is in `CHALLENGED` status, all user-initiated operations on the channel are blocked except receiving funds (which the Node queues per rule 6). This includes opening a new channel on the same chain for the same asset. These restrictions persist after the challenge timer expires, until the channel is explicitly closed and `ChannelClosed` event is seen by the Node.
+
+Invariant:
+> Credits accrued while a channel was in `CHALLENGED` status are preserved — either reintegrated into the channel on challenge clearance, or carried into the next epoch on closure — and cannot be shadowed by a concurrently-opened replacement channel.
+
 ## Invariants
 
 ---
@@ -423,6 +437,24 @@ When a **node** employs SessionKeyValidator (NOT RECOMMENDED):
 Session keys cannot be used for challenge signatures. `SessionKeyValidator.validateChallengeSignature` always reverts with `ChallengeWithSessionKeyNotSupported`.
 
 **Rationale**: A session key authorization — once signed by the user — is permanently valid on-chain because the contract only checks the cryptographic signature, not expiration or revocation. If session keys were allowed to challenge, an expired or revoked key could put any channel (where the validator is approved) into `DISPUTED` state unilaterally, bypassing Nitronode's off-chain enforcement and causing a DoS on the channel.
+
+#### Accepted Limitation: Off-Chain Session Key Scope Enforcement Does Not Apply to Direct Receive-State Acknowledgement
+
+Session key expiration and asset-scope restrictions are enforced **off-chain** by the Nitronode only. The `SessionKeyValidator` contract validates cryptographic signatures alone — it has no on-chain representation of expiration timestamps or allowed assets.
+
+**Receive-state background**: When a user receives funds off-chain, the node produces a state reflecting the increased allocation and signs it unilaterally. This node-only-signed state must be *acknowledged* by the user — signed by the user's key — to become mutually signed and enforceable on-chain. The Nitronode's `acknowledge` endpoint enforces session key validity (expiration, scope) before accepting the acknowledgement.
+
+**The bypass**: A user — or any third party in possession of the session key, including keys that have expired, been revoked off-chain, or explicitly retired — can skip the `acknowledge` endpoint entirely by:
+
+1. Fetching the node-signed receive state directly.
+2. Signing it manually with the session key.
+3. Submitting the mutually-signed state directly to the ChannelHub contract.
+
+The contract accepts the submission because both signatures are cryptographically valid. The on-chain contract has no mechanism to enforce off-chain session key constraints.
+
+**Accepted risk**: This inconsistency is acknowledged and accepted. Receive states can only increase the user's allocation — they cannot redirect funds away from the user. Earlier on-chain enforcement of receive states is always in the user's interest: if the node becomes unavailable before pending receive states are acknowledged, submitting them directly on-chain is the only remaining recovery path. Because the outcome is strictly beneficial to the user, this bypass does not constitute a financial risk.
+
+**User guidance**: Any party in possession of a session key that was ever authorized on a channel — regardless of whether the key has since expired, been revoked, or been retired — can acknowledge pending receive states and enforce them on-chain. Users should treat session key material accordingly even after decommissioning a key.
 
 ---
 

--- a/contracts/signature-validators.md
+++ b/contracts/signature-validators.md
@@ -191,7 +191,8 @@ bytes sigBody = abi.encode(SessionKeyAuthorization, bytes sessionKeySignature)
 
 **Two checks:**
 
-1. Participant authorized the session key: `authData = abi.encode(sessionKey, metadataHash)`
+1. Participant authorized the session key: `authData = abi.encode(SESSION_KEY_AUTH_TYPEHASH, sessionKey, metadataHash)`
+   where `SESSION_KEY_AUTH_TYPEHASH = keccak256("Nitrolite.SessionKey(address sessionKey,bytes32 metadataHash)")`
 2. Session key signed the state
 
 Both use EIP-191 first, then raw ECDSA if that fails.

--- a/contracts/src/sigValidators/SessionKeyValidator.sol
+++ b/contracts/src/sigValidators/SessionKeyValidator.sol
@@ -10,6 +10,10 @@ import {
 import {EcdsaSignatureUtils} from "./EcdsaSignatureUtils.sol";
 import {Utils} from "../Utils.sol";
 
+/// @dev Type hash for `SessionKeyAuthorization`, included in the authorization payload to prevent
+///      reuse of unrelated `abi.encode(address, bytes32)` signatures as session-key authorizations.
+bytes32 constant SESSION_KEY_AUTH_TYPEHASH = keccak256("Nitrolite.SessionKey(address sessionKey,bytes32 metadataHash)");
+
 /**
  * @notice Authorization struct for delegating signing authority to a session key
  * @dev The participant signs this authorization to allow the session key to sign on their behalf
@@ -25,6 +29,7 @@ struct SessionKeyAuthorization {
 
 function toSigningData(SessionKeyAuthorization memory skAuth) pure returns (bytes memory) {
     return abi.encode(
+        SESSION_KEY_AUTH_TYPEHASH,
         skAuth.sessionKey,
         skAuth.metadataHash
         // omit authSignature

--- a/contracts/test/ChannelHub_Node.t.sol
+++ b/contracts/test/ChannelHub_Node.t.sol
@@ -8,7 +8,8 @@ import {ChannelHub} from "../src/ChannelHub.sol";
 
 contract ChannelHubTest_depositToNode is ChannelHubTest_Base {
     // TODO:
-}
+
+    }
 
 contract ChannelHubTest_withdrawFromNode is ChannelHubTest_Base {
     RevertingEthReceiver public revertingReceiver;

--- a/contracts/test/ChannelHub_Node.t.sol
+++ b/contracts/test/ChannelHub_Node.t.sol
@@ -8,8 +8,7 @@ import {ChannelHub} from "../src/ChannelHub.sol";
 
 contract ChannelHubTest_depositToNode is ChannelHubTest_Base {
     // TODO:
-
-    }
+}
 
 contract ChannelHubTest_withdrawFromNode is ChannelHubTest_Base {
     RevertingEthReceiver public revertingReceiver;

--- a/contracts/test/Utils.t.sol
+++ b/contracts/test/Utils.t.sol
@@ -198,14 +198,14 @@ contract UtilsTest is Test {
         bytes memory encoded = toSigningData(auth);
 
         console.log("SessionKeyAuthorization signing data:");
-        // 0x0000000000000000000000003fba6f40f2cd5b4d833e0305061b88f029ea504459c85ca0f1634dd72294eec96f6d613893a9d3add6943b6f32f9cf7df0858239
+        // 0x251773da8b8949935ef07284d20cc8605ad7d6f4cf6b5e040ce07dae857f0b6c0000000000000000000000003fba6f40f2cd5b4d833e0305061b88f029ea504459c85ca0f1634dd72294eec96f6d613893a9d3add6943b6f32f9cf7df0858239
         console.logBytes(encoded);
 
         // 0x5C372EBfC9029aFe7F7506a4d9586604A40e117F
         uint256 privKey = 0xefc7c391f4ce326e149bb9943658998227094eb3e0acc92c343241e22fbc7624;
         bytes memory authSignature = TestUtils.signEip191(vm, privKey, encoded);
         console.log("Auth signature:");
-        // 0x0dd14906d8d4dc22ffe48c6fbec99323e1fd149c71fdd9a5fafbc584eed1e9cb00f4e761bb12a7b7271f760ee77f58a7feb9c89b7d70f1e07fcfa60846a74bd41b
+        // 0x287f031625a7a3ac8329d7746c5370c30ffad9857b6e0d022296af4bcad9ca4e0b1b680c3231f5508a1a01406697349afedff09b44c4a26a7881aa262c8bbcee1b
         console.logBytes(authSignature);
 
         auth.authSignature = authSignature;

--- a/contracts/test/sigValidators/SessionKeyValidator.t.sol
+++ b/contracts/test/sigValidators/SessionKeyValidator.t.sol
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.30;
 
-import {Test} from "forge-std/Test.sol";
+import {Test, console} from "forge-std/Test.sol";
 
 import {TestUtils} from "../TestUtils.sol";
 
 import {
     SessionKeyValidator,
     SessionKeyAuthorization,
+    SESSION_KEY_AUTH_TYPEHASH,
     toSigningData
 } from "../../src/sigValidators/SessionKeyValidator.sol";
 import {ValidationResult, VALIDATION_SUCCESS, VALIDATION_FAILURE} from "../../src/interfaces/ISignatureValidator.sol";
@@ -207,6 +208,40 @@ contract SessionKeyValidatorTest_validateSignature is SessionKeyValidatorTest_Ba
 
         ValidationResult result = validator.validateSignature(CHANNEL_ID, SIGNING_DATA, signature, user);
         assertEq(ValidationResult.unwrap(result), ValidationResult.unwrap(VALIDATION_FAILURE));
+    }
+
+    function test_log_toSigningData() public pure {
+        address FIXED_SESSION_KEY = address(0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF);
+        bytes32 FIXED_METADATA_HASH =
+            bytes32(uint256(0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890));
+
+        SessionKeyAuthorization memory skAuth = SessionKeyAuthorization({
+            sessionKey: FIXED_SESSION_KEY, metadataHash: FIXED_METADATA_HASH, authSignature: ""
+        });
+
+        bytes memory encoded = toSigningData(skAuth);
+
+        // Verify full 96-byte golden value: typehash || padded address || metadataHash.
+        bytes memory expected = hex"251773da8b8949935ef07284d20cc8605ad7d6f4cf6b5e040ce07dae857f0b6c"
+            hex"000000000000000000000000deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+            hex"abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
+        assertEq(encoded.length, 96);
+        assertEq(encoded, expected);
+
+        // Verify typehash is the first 32 bytes of the encoded payload.
+        bytes32 typehashWord;
+        assembly {
+            typehashWord := mload(add(encoded, 32))
+        }
+        assertEq(typehashWord, SESSION_KEY_AUTH_TYPEHASH);
+
+        console.log("SESSION_KEY_AUTH_TYPEHASH:");
+        // 0x251773da8b8949935ef07284d20cc8605ad7d6f4cf6b5e040ce07dae857f0b6c
+        console.logBytes32(SESSION_KEY_AUTH_TYPEHASH);
+
+        console.log("toSigningData output (96 bytes: typehash || sessionKey || metadataHash):");
+        // 0x251773da8b8949935ef07284d20cc8605ad7d6f4cf6b5e040ce07dae857f0b6c000000000000000000000000deadbeefdeadbeefdeadbeefdeadbeefdeadbeefabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890
+        console.logBytes(encoded);
     }
 }
 

--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -49,6 +49,7 @@ types:
         - escrow_withdraw
         - migrate
         - finalize
+        - challenge_rescue
 
   - transition:
       description: Represents a state transition
@@ -298,6 +299,7 @@ types:
         - migrate
         - rebalance
         - finalize
+        - challenge_rescue
 
   - transaction:
       description: Transaction record

--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -534,7 +534,14 @@ api:
                 - message: channel_not_found
                   description: The specified channel was not found
             - name: get_escrow_channel
-              description: Retrieve current on-chain escrow channel information
+              description: |
+                Retrieve current on-chain escrow channel information.
+
+                Note: when the escrow channel has been closed by the on-chain
+                purge queue (no signed FINALIZE_ESCROW_DEPOSIT was received
+                before expiry), `state_version` on the returned channel reflects
+                the initiate version (N) and does not advance to the finalize
+                version (N+1).
               request:
                 - field_name: escrow_channel_id
                   type: string

--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -381,10 +381,17 @@ types:
           description: Unix timestamp in seconds indicating when the session key expires
         - name: user_sig
           type: string
-          description: User's signature over the session key metadata to authorize the registration/update of the session key
+          description: >
+            User's EIP-191 signature over abi.encode(SESSION_KEY_AUTH_TYPEHASH, session_key, metadata_hash),
+            where SESSION_KEY_AUTH_TYPEHASH = keccak256("Nitrolite.SessionKey(address sessionKey,bytes32 metadataHash)")
+            and metadata_hash = keccak256(abi.encode(user_address, version, assets[], expires_at)).
+            Authorizes the delegation of signing authority to the session key.
         - name: session_key_sig
           type: string
-          description: Session-key holder's signature over PackChannelKeyStateV1(session_key, metadata_hash) — the same packed bytes user_sig signs, where metadata_hash binds user_address — proving possession of the key being registered. Required on every submit to prevent registration of keys the submitter does not control.
+          description: >
+            Session-key holder's EIP-191 signature over the same payload as user_sig —
+            abi.encode(SESSION_KEY_AUTH_TYPEHASH, session_key, metadata_hash) — proving possession of the key
+            being registered. Required on every submit to prevent registration of keys the submitter does not control.
 
   - app_session_key_state:
       description: Represents the state of an app session key

--- a/docs/protocol/cryptography.md
+++ b/docs/protocol/cryptography.md
@@ -93,9 +93,12 @@ A participant MAY delegate signing authority to a session key.
 
 The authorization is constructed as follows:
 
-1. The participant signs a message containing:
-   - the session key address
-   - authorization metadata hash (`keccak256` over the canonically encoded authorization metadata structure)
+1. The participant signs an authorization payload constructed as:
+   `abi.encode(SESSION_KEY_AUTH_TYPEHASH, sessionKey, metadataHash)`
+   where `SESSION_KEY_AUTH_TYPEHASH = keccak256("Nitrolite.SessionKey(address sessionKey,bytes32 metadataHash)")`,
+   `sessionKey` is the address of the delegated key, and `metadataHash` is the `keccak256` hash of the
+   canonically encoded authorization metadata structure. The type hash prefix prevents unrelated
+   64-byte signed values from being reused as session-key authorizations.
 2. The authorization signature is produced using the participant's primary key
 3. The session key MAY then produce signatures on behalf of the participant within the authorized scope
 

--- a/docs/protocol/enforcement.md
+++ b/docs/protocol/enforcement.md
@@ -118,6 +118,21 @@ Additionally, it is possible to close the channel unilaterally by submitting a v
 
 After the challenge period expires without being resolved, the disputed state becomes **final**. However, a separate **close call** is still required to release the channel's locked funds. Such close call does not require any state to be submitted alongside, only the id of a channel, and can be invoked by anyone.
 
+### Off-chain behaviour during dispute
+
+While a channel is in `CHALLENGED` (i.e. on-chain `DISPUTED`) status, the Node and the user follow additional off-chain rules:
+
+- **Node stops signing receive states.** Incoming off-chain transfer credits and app-session release credits targeting the channel are not co-signed. They are appended as unsigned entries to the channel's state history (a per-channel queue).
+- **User-initiated operations are blocked.** The user cannot deposit, withdraw, transfer, or lock funds into an app session. Only receiving funds (which the Node queues per the previous rule) is permitted.
+- **Operations remain blocked even after the challenge timer expires**, until the channel is explicitly closed and `ChannelClosed` event is seen by the Node.
+
+Two resolution paths:
+
+- **Challenge cleared** (a newer mutually signed state is enforced, returning the channel to `OPERATING`): the Node signs only the off-chain head — the highest-version queued "receive" state — so the channel's actual latest state is fully co-signed; the user countersigns and acknowledges. Earlier queued entries remain unsigned in history; the head carries forward their cumulative balance impact, so normal flow resumes with no gap and no credit lost.
+- **Challenge expires and the channel is closed**: a single `challenge_rescue` state is committed to the user's next epoch, detached from the closed channel — equivalent to the funds arriving while the user did not have a channel. Its amount is the **net effect on the home-channel balance of transitions stored strictly above the closure version** at the closed channel's epoch: receives (`transfer_receive`, `release`) contribute positively; sends (`transfer_send`, `commit`) contribute negatively; other transition kinds (deposit, withdrawal, escrow, migrate, finalize) are excluded because they require onchain backing the chain did not enforce. Signed (pre-challenge) and unsigned (during-challenge) rows both contribute. The result is clamped at zero so an adversarial close at a version where the user's own balance was higher than the off-chain head cannot dock the user further. When no relevant transitions exist above closure, the state carries zero credit and serves only to advance the state chain off the closed channel so future operations are not wedged on it.
+
+The purpose of these rules is to ensure that a `CHALLENGED` channel cannot have its dispute cleared as a side effect of incoming third-party transfers, and that the user is made whole for net real value owed by the Node regardless of which resolution path is taken.
+
 ## Close Operation
 
 A close releases the channel's locked funds and terminates the channel lifecycle.

--- a/docs/protocol/security-and-limitations.md
+++ b/docs/protocol/security-and-limitations.md
@@ -73,13 +73,14 @@ Participants do not need to trust nodes for:
 
 ## Known Limitations
 
-The following capabilities are not yet implemented:
+The following capabilities are not yet implemented or have acknowledged design trade-offs:
 
 - Trustless off-chain state operations (node liquidity enforcement)
 - Validator network for monitoring node behaviour and enforcing correctness
 - Watchtower services for automated enforcement
 - Support for non-EVM blockchains
 - Formal verification of protocol rules
+- Session key off-chain scope enforcement does not apply to direct receive-state acknowledgement. Session key expiration and asset-scope restrictions are enforced by the Nitronode off-chain only; the `SessionKeyValidator` contract validates cryptographic signatures alone. A party holding a session key — even one that has expired, been revoked, or been retired — can bypass the `acknowledge` endpoint, manually sign a pending node-issued receive state, and submit it directly to the contract. This is accepted: receive states exclusively increase the user's allocation and cannot redirect funds away from the user, so out-of-scope acknowledgement carries no financial risk and preserves a recovery path when the node is unavailable.
 
 ## Future Improvements
 

--- a/nitronode/README.md
+++ b/nitronode/README.md
@@ -141,6 +141,16 @@ nitronode/
 export GOCACHE=/tmp/gocache && go test -v ./...
 ```
 
+## Protocol Features Not Yet Active
+
+The following protocol operations are fully specified in [protocol-description.md](../protocol-description.md) and implemented in the `ChannelHub` smart contract, but are **not yet active in the Nitronode off-chain implementation**. Submitting these transition types via `channels.v1.submit_state` returns an error.
+
+| Feature | Transition types | Status |
+|---------|-----------------|--------|
+| Home chain migration | `migrate` | Off-chain flow not implemented. On-chain `initiateMigration()` / `finalizeMigration()` are functional. Event handlers for `MigrationInInitiated`, `MigrationOutFinalized`, etc. are stubs. |
+| Cross-chain escrow deposit | `mutual_lock`, `escrow_lock`, `escrow_deposit` | Off-chain flow implemented, but not fully tested. |
+| Cross-chain escrow withdrawal | `escrow_withdraw` | Off-chain flow implemented, but not fully tested. |
+
 ## Documentation
 
 - [Nitrolite Protocol Overview](../protocol-description.md)

--- a/nitronode/api/app_session_v1/README.md
+++ b/nitronode/api/app_session_v1/README.md
@@ -831,7 +831,7 @@ The implementation uses Ethereum ABI encoding for deterministic hashing and sign
 #### `PackAppSessionKeyStateV1(state AppSessionKeyStateV1) ([]byte, error)`
 - Packs session key state for signature verification using ABI encoding
 - Encodes: user_address (address), session_key (address), version (uint64), application_ids (bytes32[]), app_session_ids (bytes32[]), expires_at (uint64)
-- Each `application_id` and `app_session_id` string is converted to bytes32 via `keccak256(utf8(id))`, so every distinct string — including human-readable IDs like `"app-1"` — produces a unique hash with no collisions
+- Each `application_id` and `app_session_id` string is converted to bytes32 via `keccak256(utf8(id))`, providing deterministic, collision-resistant identifiers in practice
 - Excludes the `user_sig` field (it is the signature itself)
 - Returns Keccak256 hash of ABI-encoded data
 - Used in `submit_session_key_state` to verify the user's signature

--- a/nitronode/api/app_session_v1/README.md
+++ b/nitronode/api/app_session_v1/README.md
@@ -706,6 +706,8 @@ ORDER BY created_at DESC;
 - `version` must be greater than 0
 - `expires_at` must be in the future
 - `user_sig` is required
+- `application_ids` entries must be lowercase strings (non-lowercase values are rejected before signature verification)
+- `app_session_ids` entries must be lowercase strings (non-lowercase values are rejected before signature verification)
 - Version must be sequential (latest_version + 1)
 - Signature must recover to `user_address`
 - Newly registered keys count against the per-user cap (`NITRONODE_MAX_SESSION_KEYS_PER_USER`, default 100). Updates to keys that already exist for the user are not blocked by the cap.
@@ -715,6 +717,7 @@ ORDER BY created_at DESC;
 **Signature Verification**:
 - Uses ABI encoding via `PackAppSessionKeyStateV1` to create a deterministic hash
 - Encodes: user_address (address), session_key (address), version (uint64), application_ids (bytes32[]), app_session_ids (bytes32[]), expires_at (uint64)
+- Each application_id and app_session_id string is converted to bytes32 via `keccak256(utf8(id))` before ABI encoding
 - The `user_sig` field is excluded from packing (it is the signature itself)
 - Recovers signer address from ECDSA signature
 - Validates that recovered address matches `user_address`
@@ -828,6 +831,7 @@ The implementation uses Ethereum ABI encoding for deterministic hashing and sign
 #### `PackAppSessionKeyStateV1(state AppSessionKeyStateV1) ([]byte, error)`
 - Packs session key state for signature verification using ABI encoding
 - Encodes: user_address (address), session_key (address), version (uint64), application_ids (bytes32[]), app_session_ids (bytes32[]), expires_at (uint64)
+- Each `application_id` and `app_session_id` string is converted to bytes32 via `keccak256(utf8(id))`, so every distinct string — including human-readable IDs like `"app-1"` — produces a unique hash with no collisions
 - Excludes the `user_sig` field (it is the signature itself)
 - Returns Keccak256 hash of ABI-encoded data
 - Used in `submit_session_key_state` to verify the user's signature

--- a/nitronode/api/app_session_v1/handler.go
+++ b/nitronode/api/app_session_v1/handler.go
@@ -164,19 +164,33 @@ func (h *Handler) issueReleaseReceiverState(ctx context.Context, tx Store, recei
 	}
 
 	if newState.HomeChannelID != nil {
-		// Pack and sign the state
-		packedState, err := h.statePacker.PackState(*newState)
+		// Same rule as channel_v1.issueTransferReceiverState: sign only when the
+		// receiver's home channel is Open. CheckActiveChannel returns nil status for
+		// Challenged / Closing / Closed channels, in which case the state is stored
+		// unsigned so the challenge-rescue squash at close (Challenged path) can pick
+		// it up, and so terminal-status channels never receive a node-signed credit
+		// that won't settle.
+		_, channelStatus, err := tx.CheckActiveChannel(receiverWallet, asset)
 		if err != nil {
-			return rpc.Errorf("failed to pack receiver state: %v", err)
+			return rpc.Errorf("failed to check receiver active channel: %v", err)
 		}
+		if channelStatus != nil && *channelStatus == core.ChannelStatusOpen {
+			packedState, err := h.statePacker.PackState(*newState)
+			if err != nil {
+				return rpc.Errorf("failed to pack receiver state: %v", err)
+			}
 
-		nodeSig, err := h.signer.Sign(packedState)
-		if err != nil {
-			return rpc.Errorf("failed to sign receiver state: %v", err)
+			nodeSig, err := h.signer.Sign(packedState)
+			if err != nil {
+				return rpc.Errorf("failed to sign receiver state: %v", err)
+			}
+
+			nodeSigStr := nodeSig.String()
+			newState.NodeSig = &nodeSigStr
+		} else {
+			logger.Info("skipping node signature on receiver state for non-open home channel",
+				"homeChannelID", *newState.HomeChannelID)
 		}
-
-		nodeSigStr := nodeSig.String()
-		newState.NodeSig = &nodeSigStr
 	}
 
 	// Store the new state

--- a/nitronode/api/app_session_v1/interface.go
+++ b/nitronode/api/app_session_v1/interface.go
@@ -40,6 +40,7 @@ type Store interface {
 	// and Open (materialized onchain); callers needing onchain materialization must additionally
 	// require Status == core.ChannelStatusOpen.
 	CheckActiveChannel(wallet, asset string) (string, *core.ChannelStatus, error)
+
 	GetLastUserState(wallet, asset string, signed bool) (*core.State, error)
 	// StoreUserState persists a user state. applicationID is the client-declared
 	// origin tag (rpc.ApplicationIDQueryParam); empty string is persisted as NULL.

--- a/nitronode/api/app_session_v1/submit_app_state_test.go
+++ b/nitronode/api/app_session_v1/submit_app_state_test.go
@@ -352,6 +352,7 @@ func TestSubmitAppState_WithdrawIntent_Success(t *testing.T) {
 	mockStore.On("LockUserState", participant1, "USDC").Return(decimal.Zero, nil)
 	mockStore.On("GetLastUserState", participant1, "USDC", false).Return(existingUserState, nil)
 	mockStore.On("EnsureNoOngoingEscrowOperation", participant1, "USDC").Return(nil)
+	mockStore.On("CheckActiveChannel", participant1, "USDC").Return("0x03", core.ChannelStatusOpen, nil)
 	mockStatePacker.On("PackState", mock.Anything).Return([]byte("packed"), nil)
 	mockStore.On("RecordTransaction", mock.Anything, mock.Anything).Return(nil)
 
@@ -388,6 +389,136 @@ func TestSubmitAppState_WithdrawIntent_Success(t *testing.T) {
 	require.NotNil(t, capturedState.NodeSig, "Node signature should be present on stored state")
 	VerifyNodeSignature(t, nodeAddress, []byte("packed"), *capturedState.NodeSig)
 
+	mockStore.AssertExpectations(t)
+}
+
+func TestSubmitAppState_WithdrawIntent_ReceiverHomeChannelChallenged_NoNodeSig(t *testing.T) {
+	// When the receiver's home channel is Challenged, the release receiver state must be
+	// persisted without a node signature. Mirrors the channel_v1 protection: otherwise an
+	// attacker holding an expired or out-of-scope session key could checkpoint a
+	// node-signed release-credit state and reset the dispute timer.
+	mockStore := new(MockStore)
+	mockSigner := NewMockChannelSigner()
+	nodeAddress := strings.ToLower(mockSigner.PublicKey().Address().String())
+
+	storeTxProvider := func(fn StoreTxHandler) error {
+		return fn(mockStore)
+	}
+
+	mockAssetStore := new(MockAssetStore)
+	mockStatePacker := new(MockStatePacker)
+
+	handler := NewHandler(
+		storeTxProvider,
+		mockAssetStore,
+		&MockActionGateway{},
+		mockSigner,
+		core.NewStateAdvancerV1(mockAssetStore),
+		mockStatePacker,
+		nodeAddress,
+		true,
+		metrics.NewNoopRuntimeMetricExporter(),
+		32, 1024, 256, 16, 100,
+	)
+
+	appSessionID := "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+	wallet1 := NewTestAppSessionWallet(t)
+	participant1 := wallet1.Address
+
+	existingSession := &app.AppSessionV1{
+		SessionID:     appSessionID,
+		ApplicationID: "test-app",
+		Participants: []app.AppParticipantV1{
+			{WalletAddress: participant1, SignatureWeight: 10},
+		},
+		Quorum:      10,
+		Status:      app.AppSessionStatusOpen,
+		Version:     1,
+		SessionData: "",
+	}
+
+	currentAllocations := map[string]map[string]decimal.Decimal{
+		participant1: {"USDC": decimal.NewFromInt(100)},
+	}
+
+	appStateUpdateCore := app.AppStateUpdateV1{
+		AppSessionID: appSessionID,
+		Intent:       app.AppStateUpdateIntentWithdraw,
+		Version:      2,
+		Allocations: []app.AppAllocationV1{
+			{Participant: participant1, Asset: "USDC", Amount: decimal.NewFromInt(60)},
+		},
+		SessionData: "",
+	}
+	sig1 := wallet1.SignAppStateUpdate(t, appStateUpdateCore)
+
+	reqPayload := rpc.AppSessionsV1SubmitAppStateRequest{
+		AppStateUpdate: rpc.AppStateUpdateV1{
+			AppSessionID: appSessionID,
+			Intent:       app.AppStateUpdateIntentWithdraw,
+			Version:      "2",
+			Allocations: []rpc.AppAllocationV1{
+				{Participant: participant1, Asset: "USDC", Amount: "60"},
+			},
+			SessionData: "",
+		},
+		QuorumSigs: []string{sig1},
+	}
+
+	mockStore.On("GetApp", "test-app").Return(&app.AppInfoV1{
+		App: app.AppV1{ID: "test-app", OwnerWallet: "0x0000000000000000000000000000000000000001"},
+	}, nil).Maybe()
+	mockStore.On("GetAppSession", appSessionID).Return(existingSession, nil)
+	mockStore.On("GetParticipantAllocations", appSessionID).Return(currentAllocations, nil)
+	mockAssetStore.On("GetAssetDecimals", "USDC").Return(uint8(6), nil)
+	mockStore.On("RecordLedgerEntry", participant1, appSessionID, "USDC", decimal.NewFromInt(-40)).Return(nil)
+
+	homeChannelID := "0xHomeChannel"
+	existingUserState := core.State{
+		Asset:         "USDC",
+		UserWallet:    participant1,
+		Epoch:         1,
+		Version:       1,
+		HomeChannelID: &homeChannelID,
+		HomeLedger: core.Ledger{
+			UserBalance: decimal.NewFromInt(200),
+			UserNetFlow: decimal.NewFromInt(200),
+		},
+	}
+	mockStore.On("LockUserState", participant1, "USDC").Return(decimal.Zero, nil)
+	mockStore.On("GetLastUserState", participant1, "USDC", false).Return(existingUserState, nil)
+	mockStore.On("EnsureNoOngoingEscrowOperation", participant1, "USDC").Return(nil)
+	// Challenged receiver channel returns nil status from CheckActiveChannel
+	// (status > Open), so the receiver state is stored unsigned and the squash
+	// at HomeChannelClosed will pick it up.
+	mockStore.On("CheckActiveChannel", participant1, "USDC").Return("", nil, nil)
+	mockStore.On("RecordTransaction", mock.Anything, mock.Anything).Return(nil)
+
+	var capturedState core.State
+	mockStore.On("StoreUserState", mock.MatchedBy(func(state core.State) bool {
+		capturedState = state
+		return true
+	}), mock.Anything).Return(nil)
+
+	mockStore.On("UpdateAppSession", mock.MatchedBy(func(session app.AppSessionV1) bool {
+		return session.Version == 2 && session.Status == app.AppSessionStatusOpen
+	})).Return(nil)
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, string(rpc.AppSessionsV1SubmitAppStateMethod), payload),
+	}
+
+	handler.SubmitAppState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	if respErr := ctx.Response.Error(); respErr != nil {
+		t.Fatalf("Unexpected error response: %v", respErr)
+	}
+	require.Nil(t, capturedState.NodeSig, "Node signature must NOT be present when home channel is Challenged")
+	mockStatePacker.AssertNotCalled(t, "PackState", mock.Anything)
 	mockStore.AssertExpectations(t)
 }
 
@@ -631,12 +762,14 @@ func TestSubmitAppState_CloseIntent_Success(t *testing.T) {
 	mockStore.On("EnsureNoOngoingEscrowOperation", participant1, "USDC").Return(nil)
 	mockStatePacker.On("PackState", mock.Anything).Return([]byte("packed"), nil)
 	mockStore.On("RecordTransaction", mock.Anything, mock.Anything).Return(nil)
+	mockStore.On("CheckActiveChannel", participant1, "USDC").Return("0x03", core.ChannelStatusOpen, nil)
 
 	// Participant 2: 50 USDC
 	mockStore.On("RecordLedgerEntry", participant2, appSessionID, "USDC", decimal.NewFromInt(-50)).Return(nil)
 	mockStore.On("LockUserState", participant2, "USDC").Return(decimal.Zero, nil)
 	mockStore.On("GetLastUserState", participant2, "USDC", false).Return(existingUserState2, nil)
 	mockStore.On("EnsureNoOngoingEscrowOperation", participant2, "USDC").Return(nil)
+	mockStore.On("CheckActiveChannel", participant2, "USDC").Return("0x03", core.ChannelStatusOpen, nil)
 
 	// Capture stored states to verify node signatures
 	var capturedStates []core.State

--- a/nitronode/api/app_session_v1/submit_deposit_state_test.go
+++ b/nitronode/api/app_session_v1/submit_deposit_state_test.go
@@ -196,6 +196,7 @@ func TestSubmitDepositState_Success(t *testing.T) {
 	mockStore.On("GetLastUserState", participant1, asset, false).Return(currentUserState, nil).Once()
 	mockStore.On("EnsureNoOngoingStateTransitions", participant1, asset).Return(nil).Once()
 	mockAssetStore.On("GetAssetDecimals", asset).Return(uint8(6), nil)
+	mockAssetStore.On("GetTokenDecimals", uint64(1), "0xTokenAddress").Return(uint8(6), nil).Maybe()
 	mockStore.On("GetApp", "test-app").Return(&app.AppInfoV1{
 		App: app.AppV1{ID: "test-app", OwnerWallet: "0x0000000000000000000000000000000000000001"},
 	}, nil).Maybe()
@@ -545,6 +546,7 @@ func TestSubmitDepositState_QuorumNotMet(t *testing.T) {
 	mockStore.On("GetLastUserState", participant1, asset, false).Return(currentUserState, nil).Once()
 	mockStore.On("EnsureNoOngoingStateTransitions", participant1, asset).Return(nil).Once()
 	mockAssetStore.On("GetAssetDecimals", asset).Return(uint8(6), nil)
+	mockAssetStore.On("GetTokenDecimals", uint64(1), "0xTokenAddress").Return(uint8(6), nil).Maybe()
 	mockStore.On("GetApp", "test-app").Return(&app.AppInfoV1{
 		App: app.AppV1{ID: "test-app", OwnerWallet: "0x0000000000000000000000000000000000000001"},
 	}, nil).Maybe()
@@ -692,6 +694,7 @@ func TestSubmitDepositState_AppRegistryDisabled(t *testing.T) {
 	mockStore.On("GetLastUserState", participant1, asset, false).Return(currentUserState, nil).Once()
 	mockStore.On("EnsureNoOngoingStateTransitions", participant1, asset).Return(nil).Once()
 	mockAssetStore.On("GetAssetDecimals", asset).Return(uint8(6), nil)
+	mockAssetStore.On("GetTokenDecimals", uint64(1), "0xTokenAddress").Return(uint8(6), nil).Maybe()
 	mockStore.On("GetAppSession", appSessionID).Return(existingAppSession, nil).Once()
 	mockStore.On("GetParticipantAllocations", appSessionID).Return(
 		map[string]map[string]decimal.Decimal{}, nil,
@@ -837,6 +840,7 @@ func TestSubmitDepositState_DuplicateAllocation_Rejected(t *testing.T) {
 	mockStore.On("GetLastUserState", participant1, asset, false).Return(currentUserState, nil).Once()
 	mockStore.On("EnsureNoOngoingStateTransitions", participant1, asset).Return(nil).Once()
 	mockAssetStore.On("GetAssetDecimals", asset).Return(uint8(6), nil)
+	mockAssetStore.On("GetTokenDecimals", uint64(1), "0xTokenAddress").Return(uint8(6), nil).Maybe()
 	mockStore.On("GetParticipantAllocations", appSessionID).Return(
 		map[string]map[string]decimal.Decimal{}, nil,
 	).Once()
@@ -970,6 +974,7 @@ func TestSubmitDepositState_InvalidDecimalPrecision_Rejected(t *testing.T) {
 	mockStore.On("GetLastUserState", participant1, asset, false).Return(currentUserState, nil).Once()
 	mockStore.On("EnsureNoOngoingStateTransitions", participant1, asset).Return(nil).Once()
 	mockAssetStore.On("GetAssetDecimals", asset).Return(uint8(6), nil)
+	mockAssetStore.On("GetTokenDecimals", uint64(1), "0xTokenAddress").Return(uint8(6), nil).Maybe()
 	mockStore.On("GetParticipantAllocations", appSessionID).Return(
 		map[string]map[string]decimal.Decimal{}, nil,
 	).Once()

--- a/nitronode/api/app_session_v1/submit_session_key_state.go
+++ b/nitronode/api/app_session_v1/submit_session_key_state.go
@@ -69,6 +69,18 @@ func (h *Handler) SubmitSessionKeyState(c *rpc.Context) {
 		c.Fail(rpc.Errorf("invalid_session_key_state: application_ids array exceeds maximum length of %d", h.maxSessionKeyIDs), "")
 		return
 	}
+	for _, id := range coreState.ApplicationIDs {
+		if id != strings.ToLower(id) {
+			c.Fail(rpc.Errorf("invalid_session_key_state: application_ids must be lowercase, got: %s", id), "")
+			return
+		}
+	}
+	for _, id := range coreState.AppSessionIDs {
+		if id != strings.ToLower(id) {
+			c.Fail(rpc.Errorf("invalid_session_key_state: app_session_ids must be lowercase, got: %s", id), "")
+			return
+		}
+	}
 	if coreState.UserSig == "" {
 		c.Fail(rpc.Errorf("invalid_session_key_state: user_sig is required"), "")
 		return

--- a/nitronode/api/app_session_v1/submit_session_key_state_test.go
+++ b/nitronode/api/app_session_v1/submit_session_key_state_test.go
@@ -485,6 +485,92 @@ func TestSubmitSessionKeyState_AllowsUpdateForExistingKeyAtCap(t *testing.T) {
 	mockStore.AssertNotCalled(t, "CountSessionKeysForUser", mock.Anything)
 }
 
+func TestSubmitSessionKeyState_RejectsNonLowercaseApplicationID(t *testing.T) {
+	mockStore := new(MockStore)
+	handler := &Handler{
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockStore)
+		},
+		metrics:          metrics.NewNoopRuntimeMetricExporter(),
+		maxSessionKeyIDs: 10,
+	}
+
+	userSigner := NewMockSigner()
+	userAddress := strings.ToLower(userSigner.PublicKey().Address().String())
+	sessionKeyAddress := "0x3333333333333333333333333333333333333333"
+
+	reqPayload := rpc.AppSessionsV1SubmitSessionKeyStateRequest{
+		State: rpc.AppSessionKeyStateV1{
+			UserAddress:    userAddress,
+			SessionKey:     sessionKeyAddress,
+			Version:        "1",
+			ApplicationIDs: []string{"App-1"},
+			AppSessionIDs:  []string{},
+			ExpiresAt:      strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10),
+			UserSig:        "0xdeadbeef",
+		},
+	}
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, rpc.AppSessionsV1SubmitSessionKeyStateMethod.String(), payload),
+	}
+
+	handler.SubmitSessionKeyState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.NotNil(t, respErr)
+	assert.Contains(t, respErr.Error(), "application_ids must be lowercase, got: App-1")
+	mockStore.AssertNotCalled(t, "LockSessionKeyState", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestSubmitSessionKeyState_RejectsNonLowercaseAppSessionID(t *testing.T) {
+	mockStore := new(MockStore)
+	handler := &Handler{
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockStore)
+		},
+		metrics:          metrics.NewNoopRuntimeMetricExporter(),
+		maxSessionKeyIDs: 10,
+	}
+
+	userSigner := NewMockSigner()
+	userAddress := strings.ToLower(userSigner.PublicKey().Address().String())
+	sessionKeyAddress := "0x3333333333333333333333333333333333333333"
+
+	reqPayload := rpc.AppSessionsV1SubmitSessionKeyStateRequest{
+		State: rpc.AppSessionKeyStateV1{
+			UserAddress:    userAddress,
+			SessionKey:     sessionKeyAddress,
+			Version:        "1",
+			ApplicationIDs: []string{},
+			AppSessionIDs:  []string{"Session-ABC"},
+			ExpiresAt:      strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10),
+			UserSig:        "0xdeadbeef",
+		},
+	}
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, rpc.AppSessionsV1SubmitSessionKeyStateMethod.String(), payload),
+	}
+
+	handler.SubmitSessionKeyState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.NotNil(t, respErr)
+	assert.Contains(t, respErr.Error(), "app_session_ids must be lowercase, got: Session-ABC")
+	mockStore.AssertNotCalled(t, "LockSessionKeyState", mock.Anything, mock.Anything, mock.Anything)
+}
+
 func TestSubmitSessionKeyState_SignatureMismatch(t *testing.T) {
 	mockStore := new(MockStore)
 	userSigner := NewMockSigner()

--- a/nitronode/api/channel_v1/get_escrow_channel.go
+++ b/nitronode/api/channel_v1/get_escrow_channel.go
@@ -6,6 +6,11 @@ import (
 )
 
 // GetEscrowChannel retrieves current on-chain escrow channel information.
+//
+// Note: when the escrow channel has been closed by the on-chain purge queue
+// (no signed FINALIZE_ESCROW_DEPOSIT was received before expiry), StateVersion
+// on the returned channel reflects the initiate version (N) and does not
+// advance to the finalize version (N+1).
 func (h *Handler) GetEscrowChannel(c *rpc.Context) {
 	var req rpc.ChannelsV1GetEscrowChannelRequest
 	if err := c.Request.Payload.Translate(&req); err != nil {

--- a/nitronode/api/channel_v1/handler.go
+++ b/nitronode/api/channel_v1/handler.go
@@ -115,17 +115,34 @@ func (h *Handler) issueTransferReceiverState(ctx context.Context, tx Store, send
 	}
 
 	if newState.HomeChannelID != nil {
-		packedState, err := h.statePacker.PackState(*newState)
+		// CheckActiveChannel returns a non-nil status only when an Open or Void home
+		// channel exists for (wallet, asset); Challenged / Closing / Closed channels
+		// fall through as nil. The node only attaches a signature on Open: any other
+		// status means the channel is mid-dispute or terminal, and node-signing a
+		// receiver state on it could turn dust credits into a fresh checkpoint
+		// candidate (Challenged) or commit a credit that will never settle (Closed,
+		// Closing). The unsigned row is still persisted so the challenge-rescue
+		// squash at close can pick it up.
+		_, channelStatus, err := tx.CheckActiveChannel(receiverWallet, senderState.Asset)
 		if err != nil {
-			return nil, rpc.Errorf("failed to pack receiver state: %v", err)
+			return nil, rpc.Errorf("failed to check receiver active channel: %v", err)
 		}
+		if channelStatus != nil && *channelStatus == core.ChannelStatusOpen {
+			packedState, err := h.statePacker.PackState(*newState)
+			if err != nil {
+				return nil, rpc.Errorf("failed to pack receiver state: %v", err)
+			}
 
-		_nodeSig, err := h.nodeSigner.Sign(packedState)
-		if err != nil {
-			return nil, rpc.Errorf("failed to sign receiver state")
+			_nodeSig, err := h.nodeSigner.Sign(packedState)
+			if err != nil {
+				return nil, rpc.Errorf("failed to sign receiver state")
+			}
+			nodeSig := _nodeSig.String()
+			newState.NodeSig = &nodeSig
+		} else {
+			logger.Info("skipping node signature on receiver state for non-open home channel",
+				"homeChannelID", *newState.HomeChannelID)
 		}
-		nodeSig := _nodeSig.String()
-		newState.NodeSig = &nodeSig
 	}
 	if err := tx.StoreUserState(*newState, applicationID); err != nil {
 		return nil, rpc.Errorf("failed to store receiver state")

--- a/nitronode/api/channel_v1/request_creation.go
+++ b/nitronode/api/channel_v1/request_creation.go
@@ -136,14 +136,19 @@ func (h *Handler) RequestCreation(c *rpc.Context) {
 			return rpc.Errorf("incoming state home_channel_id is invalid")
 		}
 
-		if currentState.HomeChannelID != nil {
-			isFinal := currentState.IsFinal()
-			if !isFinal {
-				return rpc.Errorf("channel is already initialized")
-			}
-			if isFinal && strings.EqualFold(*incomingState.HomeChannelID, *currentState.HomeChannelID) {
-				return rpc.Errorf("cannot use same home channel id")
-			}
+		// Reject reuse of an already-known channel ID. Enforced at the handler rather than
+		// relying on the channels.channel_id primary key, so the invariant holds even when
+		// the prior state has no HomeChannelID (e.g., after a ChallengeRescue squash).
+		existingChannel, err := tx.GetChannelByID(homeChannelID)
+		if err != nil {
+			return rpc.Errorf("failed to look up channel by computed id: %v", err)
+		}
+		if existingChannel != nil {
+			return rpc.Errorf("cannot use same home channel id")
+		}
+
+		if currentState.HomeChannelID != nil && !currentState.IsFinal() {
+			return rpc.Errorf("channel is already initialized")
 		}
 
 		logger.Debug("processing channel creation request", "incomingVersion", incomingState.Version)

--- a/nitronode/api/channel_v1/request_creation.go
+++ b/nitronode/api/channel_v1/request_creation.go
@@ -83,6 +83,14 @@ func (h *Handler) RequestCreation(c *rpc.Context) {
 
 	var nodeSig string
 	err = h.useStoreInTx(func(tx Store) error {
+		// Gate the incoming transition through the action gateway before any state
+		// is signed, stored, or receiver-side state is issued. Mirrors SubmitState so
+		// gated actions (e.g. transfer_send) cannot bypass the 24h allowance by
+		// piggybacking on channel creation.
+		if err := h.actionGateway.AllowAction(tx, incomingState.UserWallet, incomingState.Transition.Type.GatedAction()); err != nil {
+			return rpc.NewError(err)
+		}
+
 		_, err := tx.LockUserState(incomingState.UserWallet, incomingState.Asset)
 		if err != nil {
 			return rpc.Errorf("failed to lock user state: %v", err)

--- a/nitronode/api/channel_v1/request_creation_test.go
+++ b/nitronode/api/channel_v1/request_creation_test.go
@@ -94,6 +94,7 @@ func TestRequestCreation_Success(t *testing.T) {
 	mockTxStore.On("LockUserState", userWallet, asset).Return(decimal.Zero, nil).Once()
 	mockTxStore.On("HasNonClosedHomeChannel", userWallet, asset).Return(false, nil).Once()
 	mockTxStore.On("GetLastUserState", userWallet, asset, false).Return(nil, nil).Once()
+	mockTxStore.On("GetChannelByID", mock.AnythingOfType("string")).Return((*core.Channel)(nil), nil).Once()
 	mockStatePacker.On("PackState", mock.Anything).Return(packedState, nil)
 	mockTxStore.On("CreateChannel", mock.MatchedBy(func(channel core.Channel) bool {
 		return channel.UserWallet == userWallet &&
@@ -249,6 +250,7 @@ func TestRequestCreation_Acknowledgement_Success(t *testing.T) {
 	mockTxStore.On("LockUserState", userWallet, asset).Return(decimal.Zero, nil).Once()
 	mockTxStore.On("HasNonClosedHomeChannel", userWallet, asset).Return(false, nil).Once()
 	mockTxStore.On("GetLastUserState", userWallet, asset, false).Return(nil, nil).Once()
+	mockTxStore.On("GetChannelByID", mock.AnythingOfType("string")).Return((*core.Channel)(nil), nil).Once()
 	mockStatePacker.On("PackState", mock.Anything).Return(packedState, nil)
 	mockTxStore.On("CreateChannel", mock.MatchedBy(func(channel core.Channel) bool {
 		return channel.UserWallet == userWallet &&
@@ -708,6 +710,7 @@ func TestRequestCreation_TransferSend_Success(t *testing.T) {
 	mockTxStore.On("LockUserState", senderWallet, asset).Return(decimal.Zero, nil).Once()
 	mockTxStore.On("HasNonClosedHomeChannel", senderWallet, asset).Return(false, nil).Once()
 	mockTxStore.On("GetLastUserState", senderWallet, asset, false).Return(currentSenderState, nil).Once()
+	mockTxStore.On("GetChannelByID", mock.AnythingOfType("string")).Return((*core.Channel)(nil), nil).Once()
 	mockStatePacker.On("PackState", mock.Anything).Return(packedState, nil)
 	mockTxStore.On("CreateChannel", mock.MatchedBy(func(channel core.Channel) bool {
 		return channel.UserWallet == senderWallet &&
@@ -879,4 +882,231 @@ func TestRequestCreation_ActionGatewayRejection(t *testing.T) {
 	mockTxStore.AssertNotCalled(t, "StoreUserState", mock.Anything, mock.Anything)
 	mockTxStore.AssertNotCalled(t, "RecordTransaction", mock.Anything, mock.Anything)
 	mockMemoryStore.AssertExpectations(t)
+}
+
+// TestRequestCreation_RejectReusedHomeChannelID covers the case where the user's last
+// state has no HomeChannelID (e.g., it is a ChallengeRescue squash on a fresh epoch),
+// but the computed channel ID matches a previously stored channel record. The handler
+// must reject the request explicitly rather than deferring the duplicate detection to
+// the channels.channel_id primary key in CreateChannel.
+func TestRequestCreation_RejectReusedHomeChannelID(t *testing.T) {
+	mockTxStore := new(MockStore)
+	mockMemoryStore := new(MockMemoryStore)
+	mockAssetStore := new(MockAssetStore)
+	mockSigner := NewMockSigner()
+	nodeSigner, _ := core.NewChannelDefaultSigner(mockSigner)
+	nodeAddress := mockSigner.PublicKey().Address().String()
+	mockStatePacker := new(MockStatePacker)
+
+	handler := &Handler{
+		stateAdvancer: core.NewStateAdvancerV1(mockAssetStore),
+		statePacker:   mockStatePacker,
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockTxStore)
+		},
+		memoryStore:      mockMemoryStore,
+		nodeSigner:       nodeSigner,
+		nodeAddress:      nodeAddress,
+		minChallenge:     uint32(3600),
+		maxChallenge:     uint32(604800),
+		metrics:          metrics.NewNoopRuntimeMetricExporter(),
+		maxSessionKeyIDs: 256,
+		actionGateway:    &MockActionGateway{},
+	}
+
+	userSigner := NewMockSigner()
+	userWallet := userSigner.PublicKey().Address().String()
+	asset := "USDC"
+	tokenAddress := "0xTokenAddress"
+	blockchainID := uint64(1)
+	nonce := uint64(7)
+	challenge := uint32(86400)
+
+	homeChannelID, err := core.GetHomeChannelID(nodeAddress, userWallet, asset, nonce, challenge, "0x03")
+	require.NoError(t, err)
+
+	// Simulate the post-rescue ledger head: a state whose HomeChannelID is nil because
+	// it was issued by issueChallengeRescue() after the prior home channel was closed.
+	rescueHead := core.State{
+		Asset:         asset,
+		UserWallet:    userWallet,
+		Epoch:         1,
+		Version:       1,
+		HomeChannelID: nil,
+	}
+
+	// Channel record from the closed epoch still lives in the channels table.
+	priorChannel := &core.Channel{
+		ChannelID:    homeChannelID,
+		UserWallet:   userWallet,
+		Asset:        asset,
+		Type:         core.ChannelTypeHome,
+		BlockchainID: blockchainID,
+		TokenAddress: tokenAddress,
+		Status:       core.ChannelStatusClosed,
+		Nonce:        nonce,
+	}
+
+	mockMemoryStore.On("IsAssetSupported", asset, tokenAddress, blockchainID).Return(true, nil).Once()
+	mockTxStore.On("LockUserState", userWallet, asset).Return(decimal.Zero, nil).Once()
+	mockTxStore.On("HasNonClosedHomeChannel", userWallet, asset).Return(false, nil).Once()
+	mockTxStore.On("GetLastUserState", userWallet, asset, false).Return(rescueHead, nil).Once()
+	mockTxStore.On("GetChannelByID", mock.AnythingOfType("string")).Return(priorChannel, nil).Once()
+
+	reqPayload := rpc.ChannelsV1RequestCreationRequest{
+		State: rpc.StateV1{
+			ID:            core.GetStateID(userWallet, asset, 2, 1),
+			UserWallet:    userWallet,
+			Asset:         asset,
+			Epoch:         "2",
+			Version:       "1",
+			HomeChannelID: &homeChannelID,
+			Transition:    rpc.TransitionV1{Amount: "0"},
+			HomeLedger: rpc.LedgerV1{
+				TokenAddress: tokenAddress,
+				BlockchainID: "1",
+				UserBalance:  "0",
+				UserNetFlow:  "0",
+				NodeBalance:  "0",
+				NodeNetFlow:  "0",
+			},
+		},
+		ChannelDefinition: rpc.ChannelDefinitionV1{
+			Nonce:                 strconv.FormatUint(nonce, 10),
+			Challenge:             challenge,
+			ApprovedSigValidators: "0x03",
+		},
+	}
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.Message{
+			RequestID: 1,
+			Method:    rpc.ChannelsV1RequestCreationMethod.String(),
+			Payload:   payload,
+		},
+	}
+
+	handler.RequestCreation(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.Error(t, respErr)
+	assert.Contains(t, respErr.Error(), "cannot use same home channel id")
+
+	mockTxStore.AssertExpectations(t)
+	mockTxStore.AssertNotCalled(t, "CreateChannel", mock.Anything)
+	mockTxStore.AssertNotCalled(t, "StoreUserState", mock.Anything, mock.Anything)
+}
+
+// TestRequestCreation_ChannelAlreadyInitialized covers the guard that rejects a creation
+// request when the user's prior state still has a non-nil, non-final HomeChannelID and
+// the computed channel ID is not yet stored. This is the in-flight-channel case: the
+// previous lifecycle has not been finalized off-chain, so a new creation must not start.
+func TestRequestCreation_ChannelAlreadyInitialized(t *testing.T) {
+	mockTxStore := new(MockStore)
+	mockMemoryStore := new(MockMemoryStore)
+	mockAssetStore := new(MockAssetStore)
+	mockSigner := NewMockSigner()
+	nodeSigner, _ := core.NewChannelDefaultSigner(mockSigner)
+	nodeAddress := mockSigner.PublicKey().Address().String()
+	mockStatePacker := new(MockStatePacker)
+
+	handler := &Handler{
+		stateAdvancer: core.NewStateAdvancerV1(mockAssetStore),
+		statePacker:   mockStatePacker,
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockTxStore)
+		},
+		memoryStore:      mockMemoryStore,
+		nodeSigner:       nodeSigner,
+		nodeAddress:      nodeAddress,
+		minChallenge:     uint32(3600),
+		maxChallenge:     uint32(604800),
+		metrics:          metrics.NewNoopRuntimeMetricExporter(),
+		maxSessionKeyIDs: 256,
+		actionGateway:    &MockActionGateway{},
+	}
+
+	userSigner := NewMockSigner()
+	userWallet := userSigner.PublicKey().Address().String()
+	asset := "USDC"
+	tokenAddress := "0xTokenAddress"
+	blockchainID := uint64(1)
+	priorNonce := uint64(7)
+	newNonce := uint64(8)
+	challenge := uint32(86400)
+
+	priorHomeChannelID, err := core.GetHomeChannelID(nodeAddress, userWallet, asset, priorNonce, challenge, "0x03")
+	require.NoError(t, err)
+	newHomeChannelID, err := core.GetHomeChannelID(nodeAddress, userWallet, asset, newNonce, challenge, "0x03")
+	require.NoError(t, err)
+
+	// Prior state: in-flight channel — HomeChannelID set, transition is not Finalize.
+	priorState := core.State{
+		Asset:         asset,
+		UserWallet:    userWallet,
+		Epoch:         1,
+		Version:       1,
+		HomeChannelID: &priorHomeChannelID,
+		Transition:    core.Transition{Type: core.TransitionTypeHomeDeposit},
+	}
+
+	mockMemoryStore.On("IsAssetSupported", asset, tokenAddress, blockchainID).Return(true, nil).Once()
+	mockTxStore.On("LockUserState", userWallet, asset).Return(decimal.Zero, nil).Once()
+	mockTxStore.On("HasNonClosedHomeChannel", userWallet, asset).Return(false, nil).Once()
+	mockTxStore.On("GetLastUserState", userWallet, asset, false).Return(priorState, nil).Once()
+	// New nonce → fresh channel ID, no row yet in channels.
+	mockTxStore.On("GetChannelByID", mock.AnythingOfType("string")).Return((*core.Channel)(nil), nil).Once()
+
+	reqPayload := rpc.ChannelsV1RequestCreationRequest{
+		State: rpc.StateV1{
+			ID:            core.GetStateID(userWallet, asset, 2, 1),
+			UserWallet:    userWallet,
+			Asset:         asset,
+			Epoch:         "2",
+			Version:       "1",
+			HomeChannelID: &newHomeChannelID,
+			Transition:    rpc.TransitionV1{Amount: "0"},
+			HomeLedger: rpc.LedgerV1{
+				TokenAddress: tokenAddress,
+				BlockchainID: "1",
+				UserBalance:  "0",
+				UserNetFlow:  "0",
+				NodeBalance:  "0",
+				NodeNetFlow:  "0",
+			},
+		},
+		ChannelDefinition: rpc.ChannelDefinitionV1{
+			Nonce:                 strconv.FormatUint(newNonce, 10),
+			Challenge:             challenge,
+			ApprovedSigValidators: "0x03",
+		},
+	}
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.Message{
+			RequestID: 1,
+			Method:    rpc.ChannelsV1RequestCreationMethod.String(),
+			Payload:   payload,
+		},
+	}
+
+	handler.RequestCreation(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.Error(t, respErr)
+	assert.Contains(t, respErr.Error(), "channel is already initialized")
+
+	mockTxStore.AssertExpectations(t)
+	mockTxStore.AssertNotCalled(t, "CreateChannel", mock.Anything)
+	mockTxStore.AssertNotCalled(t, "StoreUserState", mock.Anything, mock.Anything)
 }

--- a/nitronode/api/channel_v1/request_creation_test.go
+++ b/nitronode/api/channel_v1/request_creation_test.go
@@ -2,6 +2,7 @@ package channel_v1
 
 import (
 	"context"
+	"errors"
 	"strconv"
 	"testing"
 
@@ -619,4 +620,263 @@ func TestRequestCreation_NonClosedChannelRejection(t *testing.T) {
 	mockTxStore.AssertNotCalled(t, "GetLastUserState", mock.Anything, mock.Anything, mock.Anything)
 	mockTxStore.AssertNotCalled(t, "CreateChannel", mock.Anything)
 	mockTxStore.AssertNotCalled(t, "StoreUserState", mock.Anything, mock.Anything)
+}
+
+// TestRequestCreation_TransferSend_Success verifies that a TransferSend transition
+// on initial channel creation passes the action gateway and produces both
+// sender-side and receiver-side state effects. Covers the happy path opposite
+// TestRequestCreation_ActionGatewayRejection.
+func TestRequestCreation_TransferSend_Success(t *testing.T) {
+	mockTxStore := new(MockStore)
+	mockMemoryStore := new(MockMemoryStore)
+	mockAssetStore := new(MockAssetStore)
+	mockSigner := NewMockSigner()
+	nodeSigner, _ := core.NewChannelDefaultSigner(mockSigner)
+	nodeAddress := mockSigner.PublicKey().Address().String()
+	mockStatePacker := new(MockStatePacker)
+
+	handler := &Handler{
+		stateAdvancer: core.NewStateAdvancerV1(mockAssetStore),
+		statePacker:   mockStatePacker,
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockTxStore)
+		},
+		memoryStore:      mockMemoryStore,
+		nodeSigner:       nodeSigner,
+		nodeAddress:      nodeAddress,
+		minChallenge:     uint32(3600),
+		maxChallenge:     uint32(604800),
+		metrics:          metrics.NewNoopRuntimeMetricExporter(),
+		maxSessionKeyIDs: 256,
+		actionGateway:    &MockActionGateway{},
+	}
+
+	userSigner := NewMockSigner()
+	userWalletSigner, _ := core.NewChannelDefaultSigner(userSigner)
+	senderWallet := userSigner.PublicKey().Address().String()
+	receiverWallet := "0x0987654321098765432109876543210987654321"
+	asset := "USDC"
+	tokenAddress := "0xTokenAddress"
+	blockchainID := uint64(1)
+	nonce := uint64(12345)
+	challenge := uint32(86400)
+	transferAmount := decimal.NewFromInt(100)
+
+	// Sender's prior state: positive offchain balance from a prior transfer_receive,
+	// no active home channel. This is the bypass scenario MF2-L01 closes.
+	currentSenderState := core.State{
+		ID:            core.GetStateID(senderWallet, asset, 0, 1),
+		Asset:         asset,
+		UserWallet:    senderWallet,
+		Epoch:         0,
+		Version:       1,
+		HomeChannelID: nil,
+		HomeLedger: core.Ledger{
+			TokenAddress: tokenAddress,
+			BlockchainID: blockchainID,
+			UserBalance:  decimal.NewFromInt(500),
+			UserNetFlow:  decimal.Zero,
+			NodeBalance:  decimal.Zero,
+			NodeNetFlow:  decimal.NewFromInt(500),
+		},
+		Transition: core.Transition{Type: core.TransitionTypeTransferReceive},
+	}
+
+	// Build proposed sender state: NextState + ApplyChannelCreation + ApplyTransferSend.
+	incomingSenderState := currentSenderState.NextState()
+	channelDef := core.ChannelDefinition{
+		Nonce:                 nonce,
+		Challenge:             challenge,
+		ApprovedSigValidators: "0x03",
+	}
+	_, err := incomingSenderState.ApplyChannelCreation(channelDef, blockchainID, tokenAddress, nodeAddress)
+	require.NoError(t, err)
+	_, err = incomingSenderState.ApplyTransferSendTransition(receiverWallet, transferAmount)
+	require.NoError(t, err)
+
+	mockAssetStore.On("GetTokenDecimals", blockchainID, tokenAddress).Return(uint8(6), nil)
+	packedState, err := core.PackState(*incomingSenderState, mockAssetStore)
+	require.NoError(t, err)
+	userSig, err := userWalletSigner.Sign(packedState)
+	require.NoError(t, err)
+	userSigStr := userSig.String()
+	incomingSenderState.UserSig = &userSigStr
+
+	// Handler-side mocks.
+	mockMemoryStore.On("IsAssetSupported", asset, tokenAddress, blockchainID).Return(true, nil).Once()
+	mockAssetStore.On("GetAssetDecimals", asset).Return(uint8(6), nil).Once()
+	mockTxStore.On("LockUserState", senderWallet, asset).Return(decimal.Zero, nil).Once()
+	mockTxStore.On("HasNonClosedHomeChannel", senderWallet, asset).Return(false, nil).Once()
+	mockTxStore.On("GetLastUserState", senderWallet, asset, false).Return(currentSenderState, nil).Once()
+	mockStatePacker.On("PackState", mock.Anything).Return(packedState, nil)
+	mockTxStore.On("CreateChannel", mock.MatchedBy(func(channel core.Channel) bool {
+		return channel.UserWallet == senderWallet &&
+			channel.Type == core.ChannelTypeHome &&
+			channel.BlockchainID == blockchainID &&
+			channel.TokenAddress == tokenAddress &&
+			channel.Nonce == nonce &&
+			channel.ChallengeDuration == challenge
+	})).Return(nil).Once()
+	mockTxStore.On("StoreUserState", mock.MatchedBy(func(state core.State) bool {
+		return state.UserWallet == senderWallet &&
+			state.Asset == asset &&
+			state.Transition.Type == core.TransitionTypeTransferSend &&
+			state.NodeSig != nil &&
+			state.HomeChannelID != nil
+	}), mock.Anything).Return(nil).Once()
+
+	// Receiver-side: fresh user, no prior state, no home channel.
+	mockTxStore.On("LockUserState", receiverWallet, asset).Return(decimal.Zero, nil).Once()
+	mockTxStore.On("GetLastUserState", receiverWallet, asset, false).Return(nil, nil).Once()
+	mockTxStore.On("EnsureNoOngoingEscrowOperation", receiverWallet, asset).Return(nil).Once()
+	mockTxStore.On("StoreUserState", mock.MatchedBy(func(state core.State) bool {
+		return state.UserWallet == receiverWallet &&
+			state.Asset == asset &&
+			state.Transition.Type == core.TransitionTypeTransferReceive
+	}), mock.Anything).Return(nil).Once()
+
+	mockTxStore.On("RecordTransaction", mock.MatchedBy(func(tx core.Transaction) bool {
+		return tx.TxType == core.TransactionTypeTransfer &&
+			tx.Amount.Equal(transferAmount) &&
+			tx.FromAccount == senderWallet &&
+			tx.ToAccount == receiverWallet
+	}), mock.Anything).Return(nil).Once()
+
+	rpcState := toRPCState(*incomingSenderState)
+	reqPayload := rpc.ChannelsV1RequestCreationRequest{
+		State: rpcState,
+		ChannelDefinition: rpc.ChannelDefinitionV1{
+			Nonce:                 strconv.FormatUint(nonce, 10),
+			Challenge:             challenge,
+			ApprovedSigValidators: "0x03",
+		},
+	}
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.Message{
+			RequestID: 1,
+			Method:    rpc.ChannelsV1RequestCreationMethod.String(),
+			Payload:   payload,
+		},
+	}
+
+	handler.RequestCreation(ctx)
+
+	require.NotNil(t, ctx.Response)
+	if respErr := ctx.Response.Error(); respErr != nil {
+		t.Fatalf("Unexpected error response: %v", respErr)
+	}
+	var response rpc.ChannelsV1RequestCreationResponse
+	err = ctx.Response.Payload.Translate(&response)
+	require.NoError(t, err)
+	assert.NotEmpty(t, response.Signature)
+	VerifyNodeSignature(t, nodeAddress, packedState, response.Signature)
+
+	mockMemoryStore.AssertExpectations(t)
+	mockAssetStore.AssertExpectations(t)
+	mockTxStore.AssertExpectations(t)
+}
+
+// TestRequestCreation_ActionGatewayRejection verifies that an exhausted gated
+// action (e.g. transfer_send) is rejected at the gateway before any state is
+// signed, stored, or receiver-side state is issued. Mirrors the SubmitState
+// gate so users cannot bypass the 24h allowance via initial channel creation.
+func TestRequestCreation_ActionGatewayRejection(t *testing.T) {
+	mockTxStore := new(MockStore)
+	mockMemoryStore := new(MockMemoryStore)
+	mockAssetStore := new(MockAssetStore)
+	mockSigner := NewMockSigner()
+	nodeSigner, _ := core.NewChannelDefaultSigner(mockSigner)
+	nodeAddress := mockSigner.PublicKey().Address().String()
+	mockStatePacker := new(MockStatePacker)
+
+	handler := &Handler{
+		stateAdvancer: core.NewStateAdvancerV1(mockAssetStore),
+		statePacker:   mockStatePacker,
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockTxStore)
+		},
+		memoryStore:      mockMemoryStore,
+		nodeSigner:       nodeSigner,
+		nodeAddress:      nodeAddress,
+		minChallenge:     uint32(3600),
+		maxChallenge:     uint32(604800),
+		metrics:          metrics.NewNoopRuntimeMetricExporter(),
+		maxSessionKeyIDs: 256,
+		actionGateway:    &MockActionGateway{Err: errors.New("transfer allowance exhausted")},
+	}
+
+	userSigner := NewMockSigner()
+	userWallet := userSigner.PublicKey().Address().String()
+	receiverWallet := "0x0987654321098765432109876543210987654321"
+	asset := "USDC"
+	tokenAddress := "0xTokenAddress"
+	blockchainID := uint64(1)
+	nonce := uint64(77)
+	challenge := uint32(86400)
+
+	homeChannelID, err := core.GetHomeChannelID(nodeAddress, userWallet, asset, nonce, challenge, "0x03")
+	require.NoError(t, err)
+
+	mockMemoryStore.On("IsAssetSupported", asset, tokenAddress, blockchainID).Return(true, nil).Once()
+
+	reqPayload := rpc.ChannelsV1RequestCreationRequest{
+		State: rpc.StateV1{
+			ID:            core.GetStateID(userWallet, asset, 1, 1),
+			UserWallet:    userWallet,
+			Asset:         asset,
+			Epoch:         "1",
+			Version:       "1",
+			HomeChannelID: &homeChannelID,
+			Transition: rpc.TransitionV1{
+				Type:      core.TransitionTypeTransferSend,
+				AccountID: receiverWallet,
+				Amount:    "100",
+			},
+			HomeLedger: rpc.LedgerV1{
+				TokenAddress: tokenAddress,
+				BlockchainID: "1",
+				UserBalance:  "0",
+				UserNetFlow:  "0",
+				NodeBalance:  "0",
+				NodeNetFlow:  "0",
+			},
+		},
+		ChannelDefinition: rpc.ChannelDefinitionV1{
+			Nonce:                 strconv.FormatUint(nonce, 10),
+			Challenge:             challenge,
+			ApprovedSigValidators: "0x03",
+		},
+	}
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.Message{
+			RequestID: 1,
+			Method:    rpc.ChannelsV1RequestCreationMethod.String(),
+			Payload:   payload,
+		},
+	}
+
+	handler.RequestCreation(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.Error(t, respErr)
+	assert.Contains(t, respErr.Error(), "transfer allowance exhausted")
+
+	// Gate fires before any state effect: nothing should be locked, stored, or recorded.
+	mockTxStore.AssertNotCalled(t, "LockUserState", mock.Anything, mock.Anything)
+	mockTxStore.AssertNotCalled(t, "HasNonClosedHomeChannel", mock.Anything, mock.Anything)
+	mockTxStore.AssertNotCalled(t, "GetLastUserState", mock.Anything, mock.Anything, mock.Anything)
+	mockTxStore.AssertNotCalled(t, "CreateChannel", mock.Anything)
+	mockTxStore.AssertNotCalled(t, "StoreUserState", mock.Anything, mock.Anything)
+	mockTxStore.AssertNotCalled(t, "RecordTransaction", mock.Anything, mock.Anything)
+	mockMemoryStore.AssertExpectations(t)
 }

--- a/nitronode/api/channel_v1/submit_state_test.go
+++ b/nitronode/api/channel_v1/submit_state_test.go
@@ -166,6 +166,7 @@ func TestSubmitState_TransferSend_Success(t *testing.T) {
 	mockTxStore.On("LockUserState", receiverWallet, asset).Return(decimal.Zero, nil)
 	mockTxStore.On("GetLastUserState", receiverWallet, asset, false).Return(currentReceiverState, nil)
 	mockTxStore.On("EnsureNoOngoingEscrowOperation", receiverWallet, asset).Return(nil)
+	mockTxStore.On("CheckActiveChannel", receiverWallet, asset).Return("0x03", core.ChannelStatusOpen, nil).Once()
 	mockTxStore.On("StoreUserState", mock.MatchedBy(func(state core.State) bool {
 		// Verify receiver state
 		return state.UserWallet == receiverWallet &&
@@ -225,6 +226,136 @@ func TestSubmitState_TransferSend_Success(t *testing.T) {
 	VerifyNodeSignature(t, nodeAddress, packedSenderState, response.Signature)
 
 	// Verify all mock expectations
+	mockTxStore.AssertExpectations(t)
+}
+
+func TestSubmitState_TransferSend_ReceiverHomeChannelChallenged_NoNodeSig(t *testing.T) {
+	// When the receiver's home channel is in Challenged status the node must persist the
+	// receiver state row but must NOT node-sign it. Otherwise an attacker holding an
+	// expired or out-of-scope session key for the receiver could turn a dust transfer into
+	// a freshly node-signed state and use it to checkpoint the channel back to OPERATING,
+	// resetting the dispute timer indefinitely.
+	mockTxStore := new(MockStore)
+	mockMemoryStore := new(MockMemoryStore)
+	mockAssetStore := new(MockAssetStore)
+	mockSigner := NewMockSigner()
+	nodeSigner, err := core.NewChannelDefaultSigner(mockSigner)
+	require.NoError(t, err)
+	nodeAddress := mockSigner.PublicKey().Address().String()
+	minChallenge := uint32(3600)
+	mockStatePacker := new(MockStatePacker)
+
+	handler := &Handler{
+		stateAdvancer: core.NewStateAdvancerV1(mockAssetStore),
+		statePacker:   mockStatePacker,
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockTxStore)
+		},
+		memoryStore:      mockMemoryStore,
+		nodeSigner:       nodeSigner,
+		nodeAddress:      nodeAddress,
+		minChallenge:     minChallenge,
+		metrics:          metrics.NewNoopRuntimeMetricExporter(),
+		maxSessionKeyIDs: 256,
+		actionGateway:    &MockActionGateway{},
+	}
+
+	userSigner := NewMockSigner()
+	userWalletSigner, err := core.NewChannelDefaultSigner(userSigner)
+	require.NoError(t, err)
+	senderWallet := userSigner.PublicKey().Address().String()
+	receiverWallet := "0x0987654321098765432109876543210987654321"
+	asset := "USDC"
+	senderHomeChannel := "0xSenderHome"
+	receiverHomeChannel := "0xReceiverHome"
+	transferAmount := decimal.NewFromInt(100)
+
+	currentSenderState := core.State{
+		ID:            core.GetStateID(senderWallet, asset, 1, 1),
+		Asset:         asset,
+		UserWallet:    senderWallet,
+		Epoch:         1,
+		Version:       1,
+		HomeChannelID: &senderHomeChannel,
+		HomeLedger: core.Ledger{
+			TokenAddress: "0xTokenAddress",
+			BlockchainID: 1,
+			UserBalance:  decimal.NewFromInt(500),
+			UserNetFlow:  decimal.NewFromInt(500),
+		},
+	}
+
+	incomingSenderState := currentSenderState.NextState()
+	transferSendTransition, err := incomingSenderState.ApplyTransferSendTransition(receiverWallet, transferAmount)
+	require.NoError(t, err)
+
+	mockAssetStore.On("GetTokenDecimals", uint64(1), "0xTokenAddress").Return(uint8(6), nil).Maybe()
+	packedSenderState, _ := core.PackState(*incomingSenderState, mockAssetStore)
+	userSig, _ := userWalletSigner.Sign(packedSenderState)
+	userSigStr := userSig.String()
+	incomingSenderState.UserSig = &userSigStr
+
+	currentReceiverState := core.State{
+		ID:            core.GetStateID(receiverWallet, asset, 1, 1),
+		Asset:         asset,
+		UserWallet:    receiverWallet,
+		Epoch:         1,
+		Version:       1,
+		HomeChannelID: &receiverHomeChannel,
+		HomeLedger: core.Ledger{
+			TokenAddress: "0xTokenAddress",
+			BlockchainID: 1,
+			UserBalance:  decimal.NewFromInt(200),
+			UserNetFlow:  decimal.NewFromInt(200),
+		},
+	}
+
+	expectedReceiverState := currentReceiverState.NextState()
+	_, err = expectedReceiverState.ApplyTransferReceiveTransition(senderWallet, transferAmount, transferSendTransition.TxID)
+	require.NoError(t, err)
+
+	mockAssetStore.On("GetAssetDecimals", asset).Return(uint8(6), nil)
+	mockTxStore.On("LockUserState", senderWallet, asset).Return(decimal.Zero, nil)
+	mockTxStore.On("CheckActiveChannel", senderWallet, asset).Return("0x03", core.ChannelStatusOpen, nil)
+	mockTxStore.On("GetLastUserState", senderWallet, asset, false).Return(currentSenderState, nil)
+	mockTxStore.On("EnsureNoOngoingStateTransitions", senderWallet, asset).Return(nil)
+	mockStatePacker.On("PackState", mock.Anything).Return(packedSenderState, nil).Maybe()
+
+	mockTxStore.On("StoreUserState", mock.MatchedBy(func(state core.State) bool {
+		return state.UserWallet == senderWallet && state.NodeSig != nil
+	}), mock.Anything).Return(nil)
+
+	mockTxStore.On("LockUserState", receiverWallet, asset).Return(decimal.Zero, nil)
+	mockTxStore.On("GetLastUserState", receiverWallet, asset, false).Return(currentReceiverState, nil)
+	mockTxStore.On("EnsureNoOngoingEscrowOperation", receiverWallet, asset).Return(nil)
+	// Challenged status falls through CheckActiveChannel (status > Open) as a nil
+	// status pointer, so the issuance path stores the receiver row unsigned — the
+	// dust-credit checkpoint reset described in MF2-H01 stays blocked.
+	mockTxStore.On("CheckActiveChannel", receiverWallet, asset).Return("", nil, nil).Once()
+	mockTxStore.On("StoreUserState", mock.MatchedBy(func(state core.State) bool {
+		return state.UserWallet == receiverWallet &&
+			state.Version == expectedReceiverState.Version &&
+			state.Transition.Type == core.TransitionTypeTransferReceive &&
+			state.NodeSig == nil
+	}), mock.Anything).Return(nil)
+
+	mockTxStore.On("RecordTransaction", mock.MatchedBy(func(tx core.Transaction) bool {
+		return tx.TxType == core.TransactionTypeTransfer && tx.Amount.Equal(transferAmount)
+	}), mock.Anything).Return(nil)
+
+	rpcState := toRPCState(*incomingSenderState)
+	reqPayload := rpc.ChannelsV1SubmitStateRequest{State: rpcState}
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.Message{Method: "channels.v1.submit_state", Payload: payload},
+	}
+
+	handler.SubmitState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	require.Nil(t, ctx.Response.Error())
 	mockTxStore.AssertExpectations(t)
 }
 

--- a/nitronode/event_handlers/service.go
+++ b/nitronode/event_handlers/service.go
@@ -313,9 +313,15 @@ func (s *EventHandlerService) HandleHomeChannelChallenged(ctx context.Context, t
 // Once closed, no further state updates are possible for this channel.
 //
 // Additionally, when the closing path was a challenge resolution (channel was Challenged
-// and the closing state is not a finalize), the handler issues a single ChallengeRescue
-// state for the user that squashes the sum of receiver-state credits accrued during the
-// challenge window into an off-channel ledger entry tied to the closed channel's ID.
+// and no node-signed Finalize state exists for it), the handler issues a single
+// ChallengeRescue state for the user that squashes the sum of receiver-state credits
+// accrued during the challenge window into an off-channel ledger entry tied to the
+// closed channel's ID. When a node-signed Finalize already exists, the cooperative-close
+// path has already advanced the user to a fresh epoch via NextState(), and any receiver
+// credits accumulated post-Finalize live at (epoch+1, version=0..N) with HomeChannelID=nil
+// — issuing a rescue at (epoch+1, version=1) would either overwrite the lone receiver
+// credit or collide on deterministic state ID with an existing row, so the rescue is
+// skipped entirely in that case.
 func (s *EventHandlerService) HandleHomeChannelClosed(ctx context.Context, tx core.ChannelHubEventHandlerStore, event *core.HomeChannelClosedEvent) error {
 	logger := log.FromContext(ctx)
 	chanID := event.ChannelID
@@ -362,8 +368,23 @@ func (s *EventHandlerService) HandleHomeChannelClosed(ctx context.Context, tx co
 	}
 
 	if wasChallenged {
-		if err := s.issueChallengeRescue(ctx, tx, channel, event.StateVersion); err != nil {
+		// Post-Finalize cooperative close racing with an on-chain challenge: receiver
+		// credits issued after the Finalize live in a fresh epoch via NextState() and
+		// are not channel-attached, so the rescue path would either overwrite them or
+		// collide on deterministic state ID. Skip the rescue branch entirely.
+		finalized, err := tx.HasSignedFinalize(chanID)
+		if err != nil {
 			return err
+		}
+		if finalized {
+			logger.Debug("skipping challenge_rescue for post-Finalize close",
+				"channelId", chanID,
+				"userWallet", channel.UserWallet,
+				"closureVersion", event.StateVersion)
+		} else {
+			if err := s.issueChallengeRescue(ctx, tx, channel, event.StateVersion); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/nitronode/event_handlers/service.go
+++ b/nitronode/event_handlers/service.go
@@ -31,8 +31,10 @@ func NewEventHandlerService(nodeSigner *core.ChannelDefaultSigner, statePacker c
 	}
 }
 
-// HandleNodeBalanceUpdated processes the NodeBalanceUpdated event emitted when a node's balance is updated on-chain.
-// It updates the user's staked balance for the specified blockchain in the database.
+// HandleNodeBalanceUpdated processes the NodeBalanceUpdated event emitted when the node's
+// on-chain liquidity changes. It records the new node liquidity for the (blockchain, asset)
+// pair via SetNodeBalance; this is observability data only and does not affect user staking
+// state.
 func (s *EventHandlerService) HandleNodeBalanceUpdated(ctx context.Context, tx core.ChannelHubEventHandlerStore, event *core.NodeBalanceUpdatedEvent) error {
 	logger := log.FromContext(ctx)
 
@@ -47,6 +49,11 @@ func (s *EventHandlerService) HandleNodeBalanceUpdated(ctx context.Context, tx c
 // HandleHomeChannelCreated processes the HomeChannelCreated event emitted when a home channel
 // is successfully created on-chain. It updates the channel status to Open and sets the state version.
 // The channel must exist in the database with type ChannelTypeHome, otherwise a warning is logged.
+// A legitimate Created event is observed exactly once per channel, when the local row is still in
+// the ChannelStatusVoid state seeded by CreateChannel. If the channel has already advanced past
+// Void, this handler is being re-fired (indexer replay, chain reorg, block reprocessing) and any
+// mutation here would regress the post-Open lifecycle — most importantly resetting a Closing
+// channel back to Open and erasing the Finalize marker that gates CheckActiveChannel.
 func (s *EventHandlerService) HandleHomeChannelCreated(ctx context.Context, tx core.ChannelHubEventHandlerStore, event *core.HomeChannelCreatedEvent) error {
 	logger := log.FromContext(ctx)
 	chanID := event.ChannelID
@@ -60,6 +67,11 @@ func (s *EventHandlerService) HandleHomeChannelCreated(ctx context.Context, tx c
 	}
 	if channel.Type != core.ChannelTypeHome {
 		logger.Warn("channel type mismatch during HomeChannelCreated event", "channelId", chanID, "expectedType", core.ChannelTypeHome, "actualType", channel.Type)
+		return nil
+	}
+	if channel.Status >= core.ChannelStatusOpen {
+		logger.Warn("ignoring replayed HomeChannelCreated event on already-initialized channel",
+			"channelId", chanID, "currentStatus", channel.Status, "currentStateVersion", channel.StateVersion, "eventStateVersion", event.StateVersion)
 		return nil
 	}
 	channel.StateVersion = event.StateVersion
@@ -93,7 +105,11 @@ func (s *EventHandlerService) HandleHomeChannelMigrated(ctx context.Context, tx 
 
 // HandleHomeChannelCheckpointed processes the HomeChannelCheckpointed event emitted when a channel
 // state is successfully checkpointed on-chain. It updates the channel's state version and clears
-// the Challenged status if present, returning the channel to Open status.
+// the Challenged status if present, returning the channel to Open — unless the local DB already
+// holds a co-signed Finalize for this channel, in which case the post-Finalize Closing marker
+// is restored instead. Without that restore, a Closing → Challenged → Open sequence driven by
+// on-chain events would erase the fact that the node has already signed a finalized state, and
+// CheckActiveChannel would let the user submit further transitions past the finalized state.
 func (s *EventHandlerService) HandleHomeChannelCheckpointed(ctx context.Context, tx core.ChannelHubEventHandlerStore, event *core.HomeChannelCheckpointedEvent) error {
 	logger := log.FromContext(ctx)
 	chanID := event.ChannelID
@@ -124,7 +140,22 @@ func (s *EventHandlerService) HandleHomeChannelCheckpointed(ctx context.Context,
 
 	wasChallenged := channel.Status == core.ChannelStatusChallenged
 	if wasChallenged {
-		channel.Status = core.ChannelStatusOpen
+		// Reconstruct the post-Finalize Closing marker from channel_states: if the node
+		// has already signed a Finalize state for this channel, the off-chain close is
+		// still pending and the channel must not return to Open. See the doc comment on
+		// HandleHomeChannelChallenged for the round-trip rationale.
+		finalized, err := tx.HasSignedFinalize(chanID)
+		if err != nil {
+			return err
+		}
+		if finalized {
+			channel.Status = core.ChannelStatusClosing
+		} else {
+			channel.Status = core.ChannelStatusOpen
+		}
+		// The challenge is resolved on chain; the expiry timestamp is no longer relevant
+		// and would otherwise surface as a stale deadline through the channel API.
+		channel.ChallengeExpiresAt = nil
 	}
 
 	err = tx.UpdateChannel(*channel)
@@ -244,8 +275,12 @@ func (s *EventHandlerService) HandleHomeChannelChallenged(ctx context.Context, t
 
 	channel.StateVersion = event.StateVersion
 	// Closing → Challenged is an expected transition: a co-signed Finalize may race an
-	// on-chain challenge. The chain takes precedence; the off-chain close flow is abandoned
-	// and the channel follows the Challenged → Closed path instead.
+	// on-chain challenge. The status field is intentionally overwritten — the chain takes
+	// precedence while the dispute is live. The post-Finalize fact is not lost: it is
+	// shadowed in channel_states (the latest fully-signed row carries TransitionTypeFinalize)
+	// and HandleHomeChannelCheckpointed restores ChannelStatusClosing from there when the
+	// challenge resolves, so the off-chain close flow resumes instead of silently regressing
+	// to Open.
 	channel.Status = core.ChannelStatusChallenged
 	expirationTime := time.Unix(int64(event.ChallengeExpiry), 0)
 	channel.ChallengeExpiresAt = &expirationTime
@@ -311,6 +346,8 @@ func (s *EventHandlerService) HandleHomeChannelClosed(ctx context.Context, tx co
 
 	channel.StateVersion = event.StateVersion
 	channel.Status = core.ChannelStatusClosed
+	// Channel is terminal; any pending challenge deadline is no longer meaningful.
+	channel.ChallengeExpiresAt = nil
 
 	if err := tx.UpdateChannel(*channel); err != nil {
 		return err
@@ -615,6 +652,8 @@ func (s *EventHandlerService) HandleEscrowDepositFinalized(ctx context.Context, 
 
 	channel.StateVersion = event.StateVersion
 	channel.Status = core.ChannelStatusClosed
+	// Channel is terminal; any pending challenge deadline is no longer meaningful.
+	channel.ChallengeExpiresAt = nil
 
 	if err := tx.UpdateChannel(*channel); err != nil {
 		return err
@@ -781,6 +820,8 @@ func (s *EventHandlerService) HandleEscrowWithdrawalFinalized(ctx context.Contex
 
 	channel.StateVersion = event.StateVersion
 	channel.Status = core.ChannelStatusClosed
+	// Channel is terminal; any pending challenge deadline is no longer meaningful.
+	channel.ChallengeExpiresAt = nil
 
 	if err := tx.UpdateChannel(*channel); err != nil {
 		return err

--- a/nitronode/event_handlers/service.go
+++ b/nitronode/event_handlers/service.go
@@ -2,7 +2,10 @@ package event_handlers
 
 import (
 	"context"
+	"fmt"
 	"time"
+
+	"github.com/shopspring/decimal"
 
 	"github.com/layer-3/nitrolite/pkg/core"
 	"github.com/layer-3/nitrolite/pkg/log"
@@ -14,11 +17,18 @@ var _ core.LockingContractEventHandler = &EventHandlerService{}
 // EventHandlerService processes blockchain events and updates the local database state accordingly.
 // It handles events from both home channels (user state channels) and escrow channels (temporary lock channels).
 type EventHandlerService struct {
+	nodeSigner  *core.ChannelDefaultSigner
+	statePacker core.StatePacker
 }
 
 // NewEventHandlerService creates a new EventHandlerService instance.
-func NewEventHandlerService() *EventHandlerService {
-	return &EventHandlerService{}
+// nodeSigner and statePacker are used to backfill the node signature on the
+// checkpointed head state when it is missing from the local record.
+func NewEventHandlerService(nodeSigner *core.ChannelDefaultSigner, statePacker core.StatePacker) *EventHandlerService {
+	return &EventHandlerService{
+		nodeSigner:  nodeSigner,
+		statePacker: statePacker,
+	}
 }
 
 // HandleNodeBalanceUpdated processes the NodeBalanceUpdated event emitted when a node's balance is updated on-chain.
@@ -64,7 +74,7 @@ func (s *EventHandlerService) HandleHomeChannelCreated(ctx context.Context, tx c
 		return err
 	}
 
-	if err := tx.UpdateStateUserSigIfMissing(event.ChannelID, event.StateVersion, event.UserSig); err != nil {
+	if err := tx.UpdateStateSigsIfMissing(event.ChannelID, event.StateVersion, event.UserSig, ""); err != nil {
 		return err
 	}
 
@@ -99,9 +109,21 @@ func (s *EventHandlerService) HandleHomeChannelCheckpointed(ctx context.Context,
 		logger.Warn("channel type mismatch during HomeChannelCheckpointed event", "channelId", chanID, "expectedType", core.ChannelTypeHome, "actualType", channel.Type)
 		return nil
 	}
+
+	// Acquire the user's balance-row lock before mutating channel status or
+	// backfilling the off-chain head. Receiver issuance paths lock the same row
+	// and then re-check Status; without this lock an RPC can read Status=Challenged,
+	// decide to store an unsigned receiver row, but commit after we flip to Open
+	// and backfill the prior head — leaving the latest head unsigned on an Open
+	// channel. See HandleHomeChannelClosed for the same pattern.
+	if _, err := tx.LockUserState(channel.UserWallet, channel.Asset); err != nil {
+		return err
+	}
+
 	channel.StateVersion = event.StateVersion
 
-	if channel.Status == core.ChannelStatusChallenged {
+	wasChallenged := channel.Status == core.ChannelStatusChallenged
+	if wasChallenged {
 		channel.Status = core.ChannelStatusOpen
 	}
 
@@ -114,11 +136,67 @@ func (s *EventHandlerService) HandleHomeChannelCheckpointed(ctx context.Context,
 		return err
 	}
 
-	if err := tx.UpdateStateUserSigIfMissing(event.ChannelID, event.StateVersion, event.UserSig); err != nil {
+	// Always backfill the user signature at the on-chain checkpointed version so the
+	// row matches what is enforced on chain.
+	if err := tx.UpdateStateSigsIfMissing(event.ChannelID, event.StateVersion, event.UserSig, ""); err != nil {
 		return err
 	}
 
+	// When a challenge is cleared, the off-chain head may sit above event.StateVersion:
+	// any receiver state issued during the challenge was stored unsigned and is now the
+	// channel's actual latest state. Backfill the node signature on that head so future
+	// flows treat it as fully co-signed. On normal Open→Open checkpoints the head row
+	// is already node-signed via the RPC path and this is a no-op.
+	if wasChallenged {
+		if err := s.backfillOffChainHeadNodeSig(ctx, tx, event.ChannelID); err != nil {
+			return err
+		}
+	}
+
 	logger.Info("handled HomeChannelCheckpointed event", "channelId", event.ChannelID, "stateVersion", event.StateVersion, "userWallet", channel.UserWallet)
+	return nil
+}
+
+// backfillOffChainHeadNodeSig loads the off-chain head state for channelID (the highest
+// stored version, regardless of signature status) and node-signs it when the row is
+// present and the node signature is missing. The user signature is intentionally left
+// untouched: when the head was created during a challenge it carries no user signature,
+// and the user must countersign and acknowledge it via the regular RPC flow.
+func (s *EventHandlerService) backfillOffChainHeadNodeSig(ctx context.Context, tx core.ChannelHubEventHandlerStore, channelID string) error {
+	head, err := tx.GetLastStateByChannelID(channelID, false)
+	if err != nil {
+		return err
+	}
+	if head == nil || head.NodeSig != nil {
+		return nil
+	}
+	// Per the challenge-clearance spec the only states accumulated during the dispute
+	// window are receiver credits (transfer_receive, release) — user-initiated ops are
+	// rejected upstream while the channel is Challenged. If the head is some other
+	// transition kind, the invariant has broken upstream and we must not silently
+	// node-sign it. Log it and bail so the caller surfaces the inconsistency.
+	if head.Transition.Type != core.TransitionTypeTransferReceive &&
+		head.Transition.Type != core.TransitionTypeRelease {
+		log.FromContext(ctx).Debug("off-chain head after challenge clearance is not a receiver state, skipping node-sig backfill",
+			"channelId", channelID,
+			"transitionType", head.Transition.Type,
+			"version", head.Version,
+		)
+		return nil
+	}
+	packed, err := s.statePacker.PackState(*head)
+	if err != nil {
+		return err
+	}
+	sig, err := s.nodeSigner.Sign(packed)
+	if err != nil {
+		return err
+	}
+	if err := tx.UpdateStateSigsIfMissing(channelID, head.Version, "", sig.String()); err != nil {
+		return err
+	}
+	log.FromContext(ctx).Info("backfilled missing node signature on off-chain head state",
+		"channelId", channelID, "stateVersion", head.Version)
 	return nil
 }
 
@@ -146,6 +224,17 @@ func (s *EventHandlerService) HandleHomeChannelChallenged(ctx context.Context, t
 		return nil
 	}
 
+	// Acquire the user's balance-row lock before mutating channel status. Receiver
+	// issuance paths (issueTransferReceiverState / issueReleaseReceiverState) lock
+	// the same row up front and then re-check Status via CheckActiveChannel; without
+	// this lock an in-flight RPC can read Status=Open, node-sign a receiver state,
+	// and commit after we flip to Challenged — leaving a node-signed higher-version
+	// receiver state on a disputed channel. See HandleHomeChannelClosed for the same
+	// pattern.
+	if _, err := tx.LockUserState(channel.UserWallet, channel.Asset); err != nil {
+		return err
+	}
+
 	if event.StateVersion < channel.StateVersion {
 		// Per protocol the challenged version cannot be lower than the last known on-chain version.
 		// Treat as an anomaly (replay, indexer mis-order, contract bug): warn and skip persistence.
@@ -169,7 +258,7 @@ func (s *EventHandlerService) HandleHomeChannelChallenged(ctx context.Context, t
 		return err
 	}
 
-	if err := tx.UpdateStateUserSigIfMissing(event.ChannelID, event.StateVersion, event.UserSig); err != nil {
+	if err := tx.UpdateStateSigsIfMissing(event.ChannelID, event.StateVersion, event.UserSig, ""); err != nil {
 		return err
 	}
 
@@ -187,6 +276,11 @@ func (s *EventHandlerService) HandleHomeChannelChallenged(ctx context.Context, t
 // HandleHomeChannelClosed processes the HomeChannelClosed event emitted when a home channel is
 // finalized and closed on-chain. It updates the channel status to Closed and sets the final state version.
 // Once closed, no further state updates are possible for this channel.
+//
+// Additionally, when the closing path was a challenge resolution (channel was Challenged
+// and the closing state is not a finalize), the handler issues a single ChallengeRescue
+// state for the user that squashes the sum of receiver-state credits accrued during the
+// challenge window into an off-channel ledger entry tied to the closed channel's ID.
 func (s *EventHandlerService) HandleHomeChannelClosed(ctx context.Context, tx core.ChannelHubEventHandlerStore, event *core.HomeChannelClosedEvent) error {
 	logger := log.FromContext(ctx)
 	chanID := event.ChannelID
@@ -203,6 +297,18 @@ func (s *EventHandlerService) HandleHomeChannelClosed(ctx context.Context, tx co
 		return nil
 	}
 
+	// Acquire the user's balance-row lock before mutating channel status or summing
+	// receiver credits. issueTransferReceiverState / issueReleaseReceiverState lock
+	// the same row up front, so this serializes the close against any in-flight RPC
+	// receiver-issuance for the same user: either the RPC commits its unsigned row
+	// before we sum (it lands in the rescue), or it blocks until we set the channel
+	// to Closed and then sees that via its own re-check.
+	if _, err := tx.LockUserState(channel.UserWallet, channel.Asset); err != nil {
+		return err
+	}
+
+	wasChallenged := channel.Status == core.ChannelStatusChallenged
+
 	channel.StateVersion = event.StateVersion
 	channel.Status = core.ChannelStatusClosed
 
@@ -214,11 +320,109 @@ func (s *EventHandlerService) HandleHomeChannelClosed(ctx context.Context, tx co
 		return err
 	}
 
-	if err := tx.UpdateStateUserSigIfMissing(event.ChannelID, event.StateVersion, event.UserSig); err != nil {
+	if err := tx.UpdateStateSigsIfMissing(event.ChannelID, event.StateVersion, event.UserSig, ""); err != nil {
 		return err
 	}
 
+	if wasChallenged {
+		if err := s.issueChallengeRescue(ctx, tx, channel, event.StateVersion); err != nil {
+			return err
+		}
+	}
+
 	logger.Info("handled HomeChannelClosed event", "channelId", event.ChannelID, "stateVersion", event.StateVersion, "userWallet", channel.UserWallet)
+	return nil
+}
+
+// issueChallengeRescue emits a ChallengeRescue state on the user's ledger after a
+// challenged-channel close. The state is issued unconditionally so the user's latest
+// stored state moves to a fresh epoch with HomeChannelID nil; without it future
+// receiver-state issuance and channels.v1.request_creation would stay wedged on the
+// closed channel. The rescue amount is the NET effect on the user's home-channel
+// balance of transitions stored strictly above closureVersion — receives
+// (TransferReceive, Release) credit the user, sends (TransferSend, Commit) debit,
+// everything else is excluded because it requires onchain backing the chain didn't
+// enforce or belongs to a different ledger. Signed (Open-time) and unsigned
+// (during-challenge) rows both contribute. The result is clamped at zero so an
+// adversarial close at a version where the user's own balance was higher than the
+// off-chain head can't dock the user further. AccountID is the closed channel's ID;
+// HomeChannelID is nil — the shape of a credit to a user with no open home channel.
+func (s *EventHandlerService) issueChallengeRescue(ctx context.Context, tx core.ChannelHubEventHandlerStore, channel *core.Channel, closureVersion uint64) error {
+	logger := log.FromContext(ctx)
+
+	prev, err := tx.GetLastStateByChannelID(channel.ChannelID, false)
+	if err != nil {
+		return err
+	}
+	if prev == nil {
+		// Should not happen for a channel that reached Challenged → Closed: at least the
+		// closure state itself must be on file. Surface the inconsistency rather than
+		// silently dropping the rescue.
+		return fmt.Errorf("no state found for closed challenged channel %s", channel.ChannelID)
+	}
+
+	// Strict `>` against closureVersion: the row at the closure version itself is the
+	// closing state and must be excluded — only transitions issued strictly after the
+	// dispute version are unenforced. The epoch filter pins the sum to prev.Epoch (the
+	// closed channel's epoch) as a defense against any future DB inconsistency.
+	net, err := tx.SumNetTransitionAmountAfterVersion(channel.ChannelID, closureVersion, prev.Epoch)
+	if err != nil {
+		return err
+	}
+
+	// Negative net is only reachable when the user closed at a version where her own
+	// channel balance was higher than the off-chain head (adversarial rollback of her
+	// own sends/commits). Onchain has already paid her above the head value; rescue
+	// must not dock further. Honest challenges typically have receives dominating,
+	// net >= 0. Clamp defensively and log.
+	total := net
+	if net.IsNegative() {
+		logger.Warn("challenge_rescue net is negative, clamping to zero",
+			"channelId", channel.ChannelID,
+			"netAmount", net.String(),
+			"closureVersion", closureVersion,
+			"prevVersion", prev.Version,
+		)
+		total = decimal.Zero
+	}
+
+	// Invariant: any row included in the sum sits strictly above closureVersion, so the
+	// channel's off-chain head must too. A non-zero net with prev at or below closure
+	// means the state chain disagrees with itself — surface it before issuing the rescue.
+	if !total.IsZero() && prev.Version <= closureVersion {
+		return fmt.Errorf("challenge_rescue: non-zero net (%s) but prev v=%d <= closure v=%d on channel %s",
+			total.String(), prev.Version, closureVersion, channel.ChannelID)
+	}
+
+	rescue, err := core.NewChallengeRescueState(*prev, total)
+	if err != nil {
+		return err
+	}
+
+	// The rescue state is off-channel (HomeChannelID == nil) and is therefore not
+	// node-signed via the channel packer. It is treated like a credit to a user with no
+	// open home channel: the value is recorded in the user's state chain and will be
+	// folded into a properly signed state when the user next opens a channel.
+	if err := tx.StoreUserState(*rescue, ""); err != nil {
+		return err
+	}
+
+	txn, err := core.NewTransactionFromTransition(nil, rescue, rescue.Transition)
+	if err != nil {
+		return err
+	}
+	if err := tx.RecordTransaction(*txn, ""); err != nil {
+		return err
+	}
+
+	logger.Info("issued challenge_rescue state",
+		"channelId", channel.ChannelID,
+		"userWallet", channel.UserWallet,
+		"asset", channel.Asset,
+		"amount", total.String(),
+		"newStateID", rescue.ID,
+		"txID", txn.ID,
+	)
 	return nil
 }
 
@@ -260,7 +464,7 @@ func (s *EventHandlerService) HandleEscrowDepositInitiated(ctx context.Context, 
 		}
 	}
 
-	if err := tx.UpdateStateUserSigIfMissing(event.ChannelID, event.StateVersion, event.UserSig); err != nil {
+	if err := tx.UpdateStateSigsIfMissing(event.ChannelID, event.StateVersion, event.UserSig, ""); err != nil {
 		return err
 	}
 
@@ -325,7 +529,7 @@ func (s *EventHandlerService) HandleEscrowDepositChallenged(ctx context.Context,
 		}
 	}
 
-	if err := tx.UpdateStateUserSigIfMissing(event.ChannelID, event.StateVersion, event.UserSig); err != nil {
+	if err := tx.UpdateStateSigsIfMissing(event.ChannelID, event.StateVersion, event.UserSig, ""); err != nil {
 		return err
 	}
 
@@ -416,7 +620,7 @@ func (s *EventHandlerService) HandleEscrowDepositFinalized(ctx context.Context, 
 		return err
 	}
 
-	if err := tx.UpdateStateUserSigIfMissing(event.ChannelID, event.StateVersion, event.UserSig); err != nil {
+	if err := tx.UpdateStateSigsIfMissing(event.ChannelID, event.StateVersion, event.UserSig, ""); err != nil {
 		return err
 	}
 
@@ -488,7 +692,7 @@ func (s *EventHandlerService) HandleEscrowWithdrawalInitiated(ctx context.Contex
 		return err
 	}
 
-	if err := tx.UpdateStateUserSigIfMissing(event.ChannelID, event.StateVersion, event.UserSig); err != nil {
+	if err := tx.UpdateStateSigsIfMissing(event.ChannelID, event.StateVersion, event.UserSig, ""); err != nil {
 		return err
 	}
 
@@ -548,7 +752,7 @@ func (s *EventHandlerService) HandleEscrowWithdrawalChallenged(ctx context.Conte
 		}
 	}
 
-	if err := tx.UpdateStateUserSigIfMissing(event.ChannelID, event.StateVersion, event.UserSig); err != nil {
+	if err := tx.UpdateStateSigsIfMissing(event.ChannelID, event.StateVersion, event.UserSig, ""); err != nil {
 		return err
 	}
 
@@ -582,7 +786,7 @@ func (s *EventHandlerService) HandleEscrowWithdrawalFinalized(ctx context.Contex
 		return err
 	}
 
-	if err := tx.UpdateStateUserSigIfMissing(event.ChannelID, event.StateVersion, event.UserSig); err != nil {
+	if err := tx.UpdateStateSigsIfMissing(event.ChannelID, event.StateVersion, event.UserSig, ""); err != nil {
 		return err
 	}
 

--- a/nitronode/event_handlers/service.go
+++ b/nitronode/event_handlers/service.go
@@ -208,7 +208,7 @@ func (s *EventHandlerService) backfillOffChainHeadNodeSig(ctx context.Context, t
 	// node-sign it. Log it and bail so the caller surfaces the inconsistency.
 	if head.Transition.Type != core.TransitionTypeTransferReceive &&
 		head.Transition.Type != core.TransitionTypeRelease {
-		log.FromContext(ctx).Debug("off-chain head after challenge clearance is not a receiver state, skipping node-sig backfill",
+		log.FromContext(ctx).Warn("off-chain head after challenge clearance is not a receiver state, skipping node-sig backfill",
 			"channelId", channelID,
 			"transitionType", head.Transition.Type,
 			"version", head.Version,

--- a/nitronode/event_handlers/service_test.go
+++ b/nitronode/event_handlers/service_test.go
@@ -60,6 +60,57 @@ func TestHandleHomeChannelCreated_Success(t *testing.T) {
 	mockStore.AssertExpectations(t)
 }
 
+func TestHandleHomeChannelCreated_IgnoresReplayOnInitializedChannel(t *testing.T) {
+	// HomeChannelCreated must fire only once per channel (Void → Open). Any later replay —
+	// indexer restart, chain reorg, block reprocessing — would otherwise clobber the current
+	// status, including resetting a Closing channel back to Open and re-arming the submission
+	// gate past a co-signed Finalize. The handler must short-circuit when the channel is no
+	// longer in Void.
+	cases := []struct {
+		name   string
+		status core.ChannelStatus
+	}{
+		{"Open", core.ChannelStatusOpen},
+		{"Challenged", core.ChannelStatusChallenged},
+		{"Closing", core.ChannelStatusClosing},
+		{"Closed", core.ChannelStatusClosed},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockStore := new(MockStore)
+			ctx := log.SetContextLogger(context.Background(), log.NewNoopLogger())
+
+			service := &EventHandlerService{}
+
+			channelID := "0xHomeChannel123"
+			channel := &core.Channel{
+				ChannelID:    channelID,
+				UserWallet:   "0x1234567890123456789012345678901234567890",
+				Asset:        "usdc",
+				Type:         core.ChannelTypeHome,
+				Status:       tc.status,
+				StateVersion: 5,
+			}
+
+			event := &core.HomeChannelCreatedEvent{
+				ChannelID:    channelID,
+				StateVersion: 1,
+			}
+
+			mockStore.On("GetChannelByID", channelID).Return(channel, nil)
+
+			err := service.HandleHomeChannelCreated(ctx, mockStore, event)
+
+			require.NoError(t, err)
+			mockStore.AssertExpectations(t)
+			mockStore.AssertNotCalled(t, "UpdateChannel", mock.Anything)
+			mockStore.AssertNotCalled(t, "RefreshUserEnforcedBalance", mock.Anything, mock.Anything)
+			mockStore.AssertNotCalled(t, "UpdateStateSigsIfMissing", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+		})
+	}
+}
+
 func TestHandleHomeChannelCheckpointed_Success(t *testing.T) {
 	// Setup
 	mockStore := new(MockStore)
@@ -93,10 +144,13 @@ func TestHandleHomeChannelCheckpointed_Success(t *testing.T) {
 	mockStore.On("UpdateChannel", mock.MatchedBy(func(ch core.Channel) bool {
 		return ch.ChannelID == channelID &&
 			ch.Status == core.ChannelStatusOpen &&
-			ch.StateVersion == 5
+			ch.StateVersion == 5 &&
+			ch.ChallengeExpiresAt == nil
 	})).Return(nil)
 	mockStore.On("RefreshUserEnforcedBalance", userWallet, "usdc").Return(nil)
 	mockStore.On("UpdateStateSigsIfMissing", channelID, uint64(5), "", "").Return(nil)
+	// No co-signed Finalize → status restored to Open (not Closing).
+	mockStore.On("HasSignedFinalize", channelID).Return(false, nil)
 	// Off-chain head missing → no head-sig backfill.
 	mockStore.On("GetLastStateByChannelID", channelID, false).Return(nil, nil)
 
@@ -245,8 +299,12 @@ func TestHandleHomeChannelChallenged_TypeMismatch(t *testing.T) {
 }
 
 func TestHandleHomeChannelChallenged_FromClosingState(t *testing.T) {
-	// Closing → Challenged is an expected transition: a co-signed Finalize may race an
-	// on-chain challenge. The chain takes precedence; status must become Challenged.
+	// Closing → Challenged is an expected transition when a co-signed Finalize races an
+	// on-chain challenge: the chain takes precedence while the dispute is live and the
+	// status field is intentionally overwritten. The post-Finalize fact survives in
+	// channel_states; HandleHomeChannelCheckpointed restores Closing from there. See
+	// TestHandleHomeChannelCheckpointed_FromChallengedWithSignedFinalize for the
+	// completing half of the round-trip.
 	mockStore := new(MockStore)
 	ctx := log.SetContextLogger(context.Background(), log.NewNoopLogger())
 
@@ -889,14 +947,16 @@ func TestHandleEscrowDepositFinalized_Success(t *testing.T) {
 	// Test data
 	channelID := "0xEscrowChannel123"
 	userWallet := "0x1234567890123456789012345678901234567890"
+	expiryTime := time.Now().Add(time.Hour)
 
 	channel := &core.Channel{
-		ChannelID:    channelID,
-		UserWallet:   userWallet,
-		Asset:        "usdc",
-		Type:         core.ChannelTypeEscrow,
-		Status:       core.ChannelStatusOpen,
-		StateVersion: 3,
+		ChannelID:          channelID,
+		UserWallet:         userWallet,
+		Asset:              "usdc",
+		Type:               core.ChannelTypeEscrow,
+		Status:             core.ChannelStatusChallenged,
+		StateVersion:       3,
+		ChallengeExpiresAt: &expiryTime,
 	}
 
 	event := &core.EscrowDepositFinalizedEvent{
@@ -904,12 +964,13 @@ func TestHandleEscrowDepositFinalized_Success(t *testing.T) {
 		StateVersion: 5,
 	}
 
-	// Mock expectations
+	// Mock expectations — Finalized resolves any pending challenge and clears its expiry.
 	mockStore.On("GetChannelByID", channelID).Return(channel, nil)
 	mockStore.On("UpdateChannel", mock.MatchedBy(func(ch core.Channel) bool {
 		return ch.ChannelID == channelID &&
 			ch.Status == core.ChannelStatusClosed &&
-			ch.StateVersion == 5
+			ch.StateVersion == 5 &&
+			ch.ChallengeExpiresAt == nil
 	})).Return(nil)
 	mockStore.On("UpdateStateSigsIfMissing", channelID, uint64(5), "", "").Return(nil)
 
@@ -1028,14 +1089,16 @@ func TestHandleEscrowWithdrawalFinalized_Success(t *testing.T) {
 	// Test data
 	channelID := "0xEscrowChannel123"
 	userWallet := "0x1234567890123456789012345678901234567890"
+	expiryTime := time.Now().Add(time.Hour)
 
 	channel := &core.Channel{
-		ChannelID:    channelID,
-		UserWallet:   userWallet,
-		Asset:        "usdc",
-		Type:         core.ChannelTypeEscrow,
-		Status:       core.ChannelStatusOpen,
-		StateVersion: 3,
+		ChannelID:          channelID,
+		UserWallet:         userWallet,
+		Asset:              "usdc",
+		Type:               core.ChannelTypeEscrow,
+		Status:             core.ChannelStatusChallenged,
+		StateVersion:       3,
+		ChallengeExpiresAt: &expiryTime,
 	}
 
 	event := &core.EscrowWithdrawalFinalizedEvent{
@@ -1043,12 +1106,13 @@ func TestHandleEscrowWithdrawalFinalized_Success(t *testing.T) {
 		StateVersion: 5,
 	}
 
-	// Mock expectations
+	// Mock expectations — Finalized resolves any pending challenge and clears its expiry.
 	mockStore.On("GetChannelByID", channelID).Return(channel, nil)
 	mockStore.On("UpdateChannel", mock.MatchedBy(func(ch core.Channel) bool {
 		return ch.ChannelID == channelID &&
 			ch.Status == core.ChannelStatusClosed &&
-			ch.StateVersion == 5
+			ch.StateVersion == 5 &&
+			ch.ChallengeExpiresAt == nil
 	})).Return(nil)
 	mockStore.On("UpdateStateSigsIfMissing", channelID, uint64(5), "", "").Return(nil)
 
@@ -1213,14 +1277,16 @@ func TestHandleHomeChannelCheckpointed_BackfillsHeadNodeSig(t *testing.T) {
 	checkpointVersion := uint64(5)
 	headVersion := uint64(7)
 	checkpointUserSig := "0xusersighex"
+	expiryTime := time.Now().Add(time.Hour)
 
 	channel := &core.Channel{
-		ChannelID:    channelID,
-		UserWallet:   userWallet,
-		Asset:        asset,
-		Type:         core.ChannelTypeHome,
-		Status:       core.ChannelStatusChallenged,
-		StateVersion: 4,
+		ChannelID:          channelID,
+		UserWallet:         userWallet,
+		Asset:              asset,
+		Type:               core.ChannelTypeHome,
+		Status:             core.ChannelStatusChallenged,
+		StateVersion:       4,
+		ChallengeExpiresAt: &expiryTime,
 	}
 
 	// Off-chain head is a during-challenge receiver state above the on-chain checkpoint.
@@ -1251,11 +1317,15 @@ func TestHandleHomeChannelCheckpointed_BackfillsHeadNodeSig(t *testing.T) {
 	mockStore.On("GetChannelByID", channelID).Return(channel, nil)
 	mockStore.On("LockUserState", userWallet, asset).Return(decimal.Zero, nil)
 	mockStore.On("UpdateChannel", mock.MatchedBy(func(ch core.Channel) bool {
-		return ch.Status == core.ChannelStatusOpen && ch.StateVersion == checkpointVersion
+		return ch.Status == core.ChannelStatusOpen &&
+			ch.StateVersion == checkpointVersion &&
+			ch.ChallengeExpiresAt == nil
 	})).Return(nil)
 	mockStore.On("RefreshUserEnforcedBalance", userWallet, asset).Return(nil)
 	// User-sig backfill at the on-chain version.
 	mockStore.On("UpdateStateSigsIfMissing", channelID, checkpointVersion, checkpointUserSig, "").Return(nil)
+	// No co-signed Finalize → Challenged restores to Open.
+	mockStore.On("HasSignedFinalize", channelID).Return(false, nil)
 	// Off-chain head lookup returns the higher unsigned receiver state.
 	mockStore.On("GetLastStateByChannelID", channelID, false).Return(headState, nil)
 
@@ -1297,14 +1367,16 @@ func TestHandleHomeChannelCheckpointed_HeadAlreadySigned_NoBackfill(t *testing.T
 	checkpointVersion := uint64(5)
 	headVersion := uint64(5)
 	existingNodeSig := "0xnodesigalreadyhere"
+	expiryTime := time.Now().Add(time.Hour)
 
 	channel := &core.Channel{
-		ChannelID:    channelID,
-		UserWallet:   userWallet,
-		Asset:        asset,
-		Type:         core.ChannelTypeHome,
-		Status:       core.ChannelStatusChallenged,
-		StateVersion: 4,
+		ChannelID:          channelID,
+		UserWallet:         userWallet,
+		Asset:              asset,
+		Type:               core.ChannelTypeHome,
+		Status:             core.ChannelStatusChallenged,
+		StateVersion:       4,
+		ChallengeExpiresAt: &expiryTime,
 	}
 
 	headState := &core.State{
@@ -1334,9 +1406,15 @@ func TestHandleHomeChannelCheckpointed_HeadAlreadySigned_NoBackfill(t *testing.T
 
 	mockStore.On("GetChannelByID", channelID).Return(channel, nil)
 	mockStore.On("LockUserState", userWallet, asset).Return(decimal.Zero, nil)
-	mockStore.On("UpdateChannel", mock.Anything).Return(nil)
+	mockStore.On("UpdateChannel", mock.MatchedBy(func(ch core.Channel) bool {
+		return ch.Status == core.ChannelStatusOpen &&
+			ch.StateVersion == checkpointVersion &&
+			ch.ChallengeExpiresAt == nil
+	})).Return(nil)
 	mockStore.On("RefreshUserEnforcedBalance", userWallet, asset).Return(nil)
 	mockStore.On("UpdateStateSigsIfMissing", channelID, checkpointVersion, "0xusersig", "").Return(nil)
+	// No co-signed Finalize → Challenged restores to Open.
+	mockStore.On("HasSignedFinalize", channelID).Return(false, nil)
 	mockStore.On("GetLastStateByChannelID", channelID, false).Return(headState, nil)
 
 	err := service.HandleHomeChannelCheckpointed(ctx, mockStore, event)
@@ -1344,6 +1422,85 @@ func TestHandleHomeChannelCheckpointed_HeadAlreadySigned_NoBackfill(t *testing.T
 
 	mockStore.AssertExpectations(t)
 	mockStore.AssertNotCalled(t, "UpdateStateSigsIfMissing", channelID, headVersion, "", mock.AnythingOfType("string"))
+}
+
+// TestHandleHomeChannelCheckpointed_FromChallengedWithSignedFinalize exercises the post-Finalize
+// regression scenario: a Closing channel (node signed Finalize off-chain) was flipped to
+// Challenged by a stale on-chain challenge for a lower version. When a subsequent Checkpointed
+// event clears the dispute, the handler must NOT drop the status back to Open, because the local
+// DB still holds a co-signed Finalize. Restoring Closing keeps CheckActiveChannel excluding the
+// channel and prevents the user from advancing past the finalized state via SubmitState.
+func TestHandleHomeChannelCheckpointed_FromChallengedWithSignedFinalize(t *testing.T) {
+	mockStore := new(MockStore)
+	ctx := log.SetContextLogger(context.Background(), log.NewNoopLogger())
+
+	service, _ := newTestEventHandlerService(t)
+
+	channelID := "0xHomeChannel123"
+	userWallet := "0x1234567890123456789012345678901234567890"
+	asset := "usdc"
+	homeChannelIDPtr := channelID
+	finalizeVersion := uint64(7)
+	checkpointVersion := uint64(6)
+	userSig := "0xusersig"
+	nodeSig := "0xnodesig"
+	expiryTime := time.Now().Add(time.Hour)
+
+	channel := &core.Channel{
+		ChannelID:          channelID,
+		UserWallet:         userWallet,
+		Asset:              asset,
+		Type:               core.ChannelTypeHome,
+		Status:             core.ChannelStatusChallenged,
+		StateVersion:       5,
+		ChallengeExpiresAt: &expiryTime,
+	}
+
+	// Co-signed Finalize sitting above the checkpointed on-chain version.
+	finalizeState := &core.State{
+		ID:            core.GetStateID(userWallet, asset, 1, finalizeVersion),
+		Asset:         asset,
+		UserWallet:    userWallet,
+		Epoch:         1,
+		Version:       finalizeVersion,
+		HomeChannelID: &homeChannelIDPtr,
+		Transition:    core.Transition{Type: core.TransitionTypeFinalize},
+		HomeLedger: core.Ledger{
+			TokenAddress: "0xtoken",
+			BlockchainID: 1,
+			UserBalance:  decimal.NewFromInt(100),
+		},
+		UserSig: &userSig,
+		NodeSig: &nodeSig,
+	}
+
+	event := &core.HomeChannelCheckpointedEvent{
+		ChannelID:    channelID,
+		StateVersion: checkpointVersion,
+		UserSig:      userSig,
+	}
+
+	mockStore.On("GetChannelByID", channelID).Return(channel, nil)
+	mockStore.On("LockUserState", userWallet, asset).Return(decimal.Zero, nil)
+	mockStore.On("UpdateChannel", mock.MatchedBy(func(ch core.Channel) bool {
+		return ch.ChannelID == channelID &&
+			ch.Status == core.ChannelStatusClosing &&
+			ch.StateVersion == checkpointVersion &&
+			ch.ChallengeExpiresAt == nil
+	})).Return(nil)
+	mockStore.On("RefreshUserEnforcedBalance", userWallet, asset).Return(nil)
+	mockStore.On("UpdateStateSigsIfMissing", channelID, checkpointVersion, userSig, "").Return(nil)
+	// Node-signed Finalize exists → status restored to Closing.
+	mockStore.On("HasSignedFinalize", channelID).Return(true, nil)
+	// Backfill path: off-chain head is the same already-signed Finalize state — no-op.
+	mockStore.On("GetLastStateByChannelID", channelID, false).Return(finalizeState, nil)
+
+	err := service.HandleHomeChannelCheckpointed(ctx, mockStore, event)
+
+	require.NoError(t, err)
+	mockStore.AssertExpectations(t)
+	// Head already node-signed → no second backfill call.
+	mockStore.AssertNotCalled(t, "UpdateStateSigsIfMissing", channelID, finalizeVersion, mock.Anything, mock.Anything)
 }
 
 // TestHandleHomeChannelCheckpointed_AcquiresUserLockBeforeMutation pins the race fix:
@@ -1386,6 +1543,8 @@ func TestHandleHomeChannelCheckpointed_AcquiresUserLockBeforeMutation(t *testing
 	})).Return(nil)
 	mockStore.On("RefreshUserEnforcedBalance", userWallet, asset).Return(nil)
 	mockStore.On("UpdateStateSigsIfMissing", channelID, uint64(5), "", "").Return(nil)
+	// No co-signed Finalize → status restored to Open.
+	mockStore.On("HasSignedFinalize", channelID).Return(false, nil)
 	mockStore.On("GetLastStateByChannelID", channelID, false).Return(nil, nil)
 
 	err := service.HandleHomeChannelCheckpointed(ctx, mockStore, event)
@@ -1511,14 +1670,16 @@ func TestHandleHomeChannelClosed_ChallengeRescue_NoCredits(t *testing.T) {
 	blockchainID := uint64(1)
 	closureVersion := uint64(7)
 	homeChannelIDPtr := channelID
+	expiryTime := time.Now().Add(time.Hour)
 
 	channel := &core.Channel{
-		ChannelID:    channelID,
-		UserWallet:   userWallet,
-		Asset:        asset,
-		Type:         core.ChannelTypeHome,
-		Status:       core.ChannelStatusChallenged,
-		StateVersion: 5,
+		ChannelID:          channelID,
+		UserWallet:         userWallet,
+		Asset:              asset,
+		Type:               core.ChannelTypeHome,
+		Status:             core.ChannelStatusChallenged,
+		StateVersion:       5,
+		ChallengeExpiresAt: &expiryTime,
 	}
 
 	prevState := &core.State{
@@ -1543,7 +1704,12 @@ func TestHandleHomeChannelClosed_ChallengeRescue_NoCredits(t *testing.T) {
 
 	mockStore.On("GetChannelByID", channelID).Return(channel, nil)
 	mockStore.On("LockUserState", userWallet, asset).Return(decimal.Zero, nil)
-	mockStore.On("UpdateChannel", mock.Anything).Return(nil)
+	// Terminal Close clears any lingering challenge expiry alongside the status flip.
+	mockStore.On("UpdateChannel", mock.MatchedBy(func(ch core.Channel) bool {
+		return ch.Status == core.ChannelStatusClosed &&
+			ch.StateVersion == closureVersion &&
+			ch.ChallengeExpiresAt == nil
+	})).Return(nil)
 	mockStore.On("RefreshUserEnforcedBalance", userWallet, asset).Return(nil)
 	mockStore.On("UpdateStateSigsIfMissing", channelID, closureVersion, "", "").Return(nil)
 	mockStore.On("GetLastStateByChannelID", channelID, false).Return(prevState, nil)

--- a/nitronode/event_handlers/service_test.go
+++ b/nitronode/event_handlers/service_test.go
@@ -1611,6 +1611,7 @@ func TestHandleHomeChannelClosed_ChallengeRescue_Squash(t *testing.T) {
 	})).Return(nil)
 	mockStore.On("RefreshUserEnforcedBalance", userWallet, asset).Return(nil)
 	mockStore.On("UpdateStateSigsIfMissing", channelID, closureVersion, "", "").Return(nil)
+	mockStore.On("HasSignedFinalize", channelID).Return(false, nil)
 	mockStore.On("GetLastStateByChannelID", channelID, false).Return(prevState, nil)
 	mockStore.On("SumNetTransitionAmountAfterVersion", channelID, closureVersion, prevState.Epoch).Return(rescueAmount, nil)
 
@@ -1633,7 +1634,7 @@ func TestHandleHomeChannelClosed_ChallengeRescue_Squash(t *testing.T) {
 	require.True(t, rescueAmount.Equal(capturedState.Transition.Amount))
 	require.Nil(t, capturedState.HomeChannelID, "rescue state must be off-channel")
 	require.Equal(t, prevState.Epoch+1, capturedState.Epoch)
-	require.Equal(t, uint64(1), capturedState.Version)
+	require.Equal(t, uint64(0), capturedState.Version)
 	require.Nil(t, capturedState.NodeSig, "rescue state is stored unsigned, like a credit to a user with no open home channel")
 	require.True(t, rescueAmount.Equal(capturedState.HomeLedger.UserBalance))
 	require.Empty(t, capturedState.HomeLedger.TokenAddress)
@@ -1712,6 +1713,7 @@ func TestHandleHomeChannelClosed_ChallengeRescue_NoCredits(t *testing.T) {
 	})).Return(nil)
 	mockStore.On("RefreshUserEnforcedBalance", userWallet, asset).Return(nil)
 	mockStore.On("UpdateStateSigsIfMissing", channelID, closureVersion, "", "").Return(nil)
+	mockStore.On("HasSignedFinalize", channelID).Return(false, nil)
 	mockStore.On("GetLastStateByChannelID", channelID, false).Return(prevState, nil)
 	mockStore.On("SumNetTransitionAmountAfterVersion", channelID, closureVersion, prevState.Epoch).Return(decimal.Zero, nil)
 
@@ -1730,7 +1732,7 @@ func TestHandleHomeChannelClosed_ChallengeRescue_NoCredits(t *testing.T) {
 	require.True(t, capturedState.HomeLedger.UserBalance.IsZero())
 	require.Nil(t, capturedState.HomeChannelID)
 	require.Equal(t, prevState.Epoch+1, capturedState.Epoch)
-	require.Equal(t, uint64(1), capturedState.Version)
+	require.Equal(t, uint64(0), capturedState.Version)
 
 	mockStore.AssertExpectations(t)
 }
@@ -1790,6 +1792,7 @@ func TestHandleHomeChannelClosed_ChallengeRescue_NegativeNet_ClampsToZero(t *tes
 	mockStore.On("UpdateChannel", mock.Anything).Return(nil)
 	mockStore.On("RefreshUserEnforcedBalance", userWallet, asset).Return(nil)
 	mockStore.On("UpdateStateSigsIfMissing", channelID, closureVersion, "", "").Return(nil)
+	mockStore.On("HasSignedFinalize", channelID).Return(false, nil)
 	mockStore.On("GetLastStateByChannelID", channelID, false).Return(prevState, nil)
 	mockStore.On("SumNetTransitionAmountAfterVersion", channelID, closureVersion, prevState.Epoch).Return(decimal.NewFromInt(-49), nil)
 
@@ -1808,9 +1811,177 @@ func TestHandleHomeChannelClosed_ChallengeRescue_NegativeNet_ClampsToZero(t *tes
 	require.True(t, capturedState.HomeLedger.UserBalance.IsZero())
 	require.Nil(t, capturedState.HomeChannelID)
 	require.Equal(t, prevState.Epoch+1, capturedState.Epoch)
-	require.Equal(t, uint64(1), capturedState.Version)
+	require.Equal(t, uint64(0), capturedState.Version)
 
 	mockStore.AssertExpectations(t)
+}
+
+// TestHandleHomeChannelClosed_PostFinalize_SkipsRescue pins behavior for the
+// cooperative-close-racing-an-onchain-challenge path: the node has already signed a
+// Finalize state for this channel, and post-Finalize receiver credits live in a fresh
+// epoch via NextState() with HomeChannelID=nil. Issuing a rescue at (epoch+1, version=0)
+// in that case would either overwrite a lone receiver credit (silent balance loss) or
+// collide on deterministic state ID with an existing row (StoreUserState fails and rolls
+// back the close, leaving the channel stuck Challenged). The handler must short-circuit
+// the rescue branch entirely when HasSignedFinalize reports true.
+func TestHandleHomeChannelClosed_PostFinalize_SkipsRescue(t *testing.T) {
+	mockStore := new(MockStore)
+	ctx := log.SetContextLogger(context.Background(), log.NewNoopLogger())
+
+	service, _ := newTestEventHandlerService(t)
+
+	channelID := "0xHomeChannel123"
+	userWallet := "0x1234567890123456789012345678901234567890"
+	asset := "USDC"
+	closureVersion := uint64(7)
+	expiryTime := time.Now().Add(time.Hour)
+
+	channel := &core.Channel{
+		ChannelID:          channelID,
+		UserWallet:         userWallet,
+		Asset:              asset,
+		Type:               core.ChannelTypeHome,
+		Status:             core.ChannelStatusChallenged,
+		StateVersion:       5,
+		ChallengeExpiresAt: &expiryTime,
+	}
+
+	event := &core.HomeChannelClosedEvent{
+		ChannelID:    channelID,
+		StateVersion: closureVersion,
+	}
+
+	mockStore.On("GetChannelByID", channelID).Return(channel, nil)
+	mockStore.On("LockUserState", userWallet, asset).Return(decimal.Zero, nil)
+	mockStore.On("UpdateChannel", mock.MatchedBy(func(ch core.Channel) bool {
+		return ch.Status == core.ChannelStatusClosed &&
+			ch.StateVersion == closureVersion &&
+			ch.ChallengeExpiresAt == nil
+	})).Return(nil)
+	mockStore.On("RefreshUserEnforcedBalance", userWallet, asset).Return(nil)
+	mockStore.On("UpdateStateSigsIfMissing", channelID, closureVersion, "", "").Return(nil)
+	mockStore.On("HasSignedFinalize", channelID).Return(true, nil)
+
+	err := service.HandleHomeChannelClosed(ctx, mockStore, event)
+	require.NoError(t, err)
+
+	mockStore.AssertExpectations(t)
+	mockStore.AssertNotCalled(t, "GetLastStateByChannelID", mock.Anything, mock.Anything)
+	mockStore.AssertNotCalled(t, "SumNetTransitionAmountAfterVersion", mock.Anything, mock.Anything, mock.Anything)
+	mockStore.AssertNotCalled(t, "StoreUserState", mock.Anything, mock.Anything)
+	mockStore.AssertNotCalled(t, "RecordTransaction", mock.Anything, mock.Anything)
+}
+
+// TestHandleHomeChannelClosed_PostFinalize_CollisionRegression documents the exact
+// failure modes the guard prevents. Two post-Finalize receiver credits already exist on
+// the user's ledger at (epoch+1, version=0) and (epoch+1, version=1) — produced by the
+// normal NextState() path off the Finalize state with HomeChannelID=nil. Without the
+// guard the handler would:
+//   - call GetLastStateByChannelID(channelID), which only matches channel-attached
+//     rows and therefore returns the Finalize state at the original epoch,
+//   - call SumNetTransitionAmountAfterVersion(channelID, ...), which filters by
+//     home_channel_id and returns zero (post-Finalize credits have HomeChannelID=nil),
+//   - construct a rescue state at (Finalize.Epoch+1, version=0) with amount=0,
+//   - StoreUserState on that ID, which collides deterministically with the existing
+//     (epoch+1, version=0) row via GetStateID(wallet, asset, epoch, version) and
+//     rolls the transaction back, stranding the channel in Challenged.
+//
+// With the guard, HasSignedFinalize=true short-circuits the entire branch before any
+// of those DB calls fire. The mock asserts none of them are reached.
+//
+// Intentional twin of TestHandleHomeChannelClosed_PostFinalize_SkipsRescue: setup and
+// AssertNotCalled set are identical at the mock level; this case exists to document the
+// specific collision failure modes the guard prevents. Do not collapse the two.
+func TestHandleHomeChannelClosed_PostFinalize_CollisionRegression(t *testing.T) {
+	mockStore := new(MockStore)
+	ctx := log.SetContextLogger(context.Background(), log.NewNoopLogger())
+
+	service, _ := newTestEventHandlerService(t)
+
+	channelID := "0xHomeChannelCollision"
+	userWallet := "0x1234567890123456789012345678901234567890"
+	asset := "USDC"
+	closureVersion := uint64(10)
+	expiryTime := time.Now().Add(time.Hour)
+
+	channel := &core.Channel{
+		ChannelID:          channelID,
+		UserWallet:         userWallet,
+		Asset:              asset,
+		Type:               core.ChannelTypeHome,
+		Status:             core.ChannelStatusChallenged,
+		StateVersion:       9,
+		ChallengeExpiresAt: &expiryTime,
+	}
+
+	event := &core.HomeChannelClosedEvent{
+		ChannelID:    channelID,
+		StateVersion: closureVersion,
+	}
+
+	mockStore.On("GetChannelByID", channelID).Return(channel, nil)
+	mockStore.On("LockUserState", userWallet, asset).Return(decimal.Zero, nil)
+	mockStore.On("UpdateChannel", mock.MatchedBy(func(ch core.Channel) bool {
+		return ch.Status == core.ChannelStatusClosed &&
+			ch.StateVersion == closureVersion &&
+			ch.ChallengeExpiresAt == nil
+	})).Return(nil)
+	mockStore.On("RefreshUserEnforcedBalance", userWallet, asset).Return(nil)
+	mockStore.On("UpdateStateSigsIfMissing", channelID, closureVersion, "", "").Return(nil)
+	mockStore.On("HasSignedFinalize", channelID).Return(true, nil)
+
+	err := service.HandleHomeChannelClosed(ctx, mockStore, event)
+	require.NoError(t, err, "post-Finalize close must succeed; rescue branch must be skipped")
+
+	mockStore.AssertExpectations(t)
+	// The collision-class operations must not be invoked once the guard fires.
+	mockStore.AssertNotCalled(t, "GetLastStateByChannelID", mock.Anything, mock.Anything)
+	mockStore.AssertNotCalled(t, "SumNetTransitionAmountAfterVersion", mock.Anything, mock.Anything, mock.Anything)
+	mockStore.AssertNotCalled(t, "StoreUserState", mock.Anything, mock.Anything)
+	mockStore.AssertNotCalled(t, "RecordTransaction", mock.Anything, mock.Anything)
+}
+
+// TestHandleHomeChannelClosed_PostFinalize_HasSignedFinalizeErr ensures errors from the
+// HasSignedFinalize lookup are surfaced rather than silently dropping the rescue guard.
+func TestHandleHomeChannelClosed_PostFinalize_HasSignedFinalizeErr(t *testing.T) {
+	mockStore := new(MockStore)
+	ctx := log.SetContextLogger(context.Background(), log.NewNoopLogger())
+
+	service, _ := newTestEventHandlerService(t)
+
+	channelID := "0xHomeChannel123"
+	userWallet := "0x1234567890123456789012345678901234567890"
+	asset := "USDC"
+	closureVersion := uint64(7)
+
+	channel := &core.Channel{
+		ChannelID:    channelID,
+		UserWallet:   userWallet,
+		Asset:        asset,
+		Type:         core.ChannelTypeHome,
+		Status:       core.ChannelStatusChallenged,
+		StateVersion: 5,
+	}
+
+	event := &core.HomeChannelClosedEvent{
+		ChannelID:    channelID,
+		StateVersion: closureVersion,
+	}
+
+	dbErr := errors.New("db down")
+	mockStore.On("GetChannelByID", channelID).Return(channel, nil)
+	mockStore.On("LockUserState", userWallet, asset).Return(decimal.Zero, nil)
+	mockStore.On("UpdateChannel", mock.Anything).Return(nil)
+	mockStore.On("RefreshUserEnforcedBalance", userWallet, asset).Return(nil)
+	mockStore.On("UpdateStateSigsIfMissing", channelID, closureVersion, "", "").Return(nil)
+	mockStore.On("HasSignedFinalize", channelID).Return(false, dbErr)
+
+	err := service.HandleHomeChannelClosed(ctx, mockStore, event)
+	require.ErrorIs(t, err, dbErr)
+
+	mockStore.AssertNotCalled(t, "GetLastStateByChannelID", mock.Anything, mock.Anything)
+	mockStore.AssertNotCalled(t, "SumNetTransitionAmountAfterVersion", mock.Anything, mock.Anything, mock.Anything)
+	mockStore.AssertNotCalled(t, "StoreUserState", mock.Anything, mock.Anything)
 }
 
 // TestHandleHomeChannelClosed_OpenChannel_NoRescue pins behavior for the normal

--- a/nitronode/event_handlers/service_test.go
+++ b/nitronode/event_handlers/service_test.go
@@ -6,12 +6,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/layer-3/nitrolite/pkg/core"
 	"github.com/layer-3/nitrolite/pkg/log"
+	"github.com/layer-3/nitrolite/pkg/sign"
 )
 
 func TestHandleHomeChannelCreated_Success(t *testing.T) {
@@ -47,7 +50,7 @@ func TestHandleHomeChannelCreated_Success(t *testing.T) {
 			ch.StateVersion == 1
 	})).Return(nil)
 	mockStore.On("RefreshUserEnforcedBalance", userWallet, "usdc").Return(nil)
-	mockStore.On("UpdateStateUserSigIfMissing", channelID, uint64(1), "").Return(nil)
+	mockStore.On("UpdateStateSigsIfMissing", channelID, uint64(1), "", "").Return(nil)
 
 	// Execute
 	err := service.HandleHomeChannelCreated(ctx, mockStore, event)
@@ -62,7 +65,7 @@ func TestHandleHomeChannelCheckpointed_Success(t *testing.T) {
 	mockStore := new(MockStore)
 	ctx := log.SetContextLogger(context.Background(), log.NewNoopLogger())
 
-	service := &EventHandlerService{}
+	service, _ := newTestEventHandlerService(t)
 
 	// Test data
 	channelID := "0xHomeChannel123"
@@ -86,13 +89,16 @@ func TestHandleHomeChannelCheckpointed_Success(t *testing.T) {
 
 	// Mock expectations
 	mockStore.On("GetChannelByID", channelID).Return(channel, nil)
+	mockStore.On("LockUserState", userWallet, "usdc").Return(decimal.Zero, nil)
 	mockStore.On("UpdateChannel", mock.MatchedBy(func(ch core.Channel) bool {
 		return ch.ChannelID == channelID &&
 			ch.Status == core.ChannelStatusOpen &&
 			ch.StateVersion == 5
 	})).Return(nil)
 	mockStore.On("RefreshUserEnforcedBalance", userWallet, "usdc").Return(nil)
-	mockStore.On("UpdateStateUserSigIfMissing", channelID, uint64(5), "").Return(nil)
+	mockStore.On("UpdateStateSigsIfMissing", channelID, uint64(5), "", "").Return(nil)
+	// Off-chain head missing → no head-sig backfill.
+	mockStore.On("GetLastStateByChannelID", channelID, false).Return(nil, nil)
 
 	// Execute
 	err := service.HandleHomeChannelCheckpointed(ctx, mockStore, event)
@@ -132,6 +138,7 @@ func TestHandleHomeChannelChallenged_PersistsChallenge(t *testing.T) {
 	}
 
 	mockStore.On("GetChannelByID", channelID).Return(channel, nil)
+	mockStore.On("LockUserState", userWallet, "usdc").Return(decimal.Zero, nil)
 	mockStore.On("UpdateChannel", mock.MatchedBy(func(ch core.Channel) bool {
 		return ch.ChannelID == channelID &&
 			ch.Status == core.ChannelStatusChallenged &&
@@ -140,7 +147,7 @@ func TestHandleHomeChannelChallenged_PersistsChallenge(t *testing.T) {
 			ch.ChallengeExpiresAt.Unix() == int64(challengeExpiry)
 	})).Return(nil)
 	mockStore.On("RefreshUserEnforcedBalance", userWallet, "usdc").Return(nil)
-	mockStore.On("UpdateStateUserSigIfMissing", channelID, uint64(4), "").Return(nil)
+	mockStore.On("UpdateStateSigsIfMissing", channelID, uint64(4), "", "").Return(nil)
 
 	err := service.HandleHomeChannelChallenged(ctx, mockStore, event)
 
@@ -177,6 +184,7 @@ func TestHandleHomeChannelChallenged_StaleVersionIgnored(t *testing.T) {
 	}
 
 	mockStore.On("GetChannelByID", channelID).Return(channel, nil)
+	mockStore.On("LockUserState", userWallet, "usdc").Return(decimal.Zero, nil)
 
 	err := service.HandleHomeChannelChallenged(ctx, mockStore, event)
 
@@ -264,6 +272,7 @@ func TestHandleHomeChannelChallenged_FromClosingState(t *testing.T) {
 	}
 
 	mockStore.On("GetChannelByID", channelID).Return(channel, nil)
+	mockStore.On("LockUserState", userWallet, "usdc").Return(decimal.Zero, nil)
 	mockStore.On("UpdateChannel", mock.MatchedBy(func(ch core.Channel) bool {
 		return ch.ChannelID == channelID &&
 			ch.Status == core.ChannelStatusChallenged &&
@@ -272,10 +281,57 @@ func TestHandleHomeChannelChallenged_FromClosingState(t *testing.T) {
 			ch.ChallengeExpiresAt.Unix() == int64(challengeExpiry)
 	})).Return(nil)
 	mockStore.On("RefreshUserEnforcedBalance", userWallet, "usdc").Return(nil)
-	mockStore.On("UpdateStateUserSigIfMissing", channelID, uint64(4), "").Return(nil)
+	mockStore.On("UpdateStateSigsIfMissing", channelID, uint64(4), "", "").Return(nil)
 
 	err := service.HandleHomeChannelChallenged(ctx, mockStore, event)
 
+	require.NoError(t, err)
+	mockStore.AssertExpectations(t)
+}
+
+// TestHandleHomeChannelChallenged_AcquiresUserLockBeforeMutation pins the race fix:
+// the handler must call LockUserState(userWallet, asset) before UpdateChannel so an
+// in-flight receiver-issuance RPC cannot read Status=Open, node-sign a receiver state
+// and commit after the status flip to Challenged. See HandleHomeChannelClosed for the
+// same pattern.
+func TestHandleHomeChannelChallenged_AcquiresUserLockBeforeMutation(t *testing.T) {
+	mockStore := new(MockStore)
+	ctx := log.SetContextLogger(context.Background(), log.NewNoopLogger())
+
+	service := &EventHandlerService{}
+
+	channelID := "0xHomeChannel123"
+	userWallet := "0x1234567890123456789012345678901234567890"
+	asset := "usdc"
+
+	channel := &core.Channel{
+		ChannelID:    channelID,
+		UserWallet:   userWallet,
+		Asset:        asset,
+		Type:         core.ChannelTypeHome,
+		Status:       core.ChannelStatusOpen,
+		StateVersion: 3,
+	}
+
+	event := &core.HomeChannelChallengedEvent{
+		ChannelID:       channelID,
+		StateVersion:    4,
+		ChallengeExpiry: uint64(time.Now().Add(time.Hour).Unix()),
+	}
+
+	var locked bool
+	mockStore.On("GetChannelByID", channelID).Return(channel, nil)
+	mockStore.On("LockUserState", userWallet, asset).
+		Run(func(mock.Arguments) { locked = true }).
+		Return(decimal.Zero, nil)
+	mockStore.On("UpdateChannel", mock.MatchedBy(func(core.Channel) bool {
+		require.True(t, locked, "LockUserState must be called before UpdateChannel")
+		return true
+	})).Return(nil)
+	mockStore.On("RefreshUserEnforcedBalance", userWallet, asset).Return(nil)
+	mockStore.On("UpdateStateSigsIfMissing", channelID, uint64(4), "", "").Return(nil)
+
+	err := service.HandleHomeChannelChallenged(ctx, mockStore, event)
 	require.NoError(t, err)
 	mockStore.AssertExpectations(t)
 }
@@ -307,13 +363,14 @@ func TestHandleHomeChannelClosed_Success(t *testing.T) {
 
 	// Mock expectations
 	mockStore.On("GetChannelByID", channelID).Return(channel, nil)
+	mockStore.On("LockUserState", userWallet, "usdc").Return(decimal.Zero, nil)
 	mockStore.On("UpdateChannel", mock.MatchedBy(func(ch core.Channel) bool {
 		return ch.ChannelID == channelID &&
 			ch.Status == core.ChannelStatusClosed &&
 			ch.StateVersion == 10
 	})).Return(nil)
 	mockStore.On("RefreshUserEnforcedBalance", userWallet, "usdc").Return(nil)
-	mockStore.On("UpdateStateUserSigIfMissing", channelID, uint64(10), "").Return(nil)
+	mockStore.On("UpdateStateSigsIfMissing", channelID, uint64(10), "", "").Return(nil)
 
 	// Execute
 	err := service.HandleHomeChannelClosed(ctx, mockStore, event)
@@ -368,7 +425,7 @@ func TestHandleEscrowDepositInitiated_Success(t *testing.T) {
 	})).Return(nil)
 	mockStore.On("GetStateByChannelIDAndVersion", channelID, uint64(1)).Return(state, nil)
 	mockStore.On("ScheduleInitiateEscrowDeposit", "state123", uint64(0)).Return(nil)
-	mockStore.On("UpdateStateUserSigIfMissing", channelID, uint64(1), "").Return(nil)
+	mockStore.On("UpdateStateSigsIfMissing", channelID, uint64(1), "", "").Return(nil)
 
 	// Execute
 	err := service.HandleEscrowDepositInitiated(ctx, mockStore, event)
@@ -423,7 +480,7 @@ func TestHandleEscrowDepositChallenged_Success(t *testing.T) {
 	})).Return(nil)
 	mockStore.On("GetLastStateByChannelID", channelID, true).Return(state, nil)
 	mockStore.On("ScheduleFinalizeEscrowDeposit", "state123", uint64(2)).Return(nil)
-	mockStore.On("UpdateStateUserSigIfMissing", channelID, uint64(3), "").Return(nil)
+	mockStore.On("UpdateStateSigsIfMissing", channelID, uint64(3), "", "").Return(nil)
 
 	// Execute
 	err := service.HandleEscrowDepositChallenged(ctx, mockStore, event)
@@ -490,7 +547,7 @@ func TestHandleEscrowDepositChallenged_NoFinalize_SchedulesHomeChallenge(t *test
 	mockStore.On("GetStateByChannelIDAndVersion", escrowChannelID, uint64(3)).Return(initiateState, nil)
 	mockStore.On("GetChannelByID", homeChannelID).Return(homeChannel, nil)
 	mockStore.On("ScheduleChallenge", "initiate-state-id", uint64(1)).Return(nil)
-	mockStore.On("UpdateStateUserSigIfMissing", escrowChannelID, uint64(3), "").Return(nil)
+	mockStore.On("UpdateStateSigsIfMissing", escrowChannelID, uint64(3), "", "").Return(nil)
 
 	err := service.HandleEscrowDepositChallenged(ctx, mockStore, event)
 
@@ -544,7 +601,7 @@ func TestHandleEscrowDepositChallenged_NoFinalize_HomeChannelNotOpen_SkipsChalle
 	mockStore.On("GetLastStateByChannelID", escrowChannelID, true).Return(initiateState, nil)
 	mockStore.On("GetStateByChannelIDAndVersion", escrowChannelID, uint64(3)).Return(initiateState, nil)
 	mockStore.On("GetChannelByID", homeChannelID).Return(homeChannel, nil)
-	mockStore.On("UpdateStateUserSigIfMissing", escrowChannelID, uint64(3), "").Return(nil)
+	mockStore.On("UpdateStateSigsIfMissing", escrowChannelID, uint64(3), "", "").Return(nil)
 
 	err := service.HandleEscrowDepositChallenged(ctx, mockStore, event)
 
@@ -580,7 +637,7 @@ func TestHandleEscrowDepositChallenged_NoLocalState_NoSchedule(t *testing.T) {
 	mockStore.On("UpdateChannel", mock.Anything).Return(nil)
 	mockStore.On("GetLastStateByChannelID", escrowChannelID, true).Return(nil, nil)
 	mockStore.On("GetStateByChannelIDAndVersion", escrowChannelID, uint64(3)).Return(nil, nil)
-	mockStore.On("UpdateStateUserSigIfMissing", escrowChannelID, uint64(3), "").Return(nil)
+	mockStore.On("UpdateStateSigsIfMissing", escrowChannelID, uint64(3), "", "").Return(nil)
 
 	err := service.HandleEscrowDepositChallenged(ctx, mockStore, event)
 
@@ -625,7 +682,7 @@ func TestHandleEscrowDepositChallenged_HomeChannelIDNil_SkipsChallenge(t *testin
 	mockStore.On("UpdateChannel", mock.Anything).Return(nil)
 	mockStore.On("GetLastStateByChannelID", escrowChannelID, true).Return(initiateState, nil)
 	mockStore.On("GetStateByChannelIDAndVersion", escrowChannelID, uint64(3)).Return(initiateState, nil)
-	mockStore.On("UpdateStateUserSigIfMissing", escrowChannelID, uint64(3), "").Return(nil)
+	mockStore.On("UpdateStateSigsIfMissing", escrowChannelID, uint64(3), "", "").Return(nil)
 
 	err := service.HandleEscrowDepositChallenged(ctx, mockStore, event)
 
@@ -672,7 +729,7 @@ func TestHandleEscrowDepositChallenged_HomeChannelNotFound_SkipsChallenge(t *tes
 	mockStore.On("GetLastStateByChannelID", escrowChannelID, true).Return(initiateState, nil)
 	mockStore.On("GetStateByChannelIDAndVersion", escrowChannelID, uint64(3)).Return(initiateState, nil)
 	mockStore.On("GetChannelByID", homeChannelID).Return((*core.Channel)(nil), nil)
-	mockStore.On("UpdateStateUserSigIfMissing", escrowChannelID, uint64(3), "").Return(nil)
+	mockStore.On("UpdateStateSigsIfMissing", escrowChannelID, uint64(3), "", "").Return(nil)
 
 	err := service.HandleEscrowDepositChallenged(ctx, mockStore, event)
 
@@ -716,7 +773,7 @@ func TestHandleEscrowDepositChallenged_GetStateByVersionError_Propagates(t *test
 	require.ErrorIs(t, err, dbErr)
 	mockStore.AssertExpectations(t)
 	mockStore.AssertNotCalled(t, "ScheduleChallenge", mock.Anything, mock.Anything)
-	mockStore.AssertNotCalled(t, "UpdateStateUserSigIfMissing", mock.Anything, mock.Anything, mock.Anything)
+	mockStore.AssertNotCalled(t, "UpdateStateSigsIfMissing", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestHandleEscrowDepositChallenged_GetHomeChannelError_Propagates(t *testing.T) {
@@ -764,7 +821,7 @@ func TestHandleEscrowDepositChallenged_GetHomeChannelError_Propagates(t *testing
 	require.ErrorIs(t, err, dbErr)
 	mockStore.AssertExpectations(t)
 	mockStore.AssertNotCalled(t, "ScheduleChallenge", mock.Anything, mock.Anything)
-	mockStore.AssertNotCalled(t, "UpdateStateUserSigIfMissing", mock.Anything, mock.Anything, mock.Anything)
+	mockStore.AssertNotCalled(t, "UpdateStateSigsIfMissing", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestHandleEscrowDepositChallenged_HomeBlockchainIDZero_SkipsChallenge(t *testing.T) {
@@ -812,7 +869,7 @@ func TestHandleEscrowDepositChallenged_HomeBlockchainIDZero_SkipsChallenge(t *te
 	mockStore.On("GetLastStateByChannelID", escrowChannelID, true).Return(initiateState, nil)
 	mockStore.On("GetStateByChannelIDAndVersion", escrowChannelID, uint64(3)).Return(initiateState, nil)
 	mockStore.On("GetChannelByID", homeChannelID).Return(homeChannel, nil)
-	mockStore.On("UpdateStateUserSigIfMissing", escrowChannelID, uint64(3), "").Return(nil)
+	mockStore.On("UpdateStateSigsIfMissing", escrowChannelID, uint64(3), "", "").Return(nil)
 
 	err := service.HandleEscrowDepositChallenged(ctx, mockStore, event)
 
@@ -854,7 +911,7 @@ func TestHandleEscrowDepositFinalized_Success(t *testing.T) {
 			ch.Status == core.ChannelStatusClosed &&
 			ch.StateVersion == 5
 	})).Return(nil)
-	mockStore.On("UpdateStateUserSigIfMissing", channelID, uint64(5), "").Return(nil)
+	mockStore.On("UpdateStateSigsIfMissing", channelID, uint64(5), "", "").Return(nil)
 
 	// Execute
 	err := service.HandleEscrowDepositFinalized(ctx, mockStore, event)
@@ -896,7 +953,7 @@ func TestHandleEscrowWithdrawalInitiated_Success(t *testing.T) {
 			ch.Status == core.ChannelStatusOpen &&
 			ch.StateVersion == 1
 	})).Return(nil)
-	mockStore.On("UpdateStateUserSigIfMissing", channelID, uint64(1), "").Return(nil)
+	mockStore.On("UpdateStateSigsIfMissing", channelID, uint64(1), "", "").Return(nil)
 
 	// Execute
 	err := service.HandleEscrowWithdrawalInitiated(ctx, mockStore, event)
@@ -951,7 +1008,7 @@ func TestHandleEscrowWithdrawalChallenged_Success(t *testing.T) {
 	})).Return(nil)
 	mockStore.On("GetLastStateByChannelID", channelID, true).Return(state, nil)
 	mockStore.On("ScheduleFinalizeEscrowWithdrawal", "state123", uint64(2)).Return(nil)
-	mockStore.On("UpdateStateUserSigIfMissing", channelID, uint64(3), "").Return(nil)
+	mockStore.On("UpdateStateSigsIfMissing", channelID, uint64(3), "", "").Return(nil)
 
 	// Execute
 	err := service.HandleEscrowWithdrawalChallenged(ctx, mockStore, event)
@@ -993,7 +1050,7 @@ func TestHandleEscrowWithdrawalFinalized_Success(t *testing.T) {
 			ch.Status == core.ChannelStatusClosed &&
 			ch.StateVersion == 5
 	})).Return(nil)
-	mockStore.On("UpdateStateUserSigIfMissing", channelID, uint64(5), "").Return(nil)
+	mockStore.On("UpdateStateSigsIfMissing", channelID, uint64(5), "", "").Return(nil)
 
 	// Execute
 	err := service.HandleEscrowWithdrawalFinalized(ctx, mockStore, event)
@@ -1064,16 +1121,18 @@ func TestHandleHomeChannelCheckpointed_BackfillsUserSig(t *testing.T) {
 	}
 
 	mockStore.On("GetChannelByID", channelID).Return(channel, nil)
+	mockStore.On("LockUserState", userWallet, "usdc").Return(decimal.Zero, nil)
 	mockStore.On("UpdateChannel", mock.MatchedBy(func(ch core.Channel) bool {
 		return ch.StateVersion == 5
 	})).Return(nil)
 	mockStore.On("RefreshUserEnforcedBalance", userWallet, "usdc").Return(nil)
-	mockStore.On("UpdateStateUserSigIfMissing", channelID, uint64(5), userSig).Return(nil)
+	mockStore.On("UpdateStateSigsIfMissing", channelID, uint64(5), userSig, "").Return(nil)
 
 	err := service.HandleHomeChannelCheckpointed(ctx, mockStore, event)
 
 	require.NoError(t, err)
 	mockStore.AssertExpectations(t)
+	mockStore.AssertNotCalled(t, "GetLastStateByChannelID", mock.Anything, mock.Anything)
 }
 
 // TestHandleHomeChannelCheckpointed_BackfillError surfaces store errors from the backfill so
@@ -1103,15 +1162,532 @@ func TestHandleHomeChannelCheckpointed_BackfillError(t *testing.T) {
 	}
 
 	mockStore.On("GetChannelByID", channelID).Return(channel, nil)
+	mockStore.On("LockUserState", userWallet, "usdc").Return(decimal.Zero, nil)
 	mockStore.On("UpdateChannel", mock.Anything).Return(nil)
 	mockStore.On("RefreshUserEnforcedBalance", userWallet, "usdc").Return(nil)
-	mockStore.On("UpdateStateUserSigIfMissing", channelID, uint64(5), "0xdeadbeef").Return(errors.New("db error"))
+	mockStore.On("UpdateStateSigsIfMissing", channelID, uint64(5), "0xdeadbeef", "").Return(errors.New("db error"))
 
 	err := service.HandleHomeChannelCheckpointed(ctx, mockStore, event)
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "db error")
 	mockStore.AssertExpectations(t)
+}
+
+// mockEventHandlerAssetStore implements core.AssetStore for state packing in unit tests.
+type mockEventHandlerAssetStore struct{}
+
+func (mockEventHandlerAssetStore) GetAssetDecimals(string) (uint8, error) { return 6, nil }
+func (mockEventHandlerAssetStore) GetTokenDecimals(uint64, string) (uint8, error) {
+	return 6, nil
+}
+
+func newTestEventHandlerService(t *testing.T) (*EventHandlerService, string) {
+	t.Helper()
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	signer, err := sign.NewEthereumMsgSigner(hexutil.Encode(crypto.FromECDSA(key)))
+	require.NoError(t, err)
+	nodeSigner, err := core.NewChannelDefaultSigner(signer)
+	require.NoError(t, err)
+	packer := core.NewStatePackerV1(mockEventHandlerAssetStore{})
+	return NewEventHandlerService(nodeSigner, packer), signer.PublicKey().Address().String()
+}
+
+// TestHandleHomeChannelCheckpointed_BackfillsHeadNodeSig covers the case where a
+// challenge is cleared while the off-chain head sits above the checkpointed onchain
+// version: a receiver state stored unsigned during the challenge window is now the
+// channel's actual latest state. The handler must node-sign that head so future flows
+// treat it as fully co-signed; the user signature backfill targets the on-chain version
+// separately.
+func TestHandleHomeChannelCheckpointed_BackfillsHeadNodeSig(t *testing.T) {
+	mockStore := new(MockStore)
+	ctx := log.SetContextLogger(context.Background(), log.NewNoopLogger())
+
+	service, nodeAddress := newTestEventHandlerService(t)
+
+	channelID := "0xHomeChannel123"
+	userWallet := "0x1234567890123456789012345678901234567890"
+	asset := "USDC"
+	homeChannelIDPtr := channelID
+	checkpointVersion := uint64(5)
+	headVersion := uint64(7)
+	checkpointUserSig := "0xusersighex"
+
+	channel := &core.Channel{
+		ChannelID:    channelID,
+		UserWallet:   userWallet,
+		Asset:        asset,
+		Type:         core.ChannelTypeHome,
+		Status:       core.ChannelStatusChallenged,
+		StateVersion: 4,
+	}
+
+	// Off-chain head is a during-challenge receiver state above the on-chain checkpoint.
+	headState := &core.State{
+		ID:            core.GetStateID(userWallet, asset, 1, headVersion),
+		Asset:         asset,
+		UserWallet:    userWallet,
+		Epoch:         1,
+		Version:       headVersion,
+		HomeChannelID: &homeChannelIDPtr,
+		Transition:    core.Transition{Type: core.TransitionTypeTransferReceive},
+		HomeLedger: core.Ledger{
+			TokenAddress: "0xtoken",
+			BlockchainID: 1,
+			UserBalance:  decimal.NewFromInt(100),
+			UserNetFlow:  decimal.Zero,
+			NodeBalance:  decimal.Zero,
+			NodeNetFlow:  decimal.Zero,
+		},
+	}
+
+	event := &core.HomeChannelCheckpointedEvent{
+		ChannelID:    channelID,
+		StateVersion: checkpointVersion,
+		UserSig:      checkpointUserSig,
+	}
+
+	mockStore.On("GetChannelByID", channelID).Return(channel, nil)
+	mockStore.On("LockUserState", userWallet, asset).Return(decimal.Zero, nil)
+	mockStore.On("UpdateChannel", mock.MatchedBy(func(ch core.Channel) bool {
+		return ch.Status == core.ChannelStatusOpen && ch.StateVersion == checkpointVersion
+	})).Return(nil)
+	mockStore.On("RefreshUserEnforcedBalance", userWallet, asset).Return(nil)
+	// User-sig backfill at the on-chain version.
+	mockStore.On("UpdateStateSigsIfMissing", channelID, checkpointVersion, checkpointUserSig, "").Return(nil)
+	// Off-chain head lookup returns the higher unsigned receiver state.
+	mockStore.On("GetLastStateByChannelID", channelID, false).Return(headState, nil)
+
+	var capturedNodeSig string
+	mockStore.On("UpdateStateSigsIfMissing", channelID, headVersion, "", mock.AnythingOfType("string")).
+		Run(func(args mock.Arguments) {
+			capturedNodeSig = args.String(3)
+		}).Return(nil)
+
+	err := service.HandleHomeChannelCheckpointed(ctx, mockStore, event)
+	require.NoError(t, err)
+	require.NotEmpty(t, capturedNodeSig, "node signature must be populated on backfill")
+
+	// Verify the produced signature is from the configured node key.
+	packer := core.NewStatePackerV1(mockEventHandlerAssetStore{})
+	packed, err := packer.PackState(*headState)
+	require.NoError(t, err)
+	sigBytes, err := hexutil.Decode(capturedNodeSig)
+	require.NoError(t, err)
+	validator := core.NewChannelSigValidator(nil)
+	require.NoError(t, validator.Verify(nodeAddress, packed, sigBytes))
+
+	mockStore.AssertExpectations(t)
+}
+
+// TestHandleHomeChannelCheckpointed_HeadAlreadySigned_NoBackfill verifies that when
+// a challenge clears and the off-chain head is already node-signed (typical case if
+// no receiver states were issued during the challenge), the handler does not re-sign.
+func TestHandleHomeChannelCheckpointed_HeadAlreadySigned_NoBackfill(t *testing.T) {
+	mockStore := new(MockStore)
+	ctx := log.SetContextLogger(context.Background(), log.NewNoopLogger())
+
+	service, _ := newTestEventHandlerService(t)
+
+	channelID := "0xHomeChannel123"
+	userWallet := "0x1234567890123456789012345678901234567890"
+	asset := "USDC"
+	homeChannelIDPtr := channelID
+	checkpointVersion := uint64(5)
+	headVersion := uint64(5)
+	existingNodeSig := "0xnodesigalreadyhere"
+
+	channel := &core.Channel{
+		ChannelID:    channelID,
+		UserWallet:   userWallet,
+		Asset:        asset,
+		Type:         core.ChannelTypeHome,
+		Status:       core.ChannelStatusChallenged,
+		StateVersion: 4,
+	}
+
+	headState := &core.State{
+		ID:            core.GetStateID(userWallet, asset, 1, headVersion),
+		Asset:         asset,
+		UserWallet:    userWallet,
+		Epoch:         1,
+		Version:       headVersion,
+		HomeChannelID: &homeChannelIDPtr,
+		Transition:    core.Transition{Type: core.TransitionTypeTransferReceive},
+		HomeLedger: core.Ledger{
+			TokenAddress: "0xtoken",
+			BlockchainID: 1,
+			UserBalance:  decimal.NewFromInt(100),
+			UserNetFlow:  decimal.Zero,
+			NodeBalance:  decimal.Zero,
+			NodeNetFlow:  decimal.Zero,
+		},
+		NodeSig: &existingNodeSig,
+	}
+
+	event := &core.HomeChannelCheckpointedEvent{
+		ChannelID:    channelID,
+		StateVersion: checkpointVersion,
+		UserSig:      "0xusersig",
+	}
+
+	mockStore.On("GetChannelByID", channelID).Return(channel, nil)
+	mockStore.On("LockUserState", userWallet, asset).Return(decimal.Zero, nil)
+	mockStore.On("UpdateChannel", mock.Anything).Return(nil)
+	mockStore.On("RefreshUserEnforcedBalance", userWallet, asset).Return(nil)
+	mockStore.On("UpdateStateSigsIfMissing", channelID, checkpointVersion, "0xusersig", "").Return(nil)
+	mockStore.On("GetLastStateByChannelID", channelID, false).Return(headState, nil)
+
+	err := service.HandleHomeChannelCheckpointed(ctx, mockStore, event)
+	require.NoError(t, err)
+
+	mockStore.AssertExpectations(t)
+	mockStore.AssertNotCalled(t, "UpdateStateSigsIfMissing", channelID, headVersion, "", mock.AnythingOfType("string"))
+}
+
+// TestHandleHomeChannelCheckpointed_AcquiresUserLockBeforeMutation pins the race fix:
+// the handler must call LockUserState before flipping Status from Challenged to Open
+// and backfilling the off-chain head. Otherwise an in-flight receiver-issuance RPC
+// can read Status=Challenged, choose to store an unsigned receiver row, and commit
+// after the backfill — leaving the latest head unsigned on a now-Open channel.
+func TestHandleHomeChannelCheckpointed_AcquiresUserLockBeforeMutation(t *testing.T) {
+	mockStore := new(MockStore)
+	ctx := log.SetContextLogger(context.Background(), log.NewNoopLogger())
+
+	service, _ := newTestEventHandlerService(t)
+
+	channelID := "0xHomeChannel123"
+	userWallet := "0x1234567890123456789012345678901234567890"
+	asset := "usdc"
+
+	channel := &core.Channel{
+		ChannelID:    channelID,
+		UserWallet:   userWallet,
+		Asset:        asset,
+		Type:         core.ChannelTypeHome,
+		Status:       core.ChannelStatusChallenged,
+		StateVersion: 3,
+	}
+
+	event := &core.HomeChannelCheckpointedEvent{
+		ChannelID:    channelID,
+		StateVersion: 5,
+	}
+
+	var locked bool
+	mockStore.On("GetChannelByID", channelID).Return(channel, nil)
+	mockStore.On("LockUserState", userWallet, asset).
+		Run(func(mock.Arguments) { locked = true }).
+		Return(decimal.Zero, nil)
+	mockStore.On("UpdateChannel", mock.MatchedBy(func(core.Channel) bool {
+		require.True(t, locked, "LockUserState must be called before UpdateChannel")
+		return true
+	})).Return(nil)
+	mockStore.On("RefreshUserEnforcedBalance", userWallet, asset).Return(nil)
+	mockStore.On("UpdateStateSigsIfMissing", channelID, uint64(5), "", "").Return(nil)
+	mockStore.On("GetLastStateByChannelID", channelID, false).Return(nil, nil)
+
+	err := service.HandleHomeChannelCheckpointed(ctx, mockStore, event)
+	require.NoError(t, err)
+	mockStore.AssertExpectations(t)
+}
+
+// TestHandleHomeChannelClosed_ChallengeRescue_Squash exercises the path where a channel
+// is closed onchain while still Challenged: any unsigned receiver-state credits accrued
+// during the challenge window are squashed into a single ChallengeRescue state on the
+// user's ledger.
+func TestHandleHomeChannelClosed_ChallengeRescue_Squash(t *testing.T) {
+	mockStore := new(MockStore)
+	ctx := log.SetContextLogger(context.Background(), log.NewNoopLogger())
+
+	service, _ := newTestEventHandlerService(t)
+
+	channelID := "0xHomeChannel123"
+	userWallet := "0x1234567890123456789012345678901234567890"
+	asset := "USDC"
+	tokenAddress := "0xtoken"
+	blockchainID := uint64(1)
+	closureVersion := uint64(7)
+	rescueAmount := decimal.NewFromInt(150)
+	homeChannelIDPtr := channelID
+
+	channel := &core.Channel{
+		ChannelID:    channelID,
+		UserWallet:   userWallet,
+		Asset:        asset,
+		Type:         core.ChannelTypeHome,
+		Status:       core.ChannelStatusChallenged,
+		StateVersion: 5,
+	}
+
+	// Latest stored state for the channel — represents the highest-version unsigned
+	// receiver state recorded during the challenge window.
+	prevState := &core.State{
+		ID:            core.GetStateID(userWallet, asset, 1, 9),
+		Asset:         asset,
+		UserWallet:    userWallet,
+		Epoch:         1,
+		Version:       9,
+		HomeChannelID: &homeChannelIDPtr,
+		HomeLedger: core.Ledger{
+			TokenAddress: tokenAddress,
+			BlockchainID: blockchainID,
+			UserBalance:  decimal.NewFromInt(50),
+			UserNetFlow:  decimal.NewFromInt(50),
+			NodeBalance:  decimal.Zero,
+			NodeNetFlow:  decimal.Zero,
+		},
+	}
+
+	event := &core.HomeChannelClosedEvent{
+		ChannelID:    channelID,
+		StateVersion: closureVersion,
+	}
+
+	mockStore.On("GetChannelByID", channelID).Return(channel, nil)
+	mockStore.On("LockUserState", userWallet, asset).Return(decimal.Zero, nil)
+	mockStore.On("UpdateChannel", mock.MatchedBy(func(ch core.Channel) bool {
+		return ch.Status == core.ChannelStatusClosed && ch.StateVersion == closureVersion
+	})).Return(nil)
+	mockStore.On("RefreshUserEnforcedBalance", userWallet, asset).Return(nil)
+	mockStore.On("UpdateStateSigsIfMissing", channelID, closureVersion, "", "").Return(nil)
+	mockStore.On("GetLastStateByChannelID", channelID, false).Return(prevState, nil)
+	mockStore.On("SumNetTransitionAmountAfterVersion", channelID, closureVersion, prevState.Epoch).Return(rescueAmount, nil)
+
+	var capturedState core.State
+	mockStore.On("StoreUserState", mock.MatchedBy(func(state core.State) bool {
+		capturedState = state
+		return true
+	}), "").Return(nil)
+	var capturedTx core.Transaction
+	mockStore.On("RecordTransaction", mock.MatchedBy(func(tx core.Transaction) bool {
+		capturedTx = tx
+		return true
+	}), "").Return(nil)
+
+	err := service.HandleHomeChannelClosed(ctx, mockStore, event)
+	require.NoError(t, err)
+
+	require.Equal(t, core.TransitionTypeChallengeRescue, capturedState.Transition.Type)
+	require.Equal(t, channelID, capturedState.Transition.AccountID)
+	require.True(t, rescueAmount.Equal(capturedState.Transition.Amount))
+	require.Nil(t, capturedState.HomeChannelID, "rescue state must be off-channel")
+	require.Equal(t, prevState.Epoch+1, capturedState.Epoch)
+	require.Equal(t, uint64(1), capturedState.Version)
+	require.Nil(t, capturedState.NodeSig, "rescue state is stored unsigned, like a credit to a user with no open home channel")
+	require.True(t, rescueAmount.Equal(capturedState.HomeLedger.UserBalance))
+	require.Empty(t, capturedState.HomeLedger.TokenAddress)
+	require.Equal(t, uint64(0), capturedState.HomeLedger.BlockchainID)
+
+	require.Equal(t, core.TransactionTypeChallengeRescue, capturedTx.TxType)
+	require.Equal(t, channelID, capturedTx.FromAccount)
+	require.Equal(t, userWallet, capturedTx.ToAccount)
+	require.True(t, rescueAmount.Equal(capturedTx.Amount))
+
+	// TxID is derived deterministically from (fromAccount, newStateID).
+	expectedTxID, err := core.GetReceiverTransactionID(channelID, capturedState.ID)
+	require.NoError(t, err)
+	require.Equal(t, expectedTxID, capturedTx.ID)
+
+	mockStore.AssertExpectations(t)
+}
+
+// TestHandleHomeChannelClosed_ChallengeRescue_NoCredits covers the path where a channel
+// is closed while Challenged but no unsigned receiver credits accrued. A zero-amount
+// rescue state is still emitted so the user's latest stored state moves to a fresh
+// epoch with HomeChannelID nil; without it, future receiver-state issuance and
+// channels.v1.request_creation would stay wedged on the closed channel.
+func TestHandleHomeChannelClosed_ChallengeRescue_NoCredits(t *testing.T) {
+	mockStore := new(MockStore)
+	ctx := log.SetContextLogger(context.Background(), log.NewNoopLogger())
+
+	service, _ := newTestEventHandlerService(t)
+
+	channelID := "0xHomeChannel123"
+	userWallet := "0x1234567890123456789012345678901234567890"
+	asset := "USDC"
+	tokenAddress := "0xtoken"
+	blockchainID := uint64(1)
+	closureVersion := uint64(7)
+	homeChannelIDPtr := channelID
+
+	channel := &core.Channel{
+		ChannelID:    channelID,
+		UserWallet:   userWallet,
+		Asset:        asset,
+		Type:         core.ChannelTypeHome,
+		Status:       core.ChannelStatusChallenged,
+		StateVersion: 5,
+	}
+
+	prevState := &core.State{
+		ID:            core.GetStateID(userWallet, asset, 1, closureVersion),
+		Asset:         asset,
+		UserWallet:    userWallet,
+		Epoch:         1,
+		Version:       closureVersion,
+		HomeChannelID: &homeChannelIDPtr,
+		HomeLedger: core.Ledger{
+			TokenAddress: tokenAddress,
+			BlockchainID: blockchainID,
+			UserBalance:  decimal.NewFromInt(50),
+			UserNetFlow:  decimal.NewFromInt(50),
+		},
+	}
+
+	event := &core.HomeChannelClosedEvent{
+		ChannelID:    channelID,
+		StateVersion: closureVersion,
+	}
+
+	mockStore.On("GetChannelByID", channelID).Return(channel, nil)
+	mockStore.On("LockUserState", userWallet, asset).Return(decimal.Zero, nil)
+	mockStore.On("UpdateChannel", mock.Anything).Return(nil)
+	mockStore.On("RefreshUserEnforcedBalance", userWallet, asset).Return(nil)
+	mockStore.On("UpdateStateSigsIfMissing", channelID, closureVersion, "", "").Return(nil)
+	mockStore.On("GetLastStateByChannelID", channelID, false).Return(prevState, nil)
+	mockStore.On("SumNetTransitionAmountAfterVersion", channelID, closureVersion, prevState.Epoch).Return(decimal.Zero, nil)
+
+	var capturedState core.State
+	mockStore.On("StoreUserState", mock.MatchedBy(func(state core.State) bool {
+		capturedState = state
+		return true
+	}), "").Return(nil)
+	mockStore.On("RecordTransaction", mock.Anything, "").Return(nil)
+
+	err := service.HandleHomeChannelClosed(ctx, mockStore, event)
+	require.NoError(t, err)
+
+	require.Equal(t, core.TransitionTypeChallengeRescue, capturedState.Transition.Type)
+	require.True(t, capturedState.Transition.Amount.IsZero())
+	require.True(t, capturedState.HomeLedger.UserBalance.IsZero())
+	require.Nil(t, capturedState.HomeChannelID)
+	require.Equal(t, prevState.Epoch+1, capturedState.Epoch)
+	require.Equal(t, uint64(1), capturedState.Version)
+
+	mockStore.AssertExpectations(t)
+}
+
+// TestHandleHomeChannelClosed_ChallengeRescue_NegativeNet_ClampsToZero pins the
+// adversarial-rollback case: the user closes at a version where her own channel
+// balance was higher than the off-chain head, so the net transition amount above
+// closure is negative. The rescue must clamp the credit at zero — onchain has
+// already paid above the head value, and docking the user further is not the
+// rescue's job. A zero-amount rescue is still issued so the user state head
+// advances to a fresh epoch with HomeChannelID nil.
+func TestHandleHomeChannelClosed_ChallengeRescue_NegativeNet_ClampsToZero(t *testing.T) {
+	mockStore := new(MockStore)
+	ctx := log.SetContextLogger(context.Background(), log.NewNoopLogger())
+
+	service, _ := newTestEventHandlerService(t)
+
+	channelID := "0xHomeChannel123"
+	userWallet := "0x1234567890123456789012345678901234567890"
+	asset := "USDC"
+	tokenAddress := "0xtoken"
+	blockchainID := uint64(1)
+	closureVersion := uint64(2)
+	homeChannelIDPtr := channelID
+
+	channel := &core.Channel{
+		ChannelID:    channelID,
+		UserWallet:   userWallet,
+		Asset:        asset,
+		Type:         core.ChannelTypeHome,
+		Status:       core.ChannelStatusChallenged,
+		StateVersion: 1,
+	}
+
+	prevState := &core.State{
+		ID:            core.GetStateID(userWallet, asset, 1, 5),
+		Asset:         asset,
+		UserWallet:    userWallet,
+		Epoch:         1,
+		Version:       5,
+		HomeChannelID: &homeChannelIDPtr,
+		HomeLedger: core.Ledger{
+			TokenAddress: tokenAddress,
+			BlockchainID: blockchainID,
+			UserBalance:  decimal.NewFromInt(51),
+			UserNetFlow:  decimal.NewFromInt(51),
+		},
+	}
+
+	event := &core.HomeChannelClosedEvent{
+		ChannelID:    channelID,
+		StateVersion: closureVersion,
+	}
+
+	mockStore.On("GetChannelByID", channelID).Return(channel, nil)
+	mockStore.On("LockUserState", userWallet, asset).Return(decimal.Zero, nil)
+	mockStore.On("UpdateChannel", mock.Anything).Return(nil)
+	mockStore.On("RefreshUserEnforcedBalance", userWallet, asset).Return(nil)
+	mockStore.On("UpdateStateSigsIfMissing", channelID, closureVersion, "", "").Return(nil)
+	mockStore.On("GetLastStateByChannelID", channelID, false).Return(prevState, nil)
+	mockStore.On("SumNetTransitionAmountAfterVersion", channelID, closureVersion, prevState.Epoch).Return(decimal.NewFromInt(-49), nil)
+
+	var capturedState core.State
+	mockStore.On("StoreUserState", mock.MatchedBy(func(state core.State) bool {
+		capturedState = state
+		return true
+	}), "").Return(nil)
+	mockStore.On("RecordTransaction", mock.Anything, "").Return(nil)
+
+	err := service.HandleHomeChannelClosed(ctx, mockStore, event)
+	require.NoError(t, err)
+
+	require.Equal(t, core.TransitionTypeChallengeRescue, capturedState.Transition.Type)
+	require.True(t, capturedState.Transition.Amount.IsZero(), "negative net must clamp to zero, got %s", capturedState.Transition.Amount.String())
+	require.True(t, capturedState.HomeLedger.UserBalance.IsZero())
+	require.Nil(t, capturedState.HomeChannelID)
+	require.Equal(t, prevState.Epoch+1, capturedState.Epoch)
+	require.Equal(t, uint64(1), capturedState.Version)
+
+	mockStore.AssertExpectations(t)
+}
+
+// TestHandleHomeChannelClosed_OpenChannel_NoRescue pins behavior for the normal
+// Open → Closed path: the channel was never Challenged before the close event, so the
+// rescue branch is short-circuited entirely. The unsigned-receiver-sum query, rescue
+// state store, and rescue transaction record are never issued.
+func TestHandleHomeChannelClosed_OpenChannel_NoRescue(t *testing.T) {
+	mockStore := new(MockStore)
+	ctx := log.SetContextLogger(context.Background(), log.NewNoopLogger())
+
+	service, _ := newTestEventHandlerService(t)
+
+	channelID := "0xHomeChannel123"
+	userWallet := "0x1234567890123456789012345678901234567890"
+	closureVersion := uint64(7)
+
+	channel := &core.Channel{
+		ChannelID:    channelID,
+		UserWallet:   userWallet,
+		Asset:        "USDC",
+		Type:         core.ChannelTypeHome,
+		Status:       core.ChannelStatusOpen,
+		StateVersion: 5,
+	}
+
+	event := &core.HomeChannelClosedEvent{
+		ChannelID:    channelID,
+		StateVersion: closureVersion,
+	}
+
+	mockStore.On("GetChannelByID", channelID).Return(channel, nil)
+	mockStore.On("LockUserState", userWallet, "USDC").Return(decimal.Zero, nil)
+	mockStore.On("UpdateChannel", mock.Anything).Return(nil)
+	mockStore.On("RefreshUserEnforcedBalance", userWallet, "USDC").Return(nil)
+	mockStore.On("UpdateStateSigsIfMissing", channelID, closureVersion, "", "").Return(nil)
+
+	err := service.HandleHomeChannelClosed(ctx, mockStore, event)
+	require.NoError(t, err)
+
+	mockStore.AssertExpectations(t)
+	mockStore.AssertNotCalled(t, "SumNetTransitionAmountAfterVersion", mock.Anything, mock.Anything, mock.Anything)
+	mockStore.AssertNotCalled(t, "StoreUserState", mock.Anything, mock.Anything)
+	mockStore.AssertNotCalled(t, "RecordTransaction", mock.Anything, mock.Anything)
 }
 
 func TestHandleUserLockedBalanceUpdated_StoreError(t *testing.T) {

--- a/nitronode/event_handlers/testing.go
+++ b/nitronode/event_handlers/testing.go
@@ -93,8 +93,34 @@ func (m *MockStore) UpdateUserStaked(wallet string, blockchainID uint64, amount 
 	return args.Error(0)
 }
 
-// UpdateStateUserSigIfMissing mocks backfilling a user signature for a stored state.
-func (m *MockStore) UpdateStateUserSigIfMissing(channelID string, version uint64, userSig string) error {
-	args := m.Called(channelID, version, userSig)
+// UpdateStateSigsIfMissing mocks backfilling missing user and/or node signatures
+// for a stored state.
+func (m *MockStore) UpdateStateSigsIfMissing(channelID string, version uint64, userSig, nodeSig string) error {
+	args := m.Called(channelID, version, userSig, nodeSig)
+	return args.Error(0)
+}
+
+// SumNetTransitionAmountAfterVersion mocks the net-change query used to compute
+// challenge-rescue amounts on a closed channel.
+func (m *MockStore) SumNetTransitionAmountAfterVersion(channelID string, minVersion, epoch uint64) (decimal.Decimal, error) {
+	args := m.Called(channelID, minVersion, epoch)
+	return args.Get(0).(decimal.Decimal), args.Error(1)
+}
+
+// LockUserState mocks acquiring SELECT ... FOR UPDATE on a user's balance row.
+func (m *MockStore) LockUserState(wallet, asset string) (decimal.Decimal, error) {
+	args := m.Called(wallet, asset)
+	return args.Get(0).(decimal.Decimal), args.Error(1)
+}
+
+// StoreUserState mocks persisting a user state row.
+func (m *MockStore) StoreUserState(state core.State, applicationID string) error {
+	args := m.Called(state, applicationID)
+	return args.Error(0)
+}
+
+// RecordTransaction mocks recording a transaction row.
+func (m *MockStore) RecordTransaction(tx core.Transaction, applicationID string) error {
+	args := m.Called(tx, applicationID)
 	return args.Error(0)
 }

--- a/nitronode/event_handlers/testing.go
+++ b/nitronode/event_handlers/testing.go
@@ -113,6 +113,13 @@ func (m *MockStore) LockUserState(wallet, asset string) (decimal.Decimal, error)
 	return args.Get(0).(decimal.Decimal), args.Error(1)
 }
 
+// HasSignedFinalize mocks the existence check for a node-signed Finalize state on the given home channel.
+func (m *MockStore) HasSignedFinalize(channelID string) (bool, error) {
+	args := m.Called(channelID)
+	return args.Bool(0), args.Error(1)
+}
+
+
 // StoreUserState mocks persisting a user state row.
 func (m *MockStore) StoreUserState(state core.State, applicationID string) error {
 	args := m.Called(state, applicationID)

--- a/nitronode/main.go
+++ b/nitronode/main.go
@@ -77,12 +77,13 @@ func main() {
 		return bb.DbStore.ExecuteInTransaction(handler)
 	}
 
-	eventHandlerService := event_handlers.NewEventHandlerService()
-
 	nodeChannelSigner, err := core.NewChannelDefaultSigner(bb.StateSigner)
 	if err != nil {
 		logger.Fatal("failed to build node channel signer", "error", err)
 	}
+
+	eventHandlerStatePacker := core.NewStatePackerV1(bb.MemoryStore)
+	eventHandlerService := event_handlers.NewEventHandlerService(nodeChannelSigner, eventHandlerStatePacker)
 
 	for _, b := range blockchains {
 		rpcURL, ok := bb.BlockchainRPCs[b.ID]

--- a/nitronode/store/database/channel_test.go
+++ b/nitronode/store/database/channel_test.go
@@ -441,6 +441,7 @@ func TestDBStore_GetNotClosedHomeChannel(t *testing.T) {
 	})
 }
 
+
 func TestDBStore_CheckActiveChannel(t *testing.T) {
 	t.Run("Success - Has open channel", func(t *testing.T) {
 		db, cleanup := SetupTestDB(t)

--- a/nitronode/store/database/db_store.go
+++ b/nitronode/store/database/db_store.go
@@ -251,8 +251,16 @@ func (s *DBStore) EnsureNoOngoingStateTransitions(wallet, asset string) error {
 //
 // Validation logic by latest signed transition type:
 //   - escrow_lock / mutual_lock: always considered ongoing (no finalization yet)
-//   - escrow_deposit / escrow_withdraw: only considered ongoing when the on-chain
-//     escrow channel state version has not caught up with the signed state version
+//   - escrow_deposit: considered settled when the on-chain escrow channel version
+//     equals the signed state version (finalize landed). When the chain is exactly
+//     one behind, the signed N+1 finalize state lives off-chain and is gated on
+//     the escrow channel status: allowed for Open (protocol-intended steady state
+//     before the purge queue fires) and Closed (post-purge or post-finalize);
+//     blocked for Challenged (on-chain resolution still racing — finalize tx may
+//     not land, escrow chain may settle at INITIATE, and replaying N+1 later
+//     could violate engine invariants).
+//   - escrow_withdraw: considered ongoing while the on-chain escrow channel state
+//     version has not caught up with the signed state version
 //   - any other transition: not an escrow operation, allow
 func (s *DBStore) EnsureNoOngoingEscrowOperation(wallet, asset string) error {
 	wallet = strings.ToLower(wallet)
@@ -261,6 +269,7 @@ func (s *DBStore) EnsureNoOngoingEscrowOperation(wallet, asset string) error {
 		TransitionType       core.TransitionType
 		StateVersion         uint64
 		EscrowChannelVersion *uint64
+		EscrowChannelStatus  *core.ChannelStatus
 	}
 
 	var result escrowCheck
@@ -268,7 +277,8 @@ func (s *DBStore) EnsureNoOngoingEscrowOperation(wallet, asset string) error {
 		SELECT
 			s.transition_type as transition_type,
 			s.version as state_version,
-			ec.state_version as escrow_channel_version
+			ec.state_version as escrow_channel_version,
+			ec.status as escrow_channel_status
 		FROM channel_states s
 		LEFT JOIN channels ec ON ec.channel_id = s.escrow_channel_id
 		WHERE s.user_wallet = ?
@@ -294,7 +304,34 @@ func (s *DBStore) EnsureNoOngoingEscrowOperation(wallet, asset string) error {
 		return fmt.Errorf("mutual lock is still ongoing")
 
 	case core.TransitionTypeEscrowDeposit:
-		if result.EscrowChannelVersion == nil || result.StateVersion != *result.EscrowChannelVersion {
+		// Accept escrow channel at signed state version (finalize landed) or one
+		// behind (signed N+1 finalize sits off-chain; on-chain still at INITIATE
+		// version N). The one-behind branch is status-gated: Open is the protocol-
+		// intended steady state until the purge queue fires, Closed covers post-
+		// purge and post-finalize. Challenged is blocked because the on-chain
+		// resolution is still racing — finalize may not land in time, the escrow
+		// chain may settle at INITIATE, and replaying N+1 later could violate
+		// engine invariants.
+		// Compare via *v + 1 == StateVersion to avoid uint underflow when version is 0.
+		if result.EscrowChannelVersion == nil {
+			return fmt.Errorf("escrow deposit finalization is still ongoing")
+		}
+		onChain := *result.EscrowChannelVersion
+		signed := result.StateVersion
+		switch {
+		case onChain == signed:
+			// finalize already landed or signed state is older — allow
+		case onChain+1 == signed:
+			if result.EscrowChannelStatus == nil {
+				return fmt.Errorf("escrow deposit finalization is still ongoing")
+			}
+			switch *result.EscrowChannelStatus {
+			case core.ChannelStatusOpen, core.ChannelStatusClosed:
+				// allow
+			default:
+				return fmt.Errorf("escrow deposit finalization is still ongoing")
+			}
+		default:
 			return fmt.Errorf("escrow deposit finalization is still ongoing")
 		}
 

--- a/nitronode/store/database/db_store.go
+++ b/nitronode/store/database/db_store.go
@@ -229,7 +229,14 @@ func (s *DBStore) EnsureNoOngoingStateTransitions(wallet, asset string) error {
 		}
 
 	case core.TransitionTypeMigrate:
-		// Verify last_state.version == home_channel.state_version
+		// NOTE: Migration flows are not yet active off-chain. This case is currently unreachable
+		// because submit_state.go rejects TransitionTypeMigrate before EnsureNoOngoingStateTransitions
+		// is called. When migration is implemented, this check must be extended: verifying that
+		// last_state.version == home_channel.state_version confirms only that the preparation state
+		// was enforced on the OLD home chain. A complete gate must also confirm that
+		// initiateMigration() was submitted on the NEW home chain (i.e. a MIGRATING_IN channel
+		// exists with a matching state version), matching the MigrationInInitiated lifecycle step
+		// documented in protocol-description.md.
 		if result.HomeChannelVersion == nil || result.StateVersion != *result.HomeChannelVersion {
 			return fmt.Errorf("home chain migration is still ongoing")
 		}

--- a/nitronode/store/database/db_store_test.go
+++ b/nitronode/store/database/db_store_test.go
@@ -1477,7 +1477,10 @@ func TestDBStore_EnsureNoOngoingEscrowOperation(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("EscrowDeposit - chain not synced - block", func(t *testing.T) {
+	t.Run("EscrowDeposit - Open one-behind (pre-purge happy path) - allow", func(t *testing.T) {
+		// Signed finalize state is N+1; on-chain escrow channel is at initiate
+		// version N with Status=Open. This is the protocol-intended steady state
+		// until the purge queue fires, so receiver-side issuance must not block.
 		db, cleanup := SetupTestDB(t)
 		defer cleanup()
 
@@ -1488,8 +1491,60 @@ func TestDBStore_EnsureNoOngoingEscrowOperation(t *testing.T) {
 		storeState(t, store, newSignedState(2, core.TransitionTypeEscrowDeposit, true))
 
 		err := store.EnsureNoOngoingEscrowOperation(wallet, asset)
+		require.NoError(t, err)
+	})
+
+	t.Run("EscrowDeposit - Challenged one-behind - block", func(t *testing.T) {
+		// Signed finalize state is N+1; on-chain channel is Challenged at N.
+		// Resolution is racing (finalize tx may not land, escrow chain may settle
+		// at INITIATE) — block receiver-side issuance until status clears.
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+
+		store := NewDBStore(db)
+		require.NoError(t, store.CreateChannel(homeChannel))
+		challengedEscrow := newEscrowChannel(1)
+		challengedEscrow.Status = core.ChannelStatusChallenged
+		require.NoError(t, store.CreateChannel(challengedEscrow))
+
+		storeState(t, store, newSignedState(2, core.TransitionTypeEscrowDeposit, true))
+
+		err := store.EnsureNoOngoingEscrowOperation(wallet, asset)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "escrow deposit finalization is still ongoing")
+	})
+
+	t.Run("EscrowDeposit - chain more than one version behind - block", func(t *testing.T) {
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+
+		store := NewDBStore(db)
+		require.NoError(t, store.CreateChannel(homeChannel))
+		require.NoError(t, store.CreateChannel(newEscrowChannel(0)))
+
+		storeState(t, store, newSignedState(2, core.TransitionTypeEscrowDeposit, true))
+
+		err := store.EnsureNoOngoingEscrowOperation(wallet, asset)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "escrow deposit finalization is still ongoing")
+	})
+
+	t.Run("EscrowDeposit - chain version after purge close - allow", func(t *testing.T) {
+		// Simulates HandleEscrowDepositsPurged: channel marked Closed but
+		// StateVersion preserved at initiate (N) while signed state is finalize (N+1).
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+
+		store := NewDBStore(db)
+		require.NoError(t, store.CreateChannel(homeChannel))
+		purgedEscrow := newEscrowChannel(1)
+		purgedEscrow.Status = core.ChannelStatusClosed
+		require.NoError(t, store.CreateChannel(purgedEscrow))
+
+		storeState(t, store, newSignedState(2, core.TransitionTypeEscrowDeposit, true))
+
+		err := store.EnsureNoOngoingEscrowOperation(wallet, asset)
+		require.NoError(t, err)
 	})
 
 	t.Run("EscrowWithdraw - chain caught up - allow", func(t *testing.T) {

--- a/nitronode/store/database/db_store_test.go
+++ b/nitronode/store/database/db_store_test.go
@@ -811,7 +811,7 @@ func TestDBStore_EnsureNoOngoingStateTransitions(t *testing.T) {
 	})
 }
 
-func TestDBStore_UpdateStateUserSigIfMissing(t *testing.T) {
+func TestDBStore_UpdateStateSigsIfMissing(t *testing.T) {
 	t.Run("Backfills user_sig when null and unblocks gate", func(t *testing.T) {
 		// This is the wedge-recovery path: a node-only state was checkpointed on chain
 		// (e.g. recipient submitted a transfer_receive state directly). After the event
@@ -894,7 +894,7 @@ func TestDBStore_UpdateStateUserSigIfMissing(t *testing.T) {
 
 		// Backfill the user signature recovered from the on-chain event.
 		recoveredSig := "0xrecovered"
-		require.NoError(t, store.UpdateStateUserSigIfMissing(homeChannelID, 2, recoveredSig))
+		require.NoError(t, store.UpdateStateSigsIfMissing(homeChannelID, 2, recoveredSig, ""))
 
 		got, err := store.GetStateByID("state2")
 		require.NoError(t, err)
@@ -956,7 +956,7 @@ func TestDBStore_UpdateStateUserSigIfMissing(t *testing.T) {
 		require.NoError(t, store.StoreUserState(state, ""))
 
 		// Replayed event would carry a different (or any) sig; existing one must not be overwritten.
-		require.NoError(t, store.UpdateStateUserSigIfMissing(homeChannelID, 1, "0xshould-not-overwrite"))
+		require.NoError(t, store.UpdateStateSigsIfMissing(homeChannelID, 1, "0xshould-not-overwrite", "0xshould-not-overwrite-node"))
 
 		got, err := store.GetStateByID("state1")
 		require.NoError(t, err)
@@ -972,7 +972,7 @@ func TestDBStore_UpdateStateUserSigIfMissing(t *testing.T) {
 		store := NewDBStore(db)
 
 		homeChannelID := "0xhomechannel123"
-		require.NoError(t, store.UpdateStateUserSigIfMissing(homeChannelID, 1, ""))
+		require.NoError(t, store.UpdateStateSigsIfMissing(homeChannelID, 1, "", ""))
 	})
 
 	t.Run("Unknown version returns no error", func(t *testing.T) {
@@ -982,7 +982,265 @@ func TestDBStore_UpdateStateUserSigIfMissing(t *testing.T) {
 		store := NewDBStore(db)
 
 		homeChannelID := "0xhomechannel123"
-		require.NoError(t, store.UpdateStateUserSigIfMissing(homeChannelID, 99, "0xanything"))
+		require.NoError(t, store.UpdateStateSigsIfMissing(homeChannelID, 99, "0xanything", "0xanything-node"))
+	})
+
+	t.Run("Backfills node_sig when user_sig already present", func(t *testing.T) {
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+
+		store := NewDBStore(db)
+
+		homeChannelID := "0xhomechannel123"
+		require.NoError(t, store.CreateChannel(core.Channel{
+			ChannelID:         homeChannelID,
+			UserWallet:        "0xuser123",
+			Asset:             "usdc",
+			Type:              core.ChannelTypeHome,
+			BlockchainID:      1,
+			TokenAddress:      "0xtoken",
+			ChallengeDuration: 86400,
+			Nonce:             1,
+			Status:            core.ChannelStatusOpen,
+			StateVersion:      1,
+		}))
+
+		userSig := "0xusersigonly"
+		state := core.State{
+			ID:            "state-user-only",
+			Asset:         "USDC",
+			UserWallet:    "0xuser123",
+			Epoch:         1,
+			Version:       1,
+			HomeChannelID: &homeChannelID,
+			Transition:    core.Transition{Type: core.TransitionTypeHomeDeposit},
+			HomeLedger: core.Ledger{
+				UserBalance: decimal.NewFromInt(100),
+				UserNetFlow: decimal.Zero,
+				NodeBalance: decimal.Zero,
+				NodeNetFlow: decimal.Zero,
+			},
+			UserSig: &userSig,
+		}
+		require.NoError(t, store.StoreUserState(state, ""))
+
+		require.NoError(t, store.UpdateStateSigsIfMissing(homeChannelID, 1, "0xshould-not-overwrite-user", "0xrecoverednode"))
+
+		got, err := store.GetStateByID("state-user-only")
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		require.NotNil(t, got.UserSig)
+		assert.Equal(t, userSig, *got.UserSig, "existing user_sig must be preserved")
+		require.NotNil(t, got.NodeSig)
+		assert.Equal(t, "0xrecoverednode", *got.NodeSig)
+	})
+}
+
+func TestDBStore_SumNetTransitionAmountAfterVersion(t *testing.T) {
+	const wallet = "0xuser123"
+	const asset = "USDC"
+	const homeChannelID = "0xhomechannel123"
+
+	setupChannel := func(t *testing.T, store DatabaseStore) {
+		t.Helper()
+		require.NoError(t, store.CreateChannel(core.Channel{
+			ChannelID:         homeChannelID,
+			UserWallet:        wallet,
+			Asset:             "usdc",
+			Type:              core.ChannelTypeHome,
+			BlockchainID:      1,
+			TokenAddress:      "0xtoken",
+			ChallengeDuration: 86400,
+			Nonce:             1,
+			Status:            core.ChannelStatusChallenged,
+			StateVersion:      5,
+		}))
+	}
+
+	storeState := func(t *testing.T, store DatabaseStore, epoch, version uint64, transitionType core.TransitionType, amount decimal.Decimal, hasNodeSig bool) {
+		t.Helper()
+		channelIDLocal := homeChannelID
+		s := core.State{
+			ID:            core.GetStateID(wallet, asset, epoch, version),
+			Asset:         asset,
+			UserWallet:    wallet,
+			Epoch:         epoch,
+			Version:       version,
+			HomeChannelID: &channelIDLocal,
+			Transition: core.Transition{
+				Type:      transitionType,
+				TxID:      "0xtx",
+				AccountID: "0xacct",
+				Amount:    amount,
+			},
+			HomeLedger: core.Ledger{
+				UserBalance: amount,
+				UserNetFlow: decimal.Zero,
+				NodeBalance: decimal.Zero,
+				NodeNetFlow: decimal.Zero,
+			},
+		}
+		userSig := "0xusersig"
+		s.UserSig = &userSig
+		if hasNodeSig {
+			nodeSig := "0xnodesig"
+			s.NodeSig = &nodeSig
+		}
+		require.NoError(t, store.StoreUserState(s, ""))
+	}
+
+	t.Run("Scenario 3 - dust during challenge (unsigned receive only)", func(t *testing.T) {
+		// Pure MF2-H01 path: attacker sends dust during challenge window, the row is
+		// stored unsigned per the suppression rule. Sum should equal the dust amount.
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+		store := NewDBStore(db)
+		setupChannel(t, store)
+
+		storeState(t, store, 1, 2, core.TransitionTypeTransferReceive, decimal.NewFromFloat(0.001), false)
+
+		net, err := store.SumNetTransitionAmountAfterVersion(homeChannelID, 1, 1)
+		require.NoError(t, err)
+		assert.True(t, decimal.NewFromFloat(0.001).Equal(net), "want 0.001, got %s", net.String())
+	})
+
+	t.Run("Scenario 2 - signed pre-challenge receives stranded by stale-state close", func(t *testing.T) {
+		// User went TS, TR, TS, TR while channel was Open (all rows node-signed), then
+		// challenged with the early TS state. Onchain payout reflects the early state;
+		// the offchain net change above closure (the two TR minus the second TS) is what
+		// the rescue must credit.
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+		store := NewDBStore(db)
+		setupChannel(t, store)
+
+		// closureVersion = 2; v3 TR +1, v4 TS -1, v5 TR +1.
+		storeState(t, store, 1, 3, core.TransitionTypeTransferReceive, decimal.NewFromInt(1), true)
+		storeState(t, store, 1, 4, core.TransitionTypeTransferSend, decimal.NewFromInt(1), true)
+		storeState(t, store, 1, 5, core.TransitionTypeTransferReceive, decimal.NewFromInt(1), true)
+
+		net, err := store.SumNetTransitionAmountAfterVersion(homeChannelID, 2, 1)
+		require.NoError(t, err)
+		assert.True(t, decimal.NewFromInt(1).Equal(net), "want 1, got %s", net.String())
+	})
+
+	t.Run("Scenario 1 - HomeDeposit poison is excluded, real receive counted", func(t *testing.T) {
+		// Attacker tricks user into signing a fake HomeDeposit that has no onchain
+		// backing; user challenges with an earlier clean state. The poison row must not
+		// contribute to the rescue (otherwise the node pays out a phantom credit). The
+		// legitimate TR that landed above closure still does.
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+		store := NewDBStore(db)
+		setupChannel(t, store)
+
+		// closureVersion = 2; v3 poisoned HomeDeposit +300000, v4 real TR +1.
+		storeState(t, store, 1, 3, core.TransitionTypeHomeDeposit, decimal.NewFromInt(300000), true)
+		storeState(t, store, 1, 4, core.TransitionTypeTransferReceive, decimal.NewFromInt(1), true)
+
+		net, err := store.SumNetTransitionAmountAfterVersion(homeChannelID, 2, 1)
+		require.NoError(t, err)
+		assert.True(t, decimal.NewFromInt(1).Equal(net), "want 1, got %s", net.String())
+	})
+
+	t.Run("Adversarial rollback produces negative net (caller clamps)", func(t *testing.T) {
+		// User picks a closure version where her own offchain balance was higher than
+		// the head — she's rolling back a big send to retain the funds onchain. Sum
+		// reports the true negative net; clamp is the caller's job.
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+		store := NewDBStore(db)
+		setupChannel(t, store)
+
+		// closureVersion = 1; v2 TR +1, v3 TS -50.
+		storeState(t, store, 1, 2, core.TransitionTypeTransferReceive, decimal.NewFromInt(1), true)
+		storeState(t, store, 1, 3, core.TransitionTypeTransferSend, decimal.NewFromInt(50), true)
+
+		net, err := store.SumNetTransitionAmountAfterVersion(homeChannelID, 1, 1)
+		require.NoError(t, err)
+		assert.True(t, decimal.NewFromInt(-49).Equal(net), "want -49, got %s", net.String())
+	})
+
+	t.Run("Commit transitions deduct from net like sends", func(t *testing.T) {
+		// User committed funds to an app session above closure: the commit moves value
+		// from the home ledger to the session. If the session also released some of it
+		// back, release contributes positively. Both must net out.
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+		store := NewDBStore(db)
+		setupChannel(t, store)
+
+		storeState(t, store, 1, 3, core.TransitionTypeTransferReceive, decimal.NewFromInt(5), true)
+		storeState(t, store, 1, 4, core.TransitionTypeCommit, decimal.NewFromInt(3), true)
+		storeState(t, store, 1, 5, core.TransitionTypeRelease, decimal.NewFromInt(1), false)
+
+		net, err := store.SumNetTransitionAmountAfterVersion(homeChannelID, 2, 1)
+		require.NoError(t, err)
+		assert.True(t, decimal.NewFromInt(3).Equal(net), "want 3, got %s", net.String())
+	})
+
+	t.Run("Excluded transition kinds contribute zero", func(t *testing.T) {
+		// HomeDeposit / HomeWithdrawal / EscrowDeposit / EscrowWithdraw / Migrate /
+		// Finalize / Acknowledgement either need onchain backing the chain didn't enforce
+		// or belong to a different ledger; none should affect the rescue sum.
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+		store := NewDBStore(db)
+		setupChannel(t, store)
+
+		storeState(t, store, 1, 3, core.TransitionTypeHomeDeposit, decimal.NewFromInt(100), true)
+		storeState(t, store, 1, 4, core.TransitionTypeHomeWithdrawal, decimal.NewFromInt(50), true)
+		storeState(t, store, 1, 5, core.TransitionTypeEscrowDeposit, decimal.NewFromInt(10), true)
+		storeState(t, store, 1, 6, core.TransitionTypeEscrowWithdraw, decimal.NewFromInt(20), true)
+		storeState(t, store, 1, 7, core.TransitionTypeMigrate, decimal.NewFromInt(5), true)
+		storeState(t, store, 1, 8, core.TransitionTypeFinalize, decimal.NewFromInt(0), true)
+
+		net, err := store.SumNetTransitionAmountAfterVersion(homeChannelID, 2, 1)
+		require.NoError(t, err)
+		assert.True(t, net.IsZero(), "want 0, got %s", net.String())
+	})
+
+	t.Run("Returns zero when no matches", func(t *testing.T) {
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+		store := NewDBStore(db)
+		setupChannel(t, store)
+
+		net, err := store.SumNetTransitionAmountAfterVersion(homeChannelID, 0, 1)
+		require.NoError(t, err)
+		assert.True(t, net.IsZero())
+	})
+
+	t.Run("Strict > excludes rows at the closure version itself", func(t *testing.T) {
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+		store := NewDBStore(db)
+		setupChannel(t, store)
+
+		// closureVersion = 6; a TR exactly at v6 must not contribute.
+		storeState(t, store, 1, 5, core.TransitionTypeTransferReceive, decimal.NewFromInt(99), true)
+		storeState(t, store, 1, 6, core.TransitionTypeTransferReceive, decimal.NewFromInt(99), true)
+		storeState(t, store, 1, 7, core.TransitionTypeTransferReceive, decimal.NewFromInt(3), false)
+
+		net, err := store.SumNetTransitionAmountAfterVersion(homeChannelID, 6, 1)
+		require.NoError(t, err)
+		assert.True(t, decimal.NewFromInt(3).Equal(net), "want 3, got %s", net.String())
+	})
+
+	t.Run("Excludes rows in other epochs", func(t *testing.T) {
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+		store := NewDBStore(db)
+		setupChannel(t, store)
+
+		// Two rows above cutoff: one in epoch 1, one in epoch 2. Caller asks for epoch 1
+		// only; the epoch-2 row must be excluded even though every other predicate matches.
+		storeState(t, store, 1, 7, core.TransitionTypeTransferReceive, decimal.NewFromInt(30), false)
+		storeState(t, store, 2, 8, core.TransitionTypeTransferReceive, decimal.NewFromInt(999), false)
+
+		net, err := store.SumNetTransitionAmountAfterVersion(homeChannelID, 6, 1)
+		require.NoError(t, err)
+		assert.True(t, decimal.NewFromInt(30).Equal(net), "want 30, got %s", net.String())
 	})
 }
 

--- a/nitronode/store/database/db_store_test.go
+++ b/nitronode/store/database/db_store_test.go
@@ -1244,6 +1244,99 @@ func TestDBStore_SumNetTransitionAmountAfterVersion(t *testing.T) {
 	})
 }
 
+func TestDBStore_HasSignedFinalize(t *testing.T) {
+	const wallet = "0xuser123"
+	const asset = "USDC"
+	const homeChannelID = "0xhomechannel123"
+
+	setupChannel := func(t *testing.T, store DatabaseStore) {
+		t.Helper()
+		require.NoError(t, store.CreateChannel(core.Channel{
+			ChannelID:         homeChannelID,
+			UserWallet:        wallet,
+			Asset:             "usdc",
+			Type:              core.ChannelTypeHome,
+			BlockchainID:      1,
+			TokenAddress:      "0xtoken",
+			ChallengeDuration: 86400,
+			Nonce:             1,
+			Status:            core.ChannelStatusChallenged,
+			StateVersion:      5,
+		}))
+	}
+
+	storeState := func(t *testing.T, store DatabaseStore, version uint64, transitionType core.TransitionType, hasNodeSig bool) {
+		t.Helper()
+		channelIDLocal := homeChannelID
+		s := core.State{
+			ID:            core.GetStateID(wallet, asset, 1, version),
+			Asset:         asset,
+			UserWallet:    wallet,
+			Epoch:         1,
+			Version:       version,
+			HomeChannelID: &channelIDLocal,
+			Transition: core.Transition{
+				Type:      transitionType,
+				TxID:      "0xtx",
+				AccountID: "0xacct",
+				Amount:    decimal.Zero,
+			},
+		}
+		userSig := "0xusersig"
+		s.UserSig = &userSig
+		if hasNodeSig {
+			nodeSig := "0xnodesig"
+			s.NodeSig = &nodeSig
+		}
+		require.NoError(t, store.StoreUserState(s, ""))
+	}
+
+	t.Run("True when node-signed Finalize exists", func(t *testing.T) {
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+		store := NewDBStore(db)
+		setupChannel(t, store)
+
+		storeState(t, store, 6, core.TransitionTypeTransferReceive, true)
+		storeState(t, store, 7, core.TransitionTypeFinalize, true)
+
+		got, err := store.HasSignedFinalize(homeChannelID)
+		require.NoError(t, err)
+		assert.True(t, got)
+	})
+
+	t.Run("False when no Finalize state exists", func(t *testing.T) {
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+		store := NewDBStore(db)
+		setupChannel(t, store)
+
+		storeState(t, store, 6, core.TransitionTypeTransferReceive, true)
+		storeState(t, store, 7, core.TransitionTypeTransferReceive, true)
+
+		got, err := store.HasSignedFinalize(homeChannelID)
+		require.NoError(t, err)
+		assert.False(t, got)
+	})
+
+	t.Run("False when Finalize exists without node sig", func(t *testing.T) {
+		// Pins the documented invariant: a Finalize row whose node_sig is NULL must not
+		// be treated as node-signed, even though SubmitState today never stores one in
+		// that shape. Guards against a regression that drops the node_sig predicate or
+		// a future path that writes Finalize rows ahead of the node signature.
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+		store := NewDBStore(db)
+		setupChannel(t, store)
+
+		storeState(t, store, 7, core.TransitionTypeFinalize, false)
+
+		got, err := store.HasSignedFinalize(homeChannelID)
+		require.NoError(t, err)
+		assert.False(t, got)
+	})
+}
+
 func TestDBStore_EnsureNoOngoingEscrowOperation(t *testing.T) {
 	const wallet = "0xuser123"
 	const asset = "USDC"

--- a/nitronode/store/database/db_store_test.go
+++ b/nitronode/store/database/db_store_test.go
@@ -1005,6 +1005,8 @@ func TestDBStore_UpdateStateSigsIfMissing(t *testing.T) {
 			StateVersion:      1,
 		}))
 
+		_, err := store.LockUserState("0xuser123", "USDC")
+		require.NoError(t, err)
 		userSig := "0xusersigonly"
 		state := core.State{
 			ID:            "state-user-only",
@@ -1086,6 +1088,8 @@ func TestDBStore_SumNetTransitionAmountAfterVersion(t *testing.T) {
 			nodeSig := "0xnodesig"
 			s.NodeSig = &nodeSig
 		}
+		_, err := store.LockUserState(wallet, asset)
+		require.NoError(t, err)
 		require.NoError(t, store.StoreUserState(s, ""))
 	}
 
@@ -1288,6 +1292,8 @@ func TestDBStore_HasSignedFinalize(t *testing.T) {
 			nodeSig := "0xnodesig"
 			s.NodeSig = &nodeSig
 		}
+		_, err := store.LockUserState(wallet, asset)
+		require.NoError(t, err)
 		require.NoError(t, store.StoreUserState(s, ""))
 	}
 

--- a/nitronode/store/database/interface.go
+++ b/nitronode/store/database/interface.go
@@ -99,8 +99,18 @@ type DatabaseStore interface {
 	// that would prevent issuing a receiver-side state.
 	EnsureNoOngoingEscrowOperation(wallet, asset string) error
 
-	// UpdateStateUserSigIfMissing backfills the user signature for a stored state when it is currently NULL.
-	UpdateStateUserSigIfMissing(channelID string, version uint64, userSig string) error
+	// UpdateStateSigsIfMissing backfills the user and/or node signatures for a stored
+	// state when the corresponding column is currently NULL. Either signature may be
+	// empty to skip that side.
+	UpdateStateSigsIfMissing(channelID string, version uint64, userSig, nodeSig string) error
+
+	// SumNetTransitionAmountAfterVersion returns the net effect on the user's
+	// home-channel balance of transitions stored against channelID strictly above
+	// minVersion at the supplied epoch. Receiver credits (TransferReceive, Release)
+	// contribute positively; sender debits (TransferSend, Commit) contribute negatively.
+	// Other transition kinds are excluded. Used to compute the ChallengeRescue amount
+	// when a challenged channel is closed.
+	SumNetTransitionAmountAfterVersion(channelID string, minVersion, epoch uint64) (decimal.Decimal, error)
 
 	// --- Blockchain Action Operations ---
 

--- a/nitronode/store/database/interface.go
+++ b/nitronode/store/database/interface.go
@@ -104,6 +104,12 @@ type DatabaseStore interface {
 	// empty to skip that side.
 	UpdateStateSigsIfMissing(channelID string, version uint64, userSig, nodeSig string) error
 
+	// HasSignedFinalize reports whether a node-signed Finalize state exists for the given
+	// home channel. Used by event handlers to detect the post-Finalize lifecycle when the
+	// channel status field has been temporarily overwritten by an on-chain challenge.
+	HasSignedFinalize(channelID string) (bool, error)
+
+
 	// SumNetTransitionAmountAfterVersion returns the net effect on the user's
 	// home-channel balance of transitions stored against channelID strictly above
 	// minVersion at the supplied epoch. Receiver credits (TransferReceive, Release)

--- a/nitronode/store/database/state.go
+++ b/nitronode/store/database/state.go
@@ -156,9 +156,9 @@ func (s *DBStore) StoreUserState(state core.State, applicationID string) error {
 	err = s.db.Model(&UserBalance{}).
 		Where("user_wallet = ? AND asset = ?", wallet, state.Asset).
 		Updates(map[string]interface{}{
-			"balance":             balance,
-			"home_blockchain_id":  state.HomeLedger.BlockchainID,
-			"updated_at":          time.Now(),
+			"balance":            balance,
+			"home_blockchain_id": state.HomeLedger.BlockchainID,
+			"updated_at":         time.Now(),
 		}).Error
 
 	if err != nil {
@@ -249,6 +249,25 @@ func (s *DBStore) UpdateStateSigsIfMissing(channelID string, version uint64, use
 	}
 	return nil
 }
+
+// HasSignedFinalize reports whether a node-signed Finalize state exists for the given home
+// channel. Used by event handlers to detect the post-Finalize lifecycle without loading the
+// state row: the channels.status field can be temporarily overwritten by Challenged on a
+// stale on-chain challenge, but the Finalize row persists here and is the authoritative
+// marker. node_sig IS NOT NULL is checked explicitly so the contract holds even if a future
+// path ever stores a Finalize row before the node signs.
+func (s *DBStore) HasSignedFinalize(channelID string) (bool, error) {
+	var count int64
+	err := s.db.Model(&State{}).
+		Where("home_channel_id = ? AND transition_type = ? AND node_sig IS NOT NULL",
+			strings.ToLower(channelID), uint8(core.TransitionTypeFinalize)).
+		Count(&count).Error
+	if err != nil {
+		return false, fmt.Errorf("failed to check signed finalize: %w", err)
+	}
+	return count > 0, nil
+}
+
 
 // SumNetTransitionAmountAfterVersion returns the net effect on the user's home-channel
 // balance of transitions stored against channelID strictly above minVersion at the

--- a/nitronode/store/database/state.go
+++ b/nitronode/store/database/state.go
@@ -221,22 +221,75 @@ func (s *DBStore) GetLastStateByChannelID(channelID string, signed bool) (*core.
 	return databaseStateToCore(&state)
 }
 
-// UpdateStateUserSigIfMissing backfills the user signature for a stored state when it is currently NULL.
-// Used by the on-chain event reactor to repair the local record once a state has been bilaterally
-// enforced on chain. The IS NULL guard makes the call idempotent on event replay and prevents
-// overwriting a signature already populated by the user-facing RPC path.
-func (s *DBStore) UpdateStateUserSigIfMissing(channelID string, version uint64, userSig string) error {
-	if userSig == "" {
+// UpdateStateSigsIfMissing backfills the user and/or node signatures for a stored state when
+// the corresponding column is currently NULL. Used by the on-chain event reactor to repair
+// the local record once a state has been enforced on chain. Either signature may be empty,
+// in which case that side is skipped. The IS NULL guard keeps the call idempotent on event
+// replay and prevents overwriting a signature already populated by the user-facing RPC path.
+func (s *DBStore) UpdateStateSigsIfMissing(channelID string, version uint64, userSig, nodeSig string) error {
+	if userSig == "" && nodeSig == "" {
 		return nil
 	}
 	cid := strings.ToLower(channelID)
-	res := s.db.Model(&State{}).
-		Where("(home_channel_id = ? OR escrow_channel_id = ?) AND version = ? AND user_sig IS NULL", cid, cid, version).
-		Update("user_sig", userSig)
-	if res.Error != nil {
-		return fmt.Errorf("failed to backfill user_sig: %w", res.Error)
+	if userSig != "" {
+		res := s.db.Model(&State{}).
+			Where("(home_channel_id = ? OR escrow_channel_id = ?) AND version = ? AND user_sig IS NULL", cid, cid, version).
+			Update("user_sig", userSig)
+		if res.Error != nil {
+			return fmt.Errorf("failed to backfill user_sig: %w", res.Error)
+		}
+	}
+	if nodeSig != "" {
+		res := s.db.Model(&State{}).
+			Where("(home_channel_id = ? OR escrow_channel_id = ?) AND version = ? AND node_sig IS NULL", cid, cid, version).
+			Update("node_sig", nodeSig)
+		if res.Error != nil {
+			return fmt.Errorf("failed to backfill node_sig: %w", res.Error)
+		}
 	}
 	return nil
+}
+
+// SumNetTransitionAmountAfterVersion returns the net effect on the user's home-channel
+// balance of transitions stored against channelID strictly above minVersion at the
+// supplied epoch. Receiver credits (TransferReceive, Release) contribute positively;
+// sender debits (TransferSend, Commit) contribute negatively. Other transition kinds
+// (HomeDeposit, HomeWithdrawal, escrow ops, migrate, finalize, acknowledgement) are
+// excluded because they either require onchain backing the chain didn't enforce at
+// this closure or belong to a different ledger.
+//
+// Used to compute the ChallengeRescue amount when a challenged channel is closed:
+// onchain payout reflects the closure version, anything strictly above didn't enforce,
+// and the net amount the user is still owed by the node is the receives minus the
+// sends in that interval. Signed (Open-time) and unsigned (during-challenge) rows
+// both contribute — both are real value the state-advancer validated at submit time.
+// The caller clamps the result at zero before issuing the rescue.
+func (s *DBStore) SumNetTransitionAmountAfterVersion(channelID string, minVersion, epoch uint64) (decimal.Decimal, error) {
+	cid := strings.ToLower(channelID)
+	var row struct {
+		Net decimal.Decimal `gorm:"column:net"`
+	}
+	err := s.db.Raw(`
+		SELECT COALESCE(SUM(CASE
+			WHEN transition_type IN (?, ?) THEN transition_amount
+			WHEN transition_type IN (?, ?) THEN -transition_amount
+			ELSE 0
+		END), 0) AS net
+		FROM channel_states
+		WHERE home_channel_id = ?
+			AND epoch = ?
+			AND version > ?
+	`,
+		uint8(core.TransitionTypeTransferReceive),
+		uint8(core.TransitionTypeRelease),
+		uint8(core.TransitionTypeTransferSend),
+		uint8(core.TransitionTypeCommit),
+		cid, epoch, minVersion,
+	).Scan(&row).Error
+	if err != nil {
+		return decimal.Zero, fmt.Errorf("failed to compute net transition amount: %w", err)
+	}
+	return row.Net, nil
 }
 
 // GetStateByChannelIDAndVersion retrieves a specific state version for a channel.

--- a/pkg/app/session_key_v1.go
+++ b/pkg/app/session_key_v1.go
@@ -122,12 +122,12 @@ func PackAppSessionKeyStateV1(state AppSessionKeyStateV1) ([]byte, error) {
 
 	applicationIDHashes := make([][32]byte, len(state.ApplicationIDs))
 	for i, id := range state.ApplicationIDs {
-		applicationIDHashes[i] = common.HexToHash(id)
+		applicationIDHashes[i] = crypto.Keccak256Hash([]byte(id))
 	}
 
 	appSessionIDHashes := make([][32]byte, len(state.AppSessionIDs))
 	for i, id := range state.AppSessionIDs {
-		appSessionIDHashes[i] = common.HexToHash(id)
+		appSessionIDHashes[i] = crypto.Keccak256Hash([]byte(id))
 	}
 
 	packed, err := args.Pack(

--- a/pkg/app/session_key_v1_test.go
+++ b/pkg/app/session_key_v1_test.go
@@ -150,8 +150,58 @@ func TestPackAppSessionKeyStateV1(t *testing.T) {
 
 	// Strengthen assertion: validate content by comparing against pre-calculated hash
 	// This ensures that if the packing logic changes, the test will fail.
-	expectedHash := "0x9fedfbcd577c5e677b95b1273e38f52ffdeee096e98f731c5455e4c73e0274aa"
+	expectedHash := "0x6d404fa628918dbe4abec4ae2808c7ea01dc880ad4ad392ca2d0c4ce21f706c1"
 	assert.Equal(t, expectedHash, hexutil.Encode(packed))
+}
+
+func TestPackAppSessionKeyStateV1_NoIDCollision(t *testing.T) {
+	t.Parallel()
+	base := AppSessionKeyStateV1{
+		UserAddress: "0x1111111111111111111111111111111111111111",
+		SessionKey:  "0x2222222222222222222222222222222222222222",
+		Version:     1,
+		ExpiresAt:   time.Unix(1739812234, 0),
+	}
+
+	// Human-readable (non-hex) IDs must each produce a distinct packed hash.
+	ids := []string{"app-1", "app-2", "trading", "gaming", "defi"}
+	hashes := make(map[string]string)
+	for _, id := range ids {
+		s := base
+		s.ApplicationIDs = []string{id}
+		packed, err := PackAppSessionKeyStateV1(s)
+		require.NoError(t, err)
+		h := hexutil.Encode(packed)
+		if prev, seen := hashes[h]; seen {
+			t.Fatalf("collision: %q and %q produced the same hash %s", prev, id, h)
+		}
+		hashes[h] = id
+	}
+
+	// Same uniqueness requirement holds for AppSessionIDs.
+	sessionHashes := make(map[string]string)
+	for _, id := range ids {
+		s := base
+		s.AppSessionIDs = []string{id}
+		packed, err := PackAppSessionKeyStateV1(s)
+		require.NoError(t, err)
+		h := hexutil.Encode(packed)
+		if prev, seen := sessionHashes[h]; seen {
+			t.Fatalf("appSessionID collision: %q and %q produced the same hash %s", prev, id, h)
+		}
+		sessionHashes[h] = id
+	}
+
+	// An empty ID and a whitespace ID must also be distinct.
+	sEmpty := base
+	sEmpty.ApplicationIDs = []string{""}
+	sSpace := base
+	sSpace.ApplicationIDs = []string{" "}
+	hashEmpty, err := PackAppSessionKeyStateV1(sEmpty)
+	require.NoError(t, err)
+	hashSpace, err := PackAppSessionKeyStateV1(sSpace)
+	require.NoError(t, err)
+	assert.NotEqual(t, hexutil.Encode(hashEmpty), hexutil.Encode(hashSpace))
 }
 
 func TestAppSessionSignerV1(t *testing.T) {

--- a/pkg/blockchain/evm/blockchain_client.go
+++ b/pkg/blockchain/evm/blockchain_client.go
@@ -251,7 +251,7 @@ func (c *BlockchainClient) Deposit(token string, amount decimal.Decimal) (string
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to get token decimals for token %s", token)
 	}
-	amountBig, err := core.DecimalToBigInt(amount, decimals)
+	amountBig, err := core.DecimalToUint256(amount, decimals)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to convert amount %s to big.Int", amount.String())
 	}
@@ -280,7 +280,7 @@ func (c *BlockchainClient) Withdraw(to, token string, amount decimal.Decimal) (s
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to get token decimals for token %s", token)
 	}
-	amountBig, err := core.DecimalToBigInt(amount, decimals)
+	amountBig, err := core.DecimalToUint256(amount, decimals)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to convert amount %s to big.Int", amount.String())
 	}
@@ -315,7 +315,7 @@ func (c *BlockchainClient) Approve(asset string, amount decimal.Decimal) (string
 		return "", errors.Wrapf(err, "failed to get token decimals for %s", asset)
 	}
 
-	amountBig, err := core.DecimalToBigInt(amount, decimals)
+	amountBig, err := core.DecimalToUint256(amount, decimals)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to convert amount %s to big.Int", amount.String())
 	}
@@ -375,7 +375,7 @@ func (c *BlockchainClient) Create(def core.ChannelDefinition, initCCS core.State
 		}
 
 		if contractState.HomeLedger.Token == (common.Address{}) {
-			value, err := core.DecimalToBigInt(initCCS.Transition.Amount, contractState.HomeLedger.Decimals)
+			value, err := core.DecimalToUint256(initCCS.Transition.Amount, contractState.HomeLedger.Decimals)
 			if err != nil {
 				return "", errors.Wrap(err, "failed to convert native deposit amount to wei")
 			}
@@ -468,7 +468,7 @@ func (c *BlockchainClient) Checkpoint(candidate core.State) (string, error) {
 		}
 
 		if contractCandidate.HomeLedger.Token == (common.Address{}) {
-			value, valueErr := core.DecimalToBigInt(candidate.Transition.Amount, contractCandidate.HomeLedger.Decimals)
+			value, valueErr := core.DecimalToUint256(candidate.Transition.Amount, contractCandidate.HomeLedger.Decimals)
 			if valueErr != nil {
 				return "", errors.Wrap(valueErr, "failed to convert native deposit amount to wei")
 			}

--- a/pkg/blockchain/evm/channel_hub_reactor.go
+++ b/pkg/blockchain/evm/channel_hub_reactor.go
@@ -71,8 +71,29 @@ type ChannelHubReactorStore interface {
 	// RefreshUserEnforcedBalance recomputes the locked balance from the user's open home channel on-chain state.
 	RefreshUserEnforcedBalance(wallet, asset string) error
 
-	// UpdateStateUserSigIfMissing backfills the user signature for a stored state when it is currently NULL.
-	UpdateStateUserSigIfMissing(channelID string, version uint64, userSig string) error
+	// LockUserState acquires SELECT ... FOR UPDATE on the user's balance row so the
+	// caller's transaction serializes against concurrent RPC paths that already lock
+	// the same row before issuing receiver states. Postgres-only; SQLite is a no-op
+	// in tests.
+	LockUserState(wallet, asset string) (decimal.Decimal, error)
+
+	// UpdateStateSigsIfMissing backfills the user and/or node signatures for a stored
+	// state when the corresponding column is currently NULL. Either signature may be
+	// empty to skip that side.
+	UpdateStateSigsIfMissing(channelID string, version uint64, userSig, nodeSig string) error
+
+	// SumNetTransitionAmountAfterVersion returns the net effect on the user's
+	// home-channel balance of transitions stored against channelID strictly above
+	// minVersion at the supplied epoch. Receiver credits (TransferReceive, Release)
+	// contribute positively; sender debits (TransferSend, Commit) contribute negatively.
+	SumNetTransitionAmountAfterVersion(channelID string, minVersion, epoch uint64) (decimal.Decimal, error)
+
+	// StoreUserState persists a user state row. Used to record a ChallengeRescue squash
+	// state derived from a closed challenged channel.
+	StoreUserState(state core.State, applicationID string) error
+
+	// RecordTransaction creates a transaction row linking state transitions.
+	RecordTransaction(tx core.Transaction, applicationID string) error
 
 	// StoreContractEvent persists a blockchain event to the database.
 	StoreContractEvent(ev core.BlockchainEvent) error

--- a/pkg/blockchain/evm/channel_hub_reactor.go
+++ b/pkg/blockchain/evm/channel_hub_reactor.go
@@ -82,6 +82,11 @@ type ChannelHubReactorStore interface {
 	// empty to skip that side.
 	UpdateStateSigsIfMissing(channelID string, version uint64, userSig, nodeSig string) error
 
+	// HasSignedFinalize reports whether a node-signed Finalize state exists for the given
+	// home channel.
+	HasSignedFinalize(channelID string) (bool, error)
+
+
 	// SumNetTransitionAmountAfterVersion returns the net effect on the user's
 	// home-channel balance of transitions stored against channelID strictly above
 	// minVersion at the supplied epoch. Receiver credits (TransferReceive, Release)

--- a/pkg/blockchain/evm/channel_hub_reactor_test.go
+++ b/pkg/blockchain/evm/channel_hub_reactor_test.go
@@ -90,8 +90,28 @@ func (m *mockChannelHubStore) StoreContractEvent(ev core.BlockchainEvent) error 
 	return args.Error(0)
 }
 
-func (m *mockChannelHubStore) UpdateStateUserSigIfMissing(channelID string, version uint64, userSig string) error {
-	args := m.Called(channelID, version, userSig)
+func (m *mockChannelHubStore) UpdateStateSigsIfMissing(channelID string, version uint64, userSig, nodeSig string) error {
+	args := m.Called(channelID, version, userSig, nodeSig)
+	return args.Error(0)
+}
+
+func (m *mockChannelHubStore) SumNetTransitionAmountAfterVersion(channelID string, minVersion, epoch uint64) (decimal.Decimal, error) {
+	args := m.Called(channelID, minVersion, epoch)
+	return args.Get(0).(decimal.Decimal), args.Error(1)
+}
+
+func (m *mockChannelHubStore) LockUserState(wallet, asset string) (decimal.Decimal, error) {
+	args := m.Called(wallet, asset)
+	return args.Get(0).(decimal.Decimal), args.Error(1)
+}
+
+func (m *mockChannelHubStore) StoreUserState(state core.State, applicationID string) error {
+	args := m.Called(state, applicationID)
+	return args.Error(0)
+}
+
+func (m *mockChannelHubStore) RecordTransaction(tx core.Transaction, applicationID string) error {
+	args := m.Called(tx, applicationID)
 	return args.Error(0)
 }
 

--- a/pkg/blockchain/evm/channel_hub_reactor_test.go
+++ b/pkg/blockchain/evm/channel_hub_reactor_test.go
@@ -105,6 +105,12 @@ func (m *mockChannelHubStore) LockUserState(wallet, asset string) (decimal.Decim
 	return args.Get(0).(decimal.Decimal), args.Error(1)
 }
 
+func (m *mockChannelHubStore) HasSignedFinalize(channelID string) (bool, error) {
+	args := m.Called(channelID)
+	return args.Bool(0), args.Error(1)
+}
+
+
 func (m *mockChannelHubStore) StoreUserState(state core.State, applicationID string) error {
 	args := m.Called(state, applicationID)
 	return args.Error(0)

--- a/pkg/blockchain/evm/locking_client.go
+++ b/pkg/blockchain/evm/locking_client.go
@@ -1,8 +1,6 @@
 package evm
 
 import (
-	"math/big"
-
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
@@ -100,7 +98,7 @@ func (c *LockingClient) Lock(targetWalletAddress string, amount decimal.Decimal)
 		return "", errors.New("transaction signer not configured")
 	}
 
-	amountBig, err := core.DecimalToBigInt(amount, c.tokenDecimals)
+	amountBig, err := core.DecimalToUint256(amount, c.tokenDecimals)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to convert amount with decimal precision")
 	}
@@ -182,7 +180,7 @@ func (c *LockingClient) ApproveToken(amount decimal.Decimal) (string, error) {
 		return "", errors.New("transaction signer not configured")
 	}
 
-	amountBig, err := core.DecimalToBigInt(amount, c.tokenDecimals)
+	amountBig, err := core.DecimalToUint256(amount, c.tokenDecimals)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to convert amount with decimal precision")
 	}
@@ -223,10 +221,4 @@ func (c *LockingClient) GetBalance(user string) (decimal.Decimal, error) {
 	}
 
 	return decimal.NewFromBigInt(balance, -int32(c.tokenDecimals)), nil
-}
-
-// decimalToBigInt converts a decimal amount to *big.Int given token decimals.
-func decimalToBigInt(amount decimal.Decimal, decimals int32) *big.Int {
-	shifted := amount.Shift(decimals)
-	return shifted.BigInt()
 }

--- a/pkg/blockchain/evm/utils.go
+++ b/pkg/blockchain/evm/utils.go
@@ -163,24 +163,24 @@ func coreStateToContractState(state core.State, tokenGetter func(blockchainID ui
 func coreLedgerToContractLedger(ledger core.Ledger, decimals uint8) (Ledger, error) {
 	tokenAddr := common.HexToAddress(ledger.TokenAddress)
 
-	userAllocation, err := core.DecimalToBigInt(ledger.UserBalance, decimals)
+	userAllocation, err := core.DecimalToUint256(ledger.UserBalance, decimals)
 	if err != nil {
-		return Ledger{}, errors.Wrap(err, "failed to convert user balance to big.Int")
+		return Ledger{}, errors.Wrap(err, "failed to convert user balance to uint256")
 	}
 
-	userNetFlow, err := core.DecimalToBigInt(ledger.UserNetFlow, decimals)
+	userNetFlow, err := core.DecimalToInt256(ledger.UserNetFlow, decimals)
 	if err != nil {
-		return Ledger{}, errors.Wrap(err, "failed to convert user net flow to big.Int")
+		return Ledger{}, errors.Wrap(err, "failed to convert user net flow to int256")
 	}
 
-	nodeAllocation, err := core.DecimalToBigInt(ledger.NodeBalance, decimals)
+	nodeAllocation, err := core.DecimalToUint256(ledger.NodeBalance, decimals)
 	if err != nil {
-		return Ledger{}, errors.Wrap(err, "failed to convert node balance to big.Int")
+		return Ledger{}, errors.Wrap(err, "failed to convert node balance to uint256")
 	}
 
-	nodeNetFlow, err := core.DecimalToBigInt(ledger.NodeNetFlow, decimals)
+	nodeNetFlow, err := core.DecimalToInt256(ledger.NodeNetFlow, decimals)
 	if err != nil {
-		return Ledger{}, errors.Wrap(err, "failed to convert node net flow to big.Int")
+		return Ledger{}, errors.Wrap(err, "failed to convert node net flow to int256")
 	}
 
 	return Ledger{

--- a/pkg/blockchain/evm/utils_test.go
+++ b/pkg/blockchain/evm/utils_test.go
@@ -169,6 +169,45 @@ func TestCoreLedgerToContractLedger_Success(t *testing.T) {
 	require.Equal(t, expectedNodeNetFlow, result.NodeNetFlow)
 }
 
+func TestCoreLedgerToContractLedger_RejectsOutOfRangeValues(t *testing.T) {
+	t.Parallel()
+
+	tokenAddr := "0x1234567890123456789012345678901234567890"
+	overflow256 := new(big.Int).Lsh(big.NewInt(1), 256) // 2^256
+	overflow255 := new(big.Int).Lsh(big.NewInt(1), 255) // 2^255
+
+	newBaseLedger := func() core.Ledger {
+		return core.Ledger{
+			BlockchainID: 1,
+			TokenAddress: tokenAddr,
+			UserBalance:  decimal.Zero,
+			UserNetFlow:  decimal.Zero,
+			NodeBalance:  decimal.Zero,
+			NodeNetFlow:  decimal.Zero,
+		}
+	}
+
+	t.Run("user_balance_overflows_uint256", func(t *testing.T) {
+		t.Parallel()
+		ledger := newBaseLedger()
+		ledger.UserBalance = decimal.NewFromBigInt(overflow256, 0)
+
+		_, err := coreLedgerToContractLedger(ledger, 0)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "uint256")
+	})
+
+	t.Run("user_net_flow_overflows_int256", func(t *testing.T) {
+		t.Parallel()
+		ledger := newBaseLedger()
+		ledger.UserNetFlow = decimal.NewFromBigInt(overflow255, 0)
+
+		_, err := coreLedgerToContractLedger(ledger, 0)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "int256")
+	})
+}
+
 // ========= contractLedgerToCoreLedger Tests =========
 
 func TestContractLedgerToCoreLedger_Success(t *testing.T) {

--- a/pkg/core/channel_signer.go
+++ b/pkg/core/channel_signer.go
@@ -178,7 +178,7 @@ func (s *ChannelSigValidator) Recover(data, sig []byte) (string, error) {
 		}
 
 		// Step 1: Verify participant authorized this session key
-		// authMessage = _toSigningData(skAuth) = abi.encode(skAuth.sessionKey, skAuth.metadataHash)
+		// authMessage = toSigningData(skAuth) = abi.encode(SESSION_KEY_AUTH_TYPEHASH, sessionKey, metadataHash)
 		packedAuth, err := PackChannelKeyStateV1(skAuth.SessionKey.Hex(), skAuth.MetadataHash)
 		if err != nil {
 			return "", fmt.Errorf("failed to pack auth data: %w", err)

--- a/pkg/core/interface.go
+++ b/pkg/core/interface.go
@@ -145,10 +145,33 @@ type ChannelHubEventHandlerStore interface {
 	// RefreshUserEnforcedBalance recomputes the locked balance from the user's open home channel on-chain state.
 	RefreshUserEnforcedBalance(wallet, asset string) error
 
-	// UpdateStateUserSigIfMissing backfills the user signature for a stored state when it is currently NULL.
-	// Used to repair the local record after an on-chain event proves the state was bilaterally enforced.
-	// No-op when userSig is empty or no row matches; existing user_sig is never overwritten.
-	UpdateStateUserSigIfMissing(channelID string, version uint64, userSig string) error
+	// LockUserState acquires SELECT ... FOR UPDATE on the user's balance row so the
+	// caller's transaction serializes against concurrent RPC paths that already lock
+	// the same row before issuing receiver states. Postgres-only; SQLite is a no-op
+	// in tests.
+	LockUserState(wallet, asset string) (decimal.Decimal, error)
+
+	// UpdateStateSigsIfMissing backfills the user and/or node signatures for a stored state
+	// when the corresponding column is currently NULL. Used to repair the local record after
+	// an on-chain event proves the state was enforced. Either signature may be empty to skip
+	// that side; existing values are never overwritten and the call is idempotent on event replay.
+	UpdateStateSigsIfMissing(channelID string, version uint64, userSig, nodeSig string) error
+
+	// SumNetTransitionAmountAfterVersion returns the net effect on the user's
+	// home-channel balance of transitions stored against channelID strictly above
+	// minVersion at the supplied epoch. Receiver credits (TransferReceive, Release)
+	// contribute positively; sender debits (TransferSend, Commit) contribute negatively.
+	// Other transition kinds are excluded. Used to compute the ChallengeRescue amount
+	// when a challenged channel is closed.
+	SumNetTransitionAmountAfterVersion(channelID string, minVersion, epoch uint64) (decimal.Decimal, error)
+
+	// StoreUserState persists a user state row. Used by the event handler to record a
+	// ChallengeRescue squash state derived from a closed challenged channel.
+	StoreUserState(state State, applicationID string) error
+
+	// RecordTransaction creates a transaction row linking state transitions. Used by the
+	// event handler to record the ChallengeRescue transaction associated with the squash.
+	RecordTransaction(tx Transaction, applicationID string) error
 }
 
 type LockingContractEventHandler interface {

--- a/pkg/core/interface.go
+++ b/pkg/core/interface.go
@@ -157,6 +157,12 @@ type ChannelHubEventHandlerStore interface {
 	// that side; existing values are never overwritten and the call is idempotent on event replay.
 	UpdateStateSigsIfMissing(channelID string, version uint64, userSig, nodeSig string) error
 
+	// HasSignedFinalize reports whether a node-signed Finalize state exists for the given
+	// home channel. Used to detect the post-Finalize lifecycle when the channel status
+	// has been temporarily overwritten by an on-chain challenge.
+	HasSignedFinalize(channelID string) (bool, error)
+
+
 	// SumNetTransitionAmountAfterVersion returns the net effect on the user's
 	// home-channel balance of transitions stored against channelID strictly above
 	// minVersion at the supplied epoch. Receiver credits (TransferReceive, Release)

--- a/pkg/core/session_key.go
+++ b/pkg/core/session_key.go
@@ -72,16 +72,21 @@ func (s *ChannelSessionKeySignerV1) Type() ChannelSignerType {
 	return ChannelSignerType_SessionKey
 }
 
-// PackChannelKeyStateV1 packs the session key state for signing using ABI encoding.
-// This is used to generate a deterministic hash that the user signs when registering/updating a session key.
-// The user_sig field is excluded from packing since it is the signature itself.
+// SessionKeyAuthTypehash is the type hash prepended to the session key authorization payload.
+// It matches the Solidity constant SESSION_KEY_AUTH_TYPEHASH and
+// prevents unrelated abi.encode(address, bytes32) signatures from being reused as authorizations.
+var SessionKeyAuthTypehash = crypto.Keccak256Hash([]byte("Nitrolite.SessionKey(address sessionKey,bytes32 metadataHash)"))
+
+// PackChannelKeyStateV1 packs the session key authorization payload for signing using ABI encoding.
 func PackChannelKeyStateV1(sessionKey string, metadataHash common.Hash) ([]byte, error) {
 	args := abi.Arguments{
+		{Type: abi.Type{T: abi.FixedBytesTy, Size: 32}}, // SESSION_KEY_AUTH_TYPEHASH
 		{Type: abi.Type{T: abi.AddressTy}},              // session_key
 		{Type: abi.Type{T: abi.FixedBytesTy, Size: 32}}, // hashed metadata
 	}
 
 	packed, err := args.Pack(
+		SessionKeyAuthTypehash,
 		common.HexToAddress(sessionKey),
 		metadataHash,
 	)

--- a/pkg/core/session_key.go
+++ b/pkg/core/session_key.go
@@ -72,10 +72,14 @@ func (s *ChannelSessionKeySignerV1) Type() ChannelSignerType {
 	return ChannelSignerType_SessionKey
 }
 
-// SessionKeyAuthTypehash is the type hash prepended to the session key authorization payload.
+var sessionKeyAuthTypehash = crypto.Keccak256Hash([]byte("Nitrolite.SessionKey(address sessionKey,bytes32 metadataHash)"))
+
+// SessionKeyAuthTypehash returns the type hash prepended to the session key authorization payload.
 // It matches the Solidity constant SESSION_KEY_AUTH_TYPEHASH and
 // prevents unrelated abi.encode(address, bytes32) signatures from being reused as authorizations.
-var SessionKeyAuthTypehash = crypto.Keccak256Hash([]byte("Nitrolite.SessionKey(address sessionKey,bytes32 metadataHash)"))
+func SessionKeyAuthTypehash() common.Hash {
+	return sessionKeyAuthTypehash
+}
 
 // PackChannelKeyStateV1 packs the session key authorization payload for signing using ABI encoding.
 func PackChannelKeyStateV1(sessionKey string, metadataHash common.Hash) ([]byte, error) {
@@ -86,7 +90,7 @@ func PackChannelKeyStateV1(sessionKey string, metadataHash common.Hash) ([]byte,
 	}
 
 	packed, err := args.Pack(
-		SessionKeyAuthTypehash,
+		sessionKeyAuthTypehash,
 		common.HexToAddress(sessionKey),
 		metadataHash,
 	)

--- a/pkg/core/session_key_test.go
+++ b/pkg/core/session_key_test.go
@@ -208,6 +208,28 @@ func TestGenerateSessionKeyStateIDV1(t *testing.T) {
 	assert.NotEqual(t, id1, id3)
 }
 
+// TestPackChannelKeyStateV1_Typehash verifies the SessionKeyAuthTypehash matches the
+// Solidity constant SESSION_KEY_AUTH_TYPEHASH in SessionKeyValidator.sol so that
+// off-chain authorization payloads are accepted on-chain.
+func TestPackChannelKeyStateV1_Typehash(t *testing.T) {
+	t.Parallel()
+	expected := common.HexToHash("0x251773da8b8949935ef07284d20cc8605ad7d6f4cf6b5e040ce07dae857f0b6c")
+	assert.Equal(t, expected, SessionKeyAuthTypehash)
+}
+
+func TestPackChannelKeyStateV1(t *testing.T) {
+	t.Parallel()
+	sessionKey := "0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF"
+	metadataHash := common.HexToHash("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
+
+	packed, err := PackChannelKeyStateV1(sessionKey, metadataHash)
+	require.NoError(t, err)
+	assert.Len(t, packed, 96, "payload must be 96 bytes: typehash || padded address || metadataHash")
+
+	expected := common.FromHex("0x251773da8b8949935ef07284d20cc8605ad7d6f4cf6b5e040ce07dae857f0b6c000000000000000000000000deadbeefdeadbeefdeadbeefdeadbeefdeadbeefabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
+	assert.Equal(t, expected, packed)
+}
+
 func TestEncodeDecodeChannelSessionKeySignature(t *testing.T) {
 	t.Parallel()
 	skAuth := channelSessionKeyAuthorization{

--- a/pkg/core/session_key_test.go
+++ b/pkg/core/session_key_test.go
@@ -214,7 +214,7 @@ func TestGenerateSessionKeyStateIDV1(t *testing.T) {
 func TestPackChannelKeyStateV1_Typehash(t *testing.T) {
 	t.Parallel()
 	expected := common.HexToHash("0x251773da8b8949935ef07284d20cc8605ad7d6f4cf6b5e040ce07dae857f0b6c")
-	assert.Equal(t, expected, SessionKeyAuthTypehash)
+	assert.Equal(t, expected, SessionKeyAuthTypehash())
 }
 
 func TestPackChannelKeyStateV1(t *testing.T) {

--- a/pkg/core/state_advancer.go
+++ b/pkg/core/state_advancer.go
@@ -175,7 +175,11 @@ func (v *StateAdvancerV1) ValidateAdvancement(currentState, proposedState State)
 	if err := expectedState.HomeLedger.Equal(proposedState.HomeLedger); err != nil {
 		return fmt.Errorf("home ledger mismatch: %w", err)
 	}
-	if err := proposedState.HomeLedger.Validate(); err != nil {
+	homeDecimals, err := v.assetStore.GetTokenDecimals(proposedState.HomeLedger.BlockchainID, proposedState.HomeLedger.TokenAddress)
+	if err != nil {
+		return fmt.Errorf("failed to get home token decimals: %w", err)
+	}
+	if err := proposedState.HomeLedger.Validate(homeDecimals); err != nil {
 		return fmt.Errorf("invalid home ledger: %w", err)
 	}
 
@@ -197,7 +201,11 @@ func (v *StateAdvancerV1) ValidateAdvancement(currentState, proposedState State)
 		if err := expectedState.EscrowLedger.Equal(*proposedState.EscrowLedger); err != nil {
 			return fmt.Errorf("escrow ledger mismatch: %w", err)
 		}
-		if err := proposedState.EscrowLedger.Validate(); err != nil {
+		escrowDecimals, err := v.assetStore.GetTokenDecimals(proposedState.EscrowLedger.BlockchainID, proposedState.EscrowLedger.TokenAddress)
+		if err != nil {
+			return fmt.Errorf("failed to get escrow token decimals: %w", err)
+		}
+		if err := proposedState.EscrowLedger.Validate(escrowDecimals); err != nil {
 			return fmt.Errorf("invalid escrow ledger: %w", err)
 		}
 

--- a/pkg/core/state_advancer_test.go
+++ b/pkg/core/state_advancer_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/shopspring/decimal"
@@ -241,4 +242,130 @@ func TestValidateAdvancement_RejectsInvalidAmount(t *testing.T) {
 			})
 		}
 	}
+}
+
+// TestValidateAdvancement_RejectsOverflowDeposit ensures a home_deposit whose
+// scaled amount exceeds uint256 is rejected before storage. Without the bound
+// check, the offchain ledger would record the full amount while the signed
+// payload truncates to the low 256 bits.
+func TestValidateAdvancement_RejectsOverflowDeposit(t *testing.T) {
+	t.Parallel()
+
+	store := newMockAssetStore()
+	store.AddToken(1, "0xToken", 0) // decimals=0 so amount maps 1:1 to scaled
+	advancer := NewStateAdvancerV1(store)
+
+	userWallet := "0xUser"
+	asset := "USDC"
+	chanID := "0xHomeChannelId"
+	sig := "0xSig"
+
+	current := NewVoidState(asset, userWallet)
+	current.HomeChannelID = &chanID
+	current.ID = GetStateID(userWallet, asset, 0, 0)
+	current.HomeLedger.TokenAddress = "0xToken"
+	current.HomeLedger.BlockchainID = 1
+
+	// scaled = 2^256, one above the uint256 range.
+	overflow := new(big.Int).Lsh(big.NewInt(1), 256)
+	amount := decimal.NewFromBigInt(overflow, 0)
+
+	proposed := current.NextState()
+	_, err := proposed.ApplyHomeDepositTransition(amount)
+	require.NoError(t, err)
+	proposed.UserSig = &sig
+
+	err = advancer.ValidateAdvancement(*current, *proposed)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid home ledger")
+	assert.Contains(t, err.Error(), "uint256")
+}
+
+// TestValidateAdvancement_RejectsOverflowNetFlow checks that net-flow values
+// exceeding the int256 range are rejected. Reached by combining balances that
+// fit uint256 with a net flow that would overflow int256 (the signed type).
+func TestValidateAdvancement_RejectsOverflowNetFlow(t *testing.T) {
+	t.Parallel()
+
+	store := newMockAssetStore()
+	store.AddToken(1, "0xToken", 0)
+	advancer := NewStateAdvancerV1(store)
+
+	userWallet := "0xUser"
+	asset := "USDC"
+	chanID := "0xHomeChannelId"
+	sig := "0xSig"
+
+	current := NewVoidState(asset, userWallet)
+	current.HomeChannelID = &chanID
+	current.ID = GetStateID(userWallet, asset, 0, 0)
+	current.HomeLedger.TokenAddress = "0xToken"
+	current.HomeLedger.BlockchainID = 1
+
+	// 2^255, one above max int256
+	overInt := new(big.Int).Lsh(big.NewInt(1), 255)
+	amount := decimal.NewFromBigInt(overInt, 0)
+
+	proposed := current.NextState()
+	_, err := proposed.ApplyHomeDepositTransition(amount)
+	require.NoError(t, err)
+	proposed.UserSig = &sig
+
+	err = advancer.ValidateAdvancement(*current, *proposed)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid home ledger")
+	assert.Contains(t, err.Error(), "int256")
+}
+
+// TestValidateAdvancement_RejectsOverflowEscrowLedger covers the escrow branch
+// of the bound check: a state whose EscrowLedger already carries an out-of-range
+// UserBalance is rejected even when the home ledger and the new transition are
+// otherwise valid.
+func TestValidateAdvancement_RejectsOverflowEscrowLedger(t *testing.T) {
+	t.Parallel()
+
+	store := newMockAssetStore()
+	store.AddToken(1, "0xHomeToken", 0)
+	store.AddToken(2, "0xEscrowToken", 0)
+	advancer := NewStateAdvancerV1(store)
+
+	userWallet := "0xUser"
+	asset := "USDC"
+	homeChanID := "0xHomeChannelId"
+	escrowChanID := "0xEscrowChannelId"
+	sig := "0xSig"
+
+	// 2^256, one above the uint256 range.
+	overflow := new(big.Int).Lsh(big.NewInt(1), 256)
+	overflowDec := decimal.NewFromBigInt(overflow, 0)
+
+	current := NewVoidState(asset, userWallet)
+	current.HomeChannelID = &homeChanID
+	current.EscrowChannelID = &escrowChanID
+	current.ID = GetStateID(userWallet, asset, 0, 0)
+	current.HomeLedger.TokenAddress = "0xHomeToken"
+	current.HomeLedger.BlockchainID = 1
+	// Last transition is acknowledgement so NextState carries the escrow ledger
+	// forward and the new transition is not constrained.
+	current.Transition = *NewTransition(TransitionTypeAcknowledgement, "0x0", "0x0", decimal.Zero)
+	// Escrow balances sum to net flows so the equality check passes; the
+	// uint256 bound is what should reject the state.
+	current.EscrowLedger = &Ledger{
+		BlockchainID: 2,
+		TokenAddress: "0xEscrowToken",
+		UserBalance:  overflowDec,
+		UserNetFlow:  overflowDec,
+		NodeBalance:  decimal.Zero,
+		NodeNetFlow:  decimal.Zero,
+	}
+
+	proposed := current.NextState()
+	_, err := proposed.ApplyHomeDepositTransition(decimal.NewFromInt(1))
+	require.NoError(t, err)
+	proposed.UserSig = &sig
+
+	err = advancer.ValidateAdvancement(*current, *proposed)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid escrow ledger")
+	assert.Contains(t, err.Error(), "uint256")
 }

--- a/pkg/core/state_packer.go
+++ b/pkg/core/state_packer.go
@@ -12,6 +12,64 @@ type StatePackerV1 struct {
 	assetStore AssetStore
 }
 
+// contractLedger mirrors the Solidity Ledger struct used inside the signed state
+// payload. Allocation fields are encoded as uint256 and must fit [0, 2^256-1];
+// net-flow fields are encoded as int256 and must fit [-2^255, 2^255-1].
+type contractLedger struct {
+	ChainId        uint64
+	Token          common.Address
+	Decimals       uint8
+	UserAllocation *big.Int
+	UserNetFlow    *big.Int
+	NodeAllocation *big.Int
+	NodeNetFlow    *big.Int
+}
+
+// Validate guards against any caller that constructs a contractLedger without
+// going through the bounds-checking decimal helpers, so values that would be
+// silently truncated by ABI encoding are rejected before signing.
+func (l contractLedger) Validate() error {
+	if err := checkUint256(l.UserAllocation); err != nil {
+		return fmt.Errorf("user allocation: %w", err)
+	}
+	if err := checkUint256(l.NodeAllocation); err != nil {
+		return fmt.Errorf("node allocation: %w", err)
+	}
+	if err := checkInt256(l.UserNetFlow); err != nil {
+		return fmt.Errorf("user net flow: %w", err)
+	}
+	if err := checkInt256(l.NodeNetFlow); err != nil {
+		return fmt.Errorf("node net flow: %w", err)
+	}
+	return nil
+}
+
+func checkUint256(v *big.Int) error {
+	if v == nil {
+		return fmt.Errorf("value is nil")
+	}
+	if v.Sign() < 0 {
+		return fmt.Errorf("value %s is negative", v.String())
+	}
+	if v.BitLen() > 256 {
+		return fmt.Errorf("value %s exceeds uint256 max (2^256-1)", v.String())
+	}
+	return nil
+}
+
+func checkInt256(v *big.Int) error {
+	if v == nil {
+		return fmt.Errorf("value is nil")
+	}
+	if v.Cmp(maxInt256) > 0 {
+		return fmt.Errorf("value %s exceeds int256 max (2^255-1)", v.String())
+	}
+	if v.Cmp(minInt256) < 0 {
+		return fmt.Errorf("value %s below int256 min (-2^255)", v.String())
+	}
+	return nil
+}
+
 func NewStatePackerV1(assetStore AssetStore) *StatePackerV1 {
 	return &StatePackerV1{
 		assetStore: assetStore,
@@ -62,36 +120,26 @@ func (p *StatePackerV1) packSigningData(state State) (common.Hash, []byte, error
 		{Type: ledgerType},  // nonHomeState
 	}
 
-	type contractLedger struct {
-		ChainId        uint64
-		Token          common.Address
-		Decimals       uint8
-		UserAllocation *big.Int
-		UserNetFlow    *big.Int
-		NodeAllocation *big.Int
-		NodeNetFlow    *big.Int
-	}
-
 	homeDecimals, err := p.assetStore.GetTokenDecimals(state.HomeLedger.BlockchainID, state.HomeLedger.TokenAddress)
 	if err != nil {
 		return common.Hash{}, nil, err
 	}
 
-	userBalanceBI, err := DecimalToBigInt(state.HomeLedger.UserBalance, homeDecimals)
+	userBalanceBI, err := DecimalToUint256(state.HomeLedger.UserBalance, homeDecimals)
 	if err != nil {
-		return common.Hash{}, nil, err
+		return common.Hash{}, nil, fmt.Errorf("home user balance: %w", err)
 	}
-	userNetFlowBI, err := DecimalToBigInt(state.HomeLedger.UserNetFlow, homeDecimals)
+	userNetFlowBI, err := DecimalToInt256(state.HomeLedger.UserNetFlow, homeDecimals)
 	if err != nil {
-		return common.Hash{}, nil, err
+		return common.Hash{}, nil, fmt.Errorf("home user net flow: %w", err)
 	}
-	nodeBalanceBI, err := DecimalToBigInt(state.HomeLedger.NodeBalance, homeDecimals)
+	nodeBalanceBI, err := DecimalToUint256(state.HomeLedger.NodeBalance, homeDecimals)
 	if err != nil {
-		return common.Hash{}, nil, err
+		return common.Hash{}, nil, fmt.Errorf("home node balance: %w", err)
 	}
-	nodeNetFlowBI, err := DecimalToBigInt(state.HomeLedger.NodeNetFlow, homeDecimals)
+	nodeNetFlowBI, err := DecimalToInt256(state.HomeLedger.NodeNetFlow, homeDecimals)
 	if err != nil {
-		return common.Hash{}, nil, err
+		return common.Hash{}, nil, fmt.Errorf("home node net flow: %w", err)
 	}
 
 	homeLedger := contractLedger{
@@ -112,21 +160,21 @@ func (p *StatePackerV1) packSigningData(state State) (common.Hash, []byte, error
 			return common.Hash{}, nil, err
 		}
 
-		escrowUserBalanceBI, err := DecimalToBigInt(state.EscrowLedger.UserBalance, escrowDecimals)
+		escrowUserBalanceBI, err := DecimalToUint256(state.EscrowLedger.UserBalance, escrowDecimals)
 		if err != nil {
-			return common.Hash{}, nil, err
+			return common.Hash{}, nil, fmt.Errorf("escrow user balance: %w", err)
 		}
-		escrowUserNetFlowBI, err := DecimalToBigInt(state.EscrowLedger.UserNetFlow, escrowDecimals)
+		escrowUserNetFlowBI, err := DecimalToInt256(state.EscrowLedger.UserNetFlow, escrowDecimals)
 		if err != nil {
-			return common.Hash{}, nil, err
+			return common.Hash{}, nil, fmt.Errorf("escrow user net flow: %w", err)
 		}
-		escrowNodeBalanceBI, err := DecimalToBigInt(state.EscrowLedger.NodeBalance, escrowDecimals)
+		escrowNodeBalanceBI, err := DecimalToUint256(state.EscrowLedger.NodeBalance, escrowDecimals)
 		if err != nil {
-			return common.Hash{}, nil, err
+			return common.Hash{}, nil, fmt.Errorf("escrow node balance: %w", err)
 		}
-		escrowNodeNetFlowBI, err := DecimalToBigInt(state.EscrowLedger.NodeNetFlow, escrowDecimals)
+		escrowNodeNetFlowBI, err := DecimalToInt256(state.EscrowLedger.NodeNetFlow, escrowDecimals)
 		if err != nil {
-			return common.Hash{}, nil, err
+			return common.Hash{}, nil, fmt.Errorf("escrow node net flow: %w", err)
 		}
 
 		nonHomeLedger = contractLedger{
@@ -148,6 +196,13 @@ func (p *StatePackerV1) packSigningData(state State) (common.Hash, []byte, error
 			NodeAllocation: big.NewInt(0),
 			NodeNetFlow:    big.NewInt(0),
 		}
+	}
+
+	if err := homeLedger.Validate(); err != nil {
+		return common.Hash{}, nil, fmt.Errorf("invalid home ledger for signing: %w", err)
+	}
+	if err := nonHomeLedger.Validate(); err != nil {
+		return common.Hash{}, nil, fmt.Errorf("invalid escrow ledger for signing: %w", err)
 	}
 
 	intent := TransitionToIntent(state.Transition)

--- a/pkg/core/state_packer_test.go
+++ b/pkg/core/state_packer_test.go
@@ -1,11 +1,13 @@
 package core
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPackState(t *testing.T) {
@@ -101,5 +103,105 @@ func TestPackState(t *testing.T) {
 		expectedPackedState := "0x3e9dd25a843e3a234c278c6f3fab3983949e2404b276cacb3c47ada06e00f74b0000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000022000000000000000000000000000000000000000000000000000000000000000180000000000000000000000000000000000000000000000000000000000000002756774c79382894c7bdc8e9fe73285e1650c10c820b05a8bba7d0aace4adb92a000000000000000000000000000000000000000000000000000000000000002a00000000000000000000000090b7e285ab6cf4e3a2487669dba3e339db8a332000000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000011e1a300000000000000000000000000000000000000000000000000000000000bebc2010000000000000000000000000000000000000000000000000000000000000000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffa0a1f010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
 		packedHex := hexutil.Encode(packed)
 		assert.Equal(t, expectedPackedState, packedHex, "Packed state should match expected value")
+	})
+}
+
+// TestPackState_RejectsOutOfRangeValues guards against ABI silently truncating
+// values to the low 256 bits. Each subtest sets a ledger field beyond its
+// Solidity type range and expects PackState to error.
+func TestPackState_RejectsOutOfRangeValues(t *testing.T) {
+	t.Parallel()
+
+	channelID := "0x3e9dd25a843e3a234c278c6f3fab3983949e2404b276cacb3c47ada06e00f74b"
+	overflow256 := new(big.Int).Lsh(big.NewInt(1), 256) // 2^256
+	overflow255 := new(big.Int).Lsh(big.NewInt(1), 255) // 2^255
+
+	homeToken := "0x90b7E285ab6cf4e3A2487669dba3E339dB8a3320"
+	escrowToken := "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+
+	newBaseState := func() State {
+		return State{
+			Version:       1,
+			Asset:         "test",
+			HomeChannelID: &channelID,
+			Transition:    *NewTransition(TransitionTypeHomeDeposit, "tx", "acct", decimal.NewFromInt(1)),
+			HomeLedger: Ledger{
+				BlockchainID: 42,
+				TokenAddress: homeToken,
+				UserBalance:  decimal.Zero,
+				UserNetFlow:  decimal.Zero,
+				NodeBalance:  decimal.Zero,
+				NodeNetFlow:  decimal.Zero,
+			},
+		}
+	}
+
+	newEscrowLedger := func() *Ledger {
+		return &Ledger{
+			BlockchainID: 4242,
+			TokenAddress: escrowToken,
+			UserBalance:  decimal.Zero,
+			UserNetFlow:  decimal.Zero,
+			NodeBalance:  decimal.Zero,
+			NodeNetFlow:  decimal.Zero,
+		}
+	}
+
+	newStore := func() *mockAssetStore {
+		store := newMockAssetStore()
+		store.AddToken(42, homeToken, 0)
+		store.AddToken(4242, escrowToken, 0)
+		return store
+	}
+
+	t.Run("user_balance_overflows_uint256", func(t *testing.T) {
+		t.Parallel()
+
+		state := newBaseState()
+		state.HomeLedger.UserBalance = decimal.NewFromBigInt(overflow256, 0)
+		state.HomeLedger.UserNetFlow = decimal.NewFromBigInt(overflow256, 0)
+
+		_, err := NewStatePackerV1(newStore()).PackState(state)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "uint256")
+	})
+
+	t.Run("user_net_flow_overflows_int256", func(t *testing.T) {
+		t.Parallel()
+
+		state := newBaseState()
+		// balance fits uint256 but net flow exceeds int256
+		state.HomeLedger.UserBalance = decimal.NewFromBigInt(overflow255, 0)
+		state.HomeLedger.UserNetFlow = decimal.NewFromBigInt(overflow255, 0)
+
+		_, err := NewStatePackerV1(newStore()).PackState(state)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "int256")
+	})
+
+	t.Run("escrow_user_balance_overflows_uint256", func(t *testing.T) {
+		t.Parallel()
+
+		state := newBaseState()
+		state.EscrowLedger = newEscrowLedger()
+		state.EscrowLedger.UserBalance = decimal.NewFromBigInt(overflow256, 0)
+		state.EscrowLedger.UserNetFlow = decimal.NewFromBigInt(overflow256, 0)
+
+		_, err := NewStatePackerV1(newStore()).PackState(state)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "uint256")
+	})
+
+	t.Run("escrow_user_net_flow_overflows_int256", func(t *testing.T) {
+		t.Parallel()
+
+		state := newBaseState()
+		state.EscrowLedger = newEscrowLedger()
+		state.EscrowLedger.UserBalance = decimal.NewFromBigInt(overflow255, 0)
+		state.EscrowLedger.UserNetFlow = decimal.NewFromBigInt(overflow255, 0)
+
+		_, err := NewStatePackerV1(newStore()).PackState(state)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "int256")
 	})
 }

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -175,6 +175,44 @@ func NewVoidState(asset, userWallet string) *State {
 	}
 }
 
+// NewChallengeRescueState constructs a fully-formed ChallengeRescue state derived from
+// prev — the user's last known state for the asset whose home channel is being closed
+// after a challenge. The rescue state opens a fresh epoch at version 1 with no home
+// channel and no token/blockchain context (the closed channel is gone); it credits the
+// user the rescued amount as a standalone ledger entry referencing the closed channel
+// (taken from prev.HomeChannelID) via the transition's AccountID. The rescue state is
+// meant to be stored unsigned, like a credit to a user with no open home channel.
+func NewChallengeRescueState(prev State, amount decimal.Decimal) (*State, error) {
+	if prev.HomeChannelID == nil {
+		return nil, fmt.Errorf("prev state has no home channel ID")
+	}
+	if amount.IsNegative() {
+		return nil, fmt.Errorf("challenge rescue amount must be non-negative")
+	}
+
+	closedChannelID := *prev.HomeChannelID
+	rescue := &State{
+		Asset:      prev.Asset,
+		UserWallet: prev.UserWallet,
+		Epoch:      prev.Epoch + 1,
+		Version:    1,
+		HomeLedger: Ledger{
+			UserBalance: amount,
+			UserNetFlow: decimal.Zero,
+			NodeBalance: decimal.Zero,
+			NodeNetFlow: amount,
+		},
+	}
+	rescue.ID = GetStateID(rescue.UserWallet, rescue.Asset, rescue.Epoch, rescue.Version)
+
+	txID, err := GetReceiverTransactionID(closedChannelID, rescue.ID)
+	if err != nil {
+		return nil, err
+	}
+	rescue.Transition = *NewTransition(TransitionTypeChallengeRescue, txID, closedChannelID, amount)
+	return rescue, nil
+}
+
 func (state State) NextState() *State {
 	var nextState *State
 	if state.IsFinal() {
@@ -643,6 +681,10 @@ const (
 	TransactionTypeMutualLock TransactionType = 120
 
 	TransactionTypeFinalize = 200
+
+	// TransactionTypeChallengeRescue mirrors TransitionTypeChallengeRescue and records
+	// the squashed credit produced when a challenged home channel is closed onchain.
+	TransactionTypeChallengeRescue TransactionType = 201
 )
 
 // String returns the human-readable name of the transaction type
@@ -672,6 +714,8 @@ func (t TransactionType) String() string {
 		return "rebalance"
 	case TransactionTypeFinalize:
 		return "finalize"
+	case TransactionTypeChallengeRescue:
+		return "challenge_rescue"
 	default:
 		return "unknown"
 	}
@@ -711,8 +755,8 @@ func NewTransactionFromTransition(senderState *State, receiverState *State, tran
 	var toAccount, fromAccount string
 	// Transition validator is expected to make sure that all the fields are present and valid.
 
-	if transition.Type != TransitionTypeRelease && senderState == nil {
-		return nil, fmt.Errorf("sender state must not be nil for non-release transitions")
+	if transition.Type != TransitionTypeRelease && transition.Type != TransitionTypeChallengeRescue && senderState == nil {
+		return nil, fmt.Errorf("sender state must not be nil for non-release / non-challenge-rescue transitions")
 	}
 
 	var senderStateID *string
@@ -815,6 +859,13 @@ func NewTransactionFromTransition(senderState *State, receiverState *State, tran
 		txType = TransactionTypeFinalize
 		fromAccount = senderState.UserWallet
 		toAccount = *senderState.HomeChannelID
+	case TransitionTypeChallengeRescue:
+		if receiverState == nil {
+			return nil, fmt.Errorf("receiver state must not be nil for 'challenge_rescue' transition")
+		}
+		txType = TransactionTypeChallengeRescue
+		fromAccount = transition.AccountID
+		toAccount = receiverState.UserWallet
 	default:
 		return nil, fmt.Errorf("invalid transition type")
 	}
@@ -868,6 +919,13 @@ const (
 	TransitionTypeMutualLock TransitionType = 120 // AccountID: EscrowChannelID
 
 	TransitionTypeFinalize TransitionType = 200 // AccountID: HomeChannelID
+
+	// TransitionTypeChallengeRescue is issued by the node when a challenged home channel
+	// is closed onchain with a non-finalize transition. It squashes the sum of receiver
+	// states accrued under the no-sign-while-challenged rule into a single credit on the
+	// user's ledger, with AccountID set to the closed channel ID and HomeChannelID nil.
+	// Only the node can produce this transition; it has no state-advancer validation rule.
+	TransitionTypeChallengeRescue TransitionType = 201 // AccountID: closed HomeChannelID
 )
 
 // String returns the human-readable name of the transition type
@@ -901,6 +959,8 @@ func (t TransitionType) String() string {
 		return "migrate"
 	case TransitionTypeFinalize:
 		return "finalize"
+	case TransitionTypeChallengeRescue:
+		return "challenge_rescue"
 	default:
 		return "unknown"
 	}

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -638,7 +638,12 @@ func (l1 Ledger) Equal(l2 Ledger) error {
 	return nil
 }
 
-func (l Ledger) Validate() error {
+// Validate checks ledger invariants and ensures all four scaled values fit the
+// Solidity ABI ranges used for signing and onchain calls. Balances must fit
+// uint256 ([0, 2^256-1]); net flows must fit int256 ([-2^255, 2^255-1]).
+// assetDecimals is the token's decimal exponent, used to scale decimal values
+// to their smallest onchain units before the range check.
+func (l Ledger) Validate(assetDecimals uint8) error {
 	if l.TokenAddress == "" {
 		return fmt.Errorf("invalid token address")
 	}
@@ -655,6 +660,19 @@ func (l Ledger) Validate() error {
 	sumNetFlows := l.UserNetFlow.Add(l.NodeNetFlow)
 	if !sumBalances.Equal(sumNetFlows) {
 		return fmt.Errorf("ledger balances do not match net flows: balances=%s, net_flows=%s", sumBalances.String(), sumNetFlows.String())
+	}
+
+	if _, err := DecimalToUint256(l.UserBalance, assetDecimals); err != nil {
+		return fmt.Errorf("user balance out of uint256 range: %w", err)
+	}
+	if _, err := DecimalToUint256(l.NodeBalance, assetDecimals); err != nil {
+		return fmt.Errorf("node balance out of uint256 range: %w", err)
+	}
+	if _, err := DecimalToInt256(l.UserNetFlow, assetDecimals); err != nil {
+		return fmt.Errorf("user net flow out of int256 range: %w", err)
+	}
+	if _, err := DecimalToInt256(l.NodeNetFlow, assetDecimals); err != nil {
+		return fmt.Errorf("node net flow out of int256 range: %w", err)
 	}
 
 	return nil

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -177,11 +177,22 @@ func NewVoidState(asset, userWallet string) *State {
 
 // NewChallengeRescueState constructs a fully-formed ChallengeRescue state derived from
 // prev — the user's last known state for the asset whose home channel is being closed
-// after a challenge. The rescue state opens a fresh epoch at version 1 with no home
+// after a challenge. The rescue state opens a fresh epoch at version 0 with no home
 // channel and no token/blockchain context (the closed channel is gone); it credits the
 // user the rescued amount as a standalone ledger entry referencing the closed channel
 // (taken from prev.HomeChannelID) via the transition's AccountID. The rescue state is
 // meant to be stored unsigned, like a credit to a user with no open home channel.
+//
+// Version 0 matches the NextState() post-final convention: any in-protocol fresh-epoch
+// state starts at version 0. Callers must guarantee no other (epoch+1, version=0) row
+// already exists for this (wallet, asset) — for the rescue path this is enforced by
+// only invoking it on non-Finalize challenge closes (see HandleHomeChannelClosed).
+//
+// Not a general-purpose constructor: the sole authorized callsite is
+// EventHandlerService.issueChallengeRescue, which gates invocation on
+// HasSignedFinalize=false. Adding a second callsite without an equivalent guard will
+// cause StoreUserState to fail with a deterministic GetStateID collision against an
+// existing (epoch+1, version=0) row.
 func NewChallengeRescueState(prev State, amount decimal.Decimal) (*State, error) {
 	if prev.HomeChannelID == nil {
 		return nil, fmt.Errorf("prev state has no home channel ID")
@@ -195,7 +206,7 @@ func NewChallengeRescueState(prev State, amount decimal.Decimal) (*State, error)
 		Asset:      prev.Asset,
 		UserWallet: prev.UserWallet,
 		Epoch:      prev.Epoch + 1,
-		Version:    1,
+		Version:    0,
 		HomeLedger: Ledger{
 			UserBalance: amount,
 			UserNetFlow: decimal.Zero,

--- a/pkg/core/types_test.go
+++ b/pkg/core/types_test.go
@@ -215,7 +215,7 @@ func TestNewChallengeRescueState(t *testing.T) {
 		}
 	}
 
-	t.Run("Success - opens fresh epoch at version 1 with no channel context", func(t *testing.T) {
+	t.Run("Success - opens fresh epoch at version 0 with no channel context", func(t *testing.T) {
 		prev := makePrev()
 		amount := decimal.NewFromInt(42)
 
@@ -226,7 +226,7 @@ func TestNewChallengeRescueState(t *testing.T) {
 		assert.Equal(t, prev.Asset, rescue.Asset)
 		assert.Equal(t, prev.UserWallet, rescue.UserWallet)
 		assert.Equal(t, prev.Epoch+1, rescue.Epoch)
-		assert.Equal(t, uint64(1), rescue.Version)
+		assert.Equal(t, uint64(0), rescue.Version)
 		assert.Nil(t, rescue.HomeChannelID)
 		assert.Empty(t, rescue.HomeLedger.TokenAddress)
 		assert.Equal(t, uint64(0), rescue.HomeLedger.BlockchainID)

--- a/pkg/core/types_test.go
+++ b/pkg/core/types_test.go
@@ -444,26 +444,26 @@ func TestLedger_Equal_Validate(t *testing.T) {
 	}
 	l2 := l1
 	assert.NoError(t, l1.Equal(l2))
-	assert.NoError(t, l1.Validate())
+	assert.NoError(t, l1.Validate(6))
 
 	l2.TokenAddress = "0xOther"
 	assert.Error(t, l1.Equal(l2))
 
 	lInvalid := l1
 	lInvalid.TokenAddress = ""
-	assert.Error(t, lInvalid.Validate())
+	assert.Error(t, lInvalid.Validate(6))
 
 	lInvalid = l1
 	lInvalid.BlockchainID = 0
-	assert.Error(t, lInvalid.Validate())
+	assert.Error(t, lInvalid.Validate(6))
 
 	lInvalid = l1
 	lInvalid.UserBalance = decimal.NewFromInt(-1)
-	assert.Error(t, lInvalid.Validate())
+	assert.Error(t, lInvalid.Validate(6))
 
 	lInvalid = l1
 	lInvalid.UserNetFlow = decimal.NewFromInt(999) // Mismatch
-	assert.Error(t, lInvalid.Validate())
+	assert.Error(t, lInvalid.Validate(6))
 }
 
 func TestTransactionType_String(t *testing.T) {

--- a/pkg/core/types_test.go
+++ b/pkg/core/types_test.go
@@ -194,6 +194,80 @@ func TestState_ApplyReleaseTransition(t *testing.T) {
 	assert.Equal(t, "10", state.HomeLedger.UserBalance.String())
 }
 
+func TestNewChallengeRescueState(t *testing.T) {
+	t.Parallel()
+
+	closedChannelID := "0xClosedChannel"
+	makePrev := func() State {
+		channelID := closedChannelID
+		return State{
+			Asset:         "USDC",
+			UserWallet:    "0xUser",
+			Epoch:         3,
+			Version:       7,
+			HomeChannelID: &channelID,
+			HomeLedger: Ledger{
+				TokenAddress: "0xToken",
+				BlockchainID: 1,
+				UserBalance:  decimal.NewFromInt(50),
+				UserNetFlow:  decimal.NewFromInt(50),
+			},
+		}
+	}
+
+	t.Run("Success - opens fresh epoch at version 1 with no channel context", func(t *testing.T) {
+		prev := makePrev()
+		amount := decimal.NewFromInt(42)
+
+		rescue, err := NewChallengeRescueState(prev, amount)
+		require.NoError(t, err)
+		require.NotNil(t, rescue)
+
+		assert.Equal(t, prev.Asset, rescue.Asset)
+		assert.Equal(t, prev.UserWallet, rescue.UserWallet)
+		assert.Equal(t, prev.Epoch+1, rescue.Epoch)
+		assert.Equal(t, uint64(1), rescue.Version)
+		assert.Nil(t, rescue.HomeChannelID)
+		assert.Empty(t, rescue.HomeLedger.TokenAddress)
+		assert.Equal(t, uint64(0), rescue.HomeLedger.BlockchainID)
+		assert.True(t, amount.Equal(rescue.HomeLedger.UserBalance))
+		assert.True(t, amount.Equal(rescue.HomeLedger.NodeNetFlow))
+		assert.True(t, rescue.HomeLedger.UserNetFlow.IsZero())
+		assert.True(t, rescue.HomeLedger.NodeBalance.IsZero())
+
+		assert.Equal(t, TransitionTypeChallengeRescue, rescue.Transition.Type)
+		assert.Equal(t, closedChannelID, rescue.Transition.AccountID)
+		assert.True(t, amount.Equal(rescue.Transition.Amount))
+
+		expectedTxID, err := GetReceiverTransactionID(closedChannelID, rescue.ID)
+		require.NoError(t, err)
+		assert.Equal(t, expectedTxID, rescue.Transition.TxID)
+	})
+
+	t.Run("Accepts zero amount", func(t *testing.T) {
+		prev := makePrev()
+		rescue, err := NewChallengeRescueState(prev, decimal.Zero)
+		require.NoError(t, err)
+		require.NotNil(t, rescue)
+		assert.True(t, rescue.Transition.Amount.IsZero())
+		assert.True(t, rescue.HomeLedger.UserBalance.IsZero())
+		assert.True(t, rescue.HomeLedger.NodeNetFlow.IsZero())
+	})
+
+	t.Run("Rejects negative amount", func(t *testing.T) {
+		prev := makePrev()
+		_, err := NewChallengeRescueState(prev, decimal.NewFromInt(-1))
+		require.Error(t, err)
+	})
+
+	t.Run("Rejects prev state without home channel", func(t *testing.T) {
+		prev := makePrev()
+		prev.HomeChannelID = nil
+		_, err := NewChallengeRescueState(prev, decimal.NewFromInt(1))
+		require.Error(t, err)
+	})
+}
+
 func TestState_ApplyMutualLockTransition(t *testing.T) {
 	t.Parallel()
 	state := NewVoidState("USDC", "0xUser")

--- a/pkg/core/utils.go
+++ b/pkg/core/utils.go
@@ -7,9 +7,16 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
+	ethmath "github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/shopspring/decimal"
 )
+
+// maxInt256 = 2^255 - 1, the largest value representable as Solidity int256.
+var maxInt256 = new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 255), big.NewInt(1))
+
+// minInt256 = -2^255, the smallest value representable as Solidity int256.
+var minInt256 = new(big.Int).Neg(new(big.Int).Lsh(big.NewInt(1), 255))
 
 const (
 	// ChannelHubVersion is the version of the ChannelHub contract that this code is compatible with.
@@ -85,22 +92,54 @@ func ValidateDecimalPrecision(amount decimal.Decimal, maxDecimals uint8) error {
 	return nil
 }
 
-// DecimalToBigInt converts a decimal.Decimal amount to *big.Int scaled to the token's smallest unit.
-// For example, 1.23 USDC (6 decimals) becomes 1230000.
-// This is used when preparing amounts for smart contract calls.
-func DecimalToBigInt(amount decimal.Decimal, decimals uint8) (*big.Int, error) {
-	// 1. Calculate the multiplier (e.g., 10^6)
+// decimalToBigInt scales a decimal amount to the token's smallest unit and
+// returns an unbounded *big.Int. Internal helper for DecimalToUint256 /
+// DecimalToInt256; callers outside this file must use the bounded variants so
+// values exceeding the Solidity ABI range are rejected rather than silently
+// truncated.
+func decimalToBigInt(amount decimal.Decimal, decimals uint8) (*big.Int, error) {
 	multiplier := decimal.New(1, int32(decimals))
-
-	// 2. Scale the amount
 	scaled := amount.Mul(multiplier)
 
 	if !scaled.IsInteger() {
 		return nil, fmt.Errorf("amount %s exceeds maximum decimal precision: max %d decimals allowed", amount.String(), decimals)
 	}
 
-	// 4. Safe to convert
 	return scaled.BigInt(), nil
+}
+
+// DecimalToUint256 scales amount to the token's smallest unit and rejects values
+// outside the Solidity uint256 range [0, 2^256 - 1]. Use for allocation/balance
+// fields that are ABI-encoded as uint256 prior to signing or onchain submission.
+func DecimalToUint256(amount decimal.Decimal, decimals uint8) (*big.Int, error) {
+	scaled, err := decimalToBigInt(amount, decimals)
+	if err != nil {
+		return nil, err
+	}
+	if scaled.Sign() < 0 {
+		return nil, fmt.Errorf("amount %s is negative, expected uint256 range [0, 2^256-1]", amount.String())
+	}
+	if scaled.Cmp(ethmath.MaxBig256) > 0 {
+		return nil, fmt.Errorf("amount %s exceeds uint256 max (2^256-1)", amount.String())
+	}
+	return scaled, nil
+}
+
+// DecimalToInt256 scales amount to the token's smallest unit and rejects values
+// outside the Solidity int256 range [-2^255, 2^255 - 1]. Use for net-flow fields
+// that are ABI-encoded as int256 prior to signing or onchain submission.
+func DecimalToInt256(amount decimal.Decimal, decimals uint8) (*big.Int, error) {
+	scaled, err := decimalToBigInt(amount, decimals)
+	if err != nil {
+		return nil, err
+	}
+	if scaled.Cmp(maxInt256) > 0 {
+		return nil, fmt.Errorf("amount %s exceeds int256 max (2^255-1)", amount.String())
+	}
+	if scaled.Cmp(minInt256) < 0 {
+		return nil, fmt.Errorf("amount %s below int256 min (-2^255)", amount.String())
+	}
+	return scaled, nil
 }
 
 // getHomeChannelID is the internal implementation that generates a unique identifier for a primary channel

--- a/pkg/core/utils_test.go
+++ b/pkg/core/utils_test.go
@@ -370,7 +370,7 @@ func TestDecimalToBigInt(t *testing.T) {
 			amount, err := decimal.NewFromString(tt.amount)
 			assert.NoError(t, err, "Test setup error: invalid amount string")
 
-			result, err := DecimalToBigInt(amount, tt.decimals)
+			result, err := decimalToBigInt(amount, tt.decimals)
 			assert.NoError(t, err)
 
 			expected, ok := new(big.Int).SetString(tt.expected, 10)
@@ -386,7 +386,7 @@ func TestDecimalToBigInt_NegativeAmounts(t *testing.T) {
 	t.Run("negative_usdc", func(t *testing.T) {
 		t.Parallel()
 		amount := decimal.NewFromFloat(-1.23)
-		result, err := DecimalToBigInt(amount, 6)
+		result, err := decimalToBigInt(amount, 6)
 		assert.NoError(t, err)
 		expected := big.NewInt(-1230000)
 		assert.Equal(t, expected.String(), result.String(), "Negative amounts should be handled correctly")
@@ -395,7 +395,7 @@ func TestDecimalToBigInt_NegativeAmounts(t *testing.T) {
 	t.Run("negative_eth", func(t *testing.T) {
 		t.Parallel()
 		amount := decimal.NewFromFloat(-0.5)
-		result, err := DecimalToBigInt(amount, 18)
+		result, err := decimalToBigInt(amount, 18)
 		assert.NoError(t, err)
 		expected, _ := new(big.Int).SetString("-500000000000000000", 10)
 		assert.Equal(t, expected.String(), result.String(), "Negative ETH amount should convert correctly")
@@ -404,7 +404,7 @@ func TestDecimalToBigInt_NegativeAmounts(t *testing.T) {
 	t.Run("negative_zero", func(t *testing.T) {
 		t.Parallel()
 		amount := decimal.NewFromInt(0)
-		result, err := DecimalToBigInt(amount, 6)
+		result, err := decimalToBigInt(amount, 6)
 		assert.NoError(t, err)
 		expected := big.NewInt(0)
 		assert.Equal(t, expected.String(), result.String(), "Zero should always be zero")
@@ -418,7 +418,7 @@ func TestDecimalToBigInt_EdgeCases(t *testing.T) {
 		// Test with a very large amount
 		amount, err := decimal.NewFromString("999999999999999999.123456")
 		assert.NoError(t, err)
-		result, err := DecimalToBigInt(amount, 6)
+		result, err := decimalToBigInt(amount, 6)
 		assert.NoError(t, err)
 		// 999999999999999999.123456 * 10^6 = 999999999999999999123456
 		expected, ok := new(big.Int).SetString("999999999999999999123456", 10)
@@ -430,7 +430,7 @@ func TestDecimalToBigInt_EdgeCases(t *testing.T) {
 		t.Parallel()
 		// Test with an amount that has more decimals than supported
 		amount := decimal.NewFromFloat(0.0000001) // 7 decimals
-		_, err := DecimalToBigInt(amount, 6)      // Only 6 decimal precision
+		_, err := decimalToBigInt(amount, 6)      // Only 6 decimal precision
 		// This should return an error because the amount has more decimal places than allowed
 		// After scaling: 0.0000001 * 10^6 = 0.1, which still has a fractional part
 		assert.Error(t, err, "Amount with more decimals than supported should return an error")
@@ -441,7 +441,7 @@ func TestDecimalToBigInt_EdgeCases(t *testing.T) {
 		t.Parallel()
 		// Test with maximum uint8 value for decimals (not practical, but edge case)
 		amount := decimal.NewFromInt(1)
-		result, err := DecimalToBigInt(amount, 255)
+		result, err := decimalToBigInt(amount, 255)
 		assert.NoError(t, err)
 		// 1 * 10^255 should work
 		expected := new(big.Int).Exp(big.NewInt(10), big.NewInt(255), nil)
@@ -453,7 +453,7 @@ func TestDecimalToBigInt_EdgeCases(t *testing.T) {
 		// Test that we don't lose precision during conversion
 		amount, err := decimal.NewFromString("123.456789")
 		assert.NoError(t, err)
-		result, err := DecimalToBigInt(amount, 6)
+		result, err := decimalToBigInt(amount, 6)
 		assert.NoError(t, err)
 		// 123.456789 * 10^6 = 123456789
 		expected := big.NewInt(123456789)
@@ -471,7 +471,7 @@ func TestDecimalToBigInt_RoundTrip(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Convert to big.Int
-		bigIntValue, err := DecimalToBigInt(amount, 6)
+		bigIntValue, err := decimalToBigInt(amount, 6)
 		assert.NoError(t, err)
 		// Convert back to decimal
 		divisor := decimal.New(1, 6) // 10^6
@@ -722,5 +722,111 @@ func TestGetStateTransitionsHash(t *testing.T) {
 			"0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",                         // 20-byte address
 			decimal.NewFromInt(-100)))
 		assert.NoError(t, err)
+	})
+}
+
+func TestDecimalToUint256(t *testing.T) {
+	t.Parallel()
+
+	// 2^256 - 1, max uint256
+	maxUint256, ok := new(big.Int).SetString("115792089237316195423570985008687907853269984665640564039457584007913129639935", 10)
+	require.True(t, ok)
+	// 2^256, one above the limit
+	overflow := new(big.Int).Add(maxUint256, big.NewInt(1))
+
+	t.Run("zero", func(t *testing.T) {
+		t.Parallel()
+		got, err := DecimalToUint256(decimal.Zero, 18)
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), got.Int64())
+	})
+
+	t.Run("small_positive", func(t *testing.T) {
+		t.Parallel()
+		amount := decimal.NewFromInt(1234)
+		got, err := DecimalToUint256(amount, 0)
+		require.NoError(t, err)
+		assert.Equal(t, int64(1234), got.Int64())
+	})
+
+	t.Run("max_uint256_accepted", func(t *testing.T) {
+		t.Parallel()
+		amount := decimal.NewFromBigInt(maxUint256, 0)
+		got, err := DecimalToUint256(amount, 0)
+		require.NoError(t, err)
+		assert.Equal(t, 0, got.Cmp(maxUint256))
+	})
+
+	t.Run("one_over_uint256_rejected", func(t *testing.T) {
+		t.Parallel()
+		amount := decimal.NewFromBigInt(overflow, 0)
+		_, err := DecimalToUint256(amount, 0)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeds uint256 max")
+	})
+
+	t.Run("scaling_pushes_over_uint256", func(t *testing.T) {
+		t.Parallel()
+		// value at uint256 max with 1 extra decimal of scale exceeds the range.
+		amount := decimal.NewFromBigInt(maxUint256, 0)
+		_, err := DecimalToUint256(amount, 1)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeds uint256 max")
+	})
+
+	t.Run("negative_rejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := DecimalToUint256(decimal.NewFromInt(-1), 0)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "negative")
+	})
+}
+
+func TestDecimalToInt256(t *testing.T) {
+	t.Parallel()
+
+	maxInt, ok := new(big.Int).SetString("57896044618658097711785492504343953926634992332820282019728792003956564819967", 10) // 2^255 - 1
+	require.True(t, ok)
+	minInt := new(big.Int).Neg(new(big.Int).Lsh(big.NewInt(1), 255)) // -2^255
+	overMax := new(big.Int).Add(maxInt, big.NewInt(1))
+	underMin := new(big.Int).Sub(minInt, big.NewInt(1))
+
+	t.Run("zero", func(t *testing.T) {
+		t.Parallel()
+		got, err := DecimalToInt256(decimal.Zero, 18)
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), got.Int64())
+	})
+
+	t.Run("max_int256_accepted", func(t *testing.T) {
+		t.Parallel()
+		amount := decimal.NewFromBigInt(maxInt, 0)
+		got, err := DecimalToInt256(amount, 0)
+		require.NoError(t, err)
+		assert.Equal(t, 0, got.Cmp(maxInt))
+	})
+
+	t.Run("min_int256_accepted", func(t *testing.T) {
+		t.Parallel()
+		amount := decimal.NewFromBigInt(minInt, 0)
+		got, err := DecimalToInt256(amount, 0)
+		require.NoError(t, err)
+		assert.Equal(t, 0, got.Cmp(minInt))
+	})
+
+	t.Run("one_over_max_rejected", func(t *testing.T) {
+		t.Parallel()
+		amount := decimal.NewFromBigInt(overMax, 0)
+		_, err := DecimalToInt256(amount, 0)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeds int256 max")
+	})
+
+	t.Run("one_under_min_rejected", func(t *testing.T) {
+		t.Parallel()
+		amount := decimal.NewFromBigInt(underMin, 0)
+		_, err := DecimalToInt256(amount, 0)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "below int256 min")
 	})
 }

--- a/protocol-description.md
+++ b/protocol-description.md
@@ -434,6 +434,8 @@ Migration enables moving the channel's "home" security chain from one blockchain
 
 Like other cross-chain operations, migration is **two-phase** and **optimistic**.
 
+> **NOTE:** Home chain migration is **not yet active in the Nitronode off-chain implementation**. The on-chain `ChannelHub` contract fully implements both `initiateMigration()` and `finalizeMigration()`, and the migration protocol is fully specified below. The Nitronode off-chain flow — including the `migrate` transition type, two-chain event coordination, and the `MigrationInInitiated` / `MigrationOutFinalized` lifecycle — has not yet been implemented. Submitting a `migrate` transition via the `channels.v1.submit_state` RPC method returns an error. This section documents the intended design for future implementation.
+
 ---
 
 ### Preparation phase (INITIATE_MIGRATION)

--- a/protocol-description.md
+++ b/protocol-description.md
@@ -290,6 +290,23 @@ Invariant:
 
 ---
 
+### Off-chain behaviour during dispute
+
+While a channel is in `CHALLENGED` (i.e. on-chain `DISPUTED`) status, the Node and the user follow additional off-chain rules:
+
+* **Node stops signing receive states.** Incoming off-chain transfer credits and app-session release credits targeting the channel are not co-signed. They are appended as unsigned entries to the channel's state history (a per-channel queue).
+* **User-initiated operations are blocked.** The user cannot deposit, withdraw, transfer, or lock funds into an app session. Only receiving funds (which the Node queues per the previous rule) is permitted.
+* **Operations remain blocked even after the challenge timer expires**, until the channel is explicitly closed and `ChannelClosed` event is seen by the Node.
+
+Two resolution paths:
+
+* **Challenge cleared** (a newer mutually signed state is enforced, returning the channel to `OPERATING`): the Node signs only the off-chain head — the highest-version queued "receive" state — so the channel's actual latest state is fully co-signed; the user countersigns and acknowledges. Earlier queued entries remain unsigned in history; the head carries forward their cumulative balance impact, so normal flow resumes with no gap and no credit lost.
+* **Challenge expires and the channel is closed**: a single `challenge_rescue` state is committed to the user's next epoch, detached from the closed channel — equivalent to the funds arriving while the user did not have a channel. Its amount is the **net effect on the home-channel balance of transitions stored strictly above the closure version** at the closed channel's epoch: receives (`transfer_receive`, `release`) contribute positively; sends (`transfer_send`, `commit`) contribute negatively; other transition kinds (deposit, withdrawal, escrow, migrate, finalize) are excluded because they require onchain backing the chain did not enforce. Signed (pre-challenge) and unsigned (during-challenge) rows both contribute. The result is clamped at zero so an adversarial close at a version where the user's own balance was higher than the off-chain head cannot dock the user further. When no relevant transitions exist above closure, the state carries zero credit and serves only to advance the state chain off the closed channel so future operations are not wedged on it.
+
+The purpose of these rules is to ensure that a `CHALLENGED` channel cannot have its dispute cleared as a side effect of incoming third-party transfers, and that the user is made whole for net real value owed by the Node regardless of which resolution path is taken.
+
+---
+
 ## Channel closure
 
 A channel can be closed:

--- a/sdk/go/channel.go
+++ b/sdk/go/channel.go
@@ -755,6 +755,11 @@ func (c *Client) GetHomeChannel(ctx context.Context, wallet, asset string) (*cor
 //   - Channel information for the escrow channel
 //   - Error if the request fails
 //
+// Note: when the escrow channel has been closed by the on-chain purge queue
+// (no signed FINALIZE_ESCROW_DEPOSIT was received before expiry), StateVersion
+// on the returned channel reflects the initiate version (N) and does not advance
+// to the finalize version (N+1).
+//
 // Example:
 //
 //	channel, err := client.GetEscrowChannel(ctx, "0x1234...")

--- a/sdk/ts/src/app/packing.ts
+++ b/sdk/ts/src/app/packing.ts
@@ -1,4 +1,4 @@
-import { Address, Hex, encodeAbiParameters, keccak256, toHex } from 'viem';
+import { Address, encodeAbiParameters, keccak256, toHex } from 'viem';
 import {
   AppDefinitionV1,
   AppStateUpdateV1,

--- a/sdk/ts/src/app/packing.ts
+++ b/sdk/ts/src/app/packing.ts
@@ -1,4 +1,4 @@
-import { Address, Hex, encodeAbiParameters, keccak256, pad, toHex } from 'viem';
+import { Address, Hex, encodeAbiParameters, keccak256, toHex } from 'viem';
 import {
   AppDefinitionV1,
   AppStateUpdateV1,
@@ -208,45 +208,19 @@ export function packAppV1(app: AppV1): `0x${string}` {
 }
 
 /**
- * hexToBytes32 converts a hex string to a 32-byte value, matching Go's common.HexToHash behavior.
- * - Strips "0x" prefix if present
- * - Decodes hex characters; non-hex strings produce zero bytes
- * - Right-aligns the result in 32 bytes (left-padded with zeros)
- */
-function hexToBytes32(s: string): Hex {
-  // Strip 0x prefix
-  let hex = s.startsWith('0x') || s.startsWith('0X') ? s.slice(2) : s;
-  // Pad to even length
-  if (hex.length % 2 === 1) {
-    hex = '0' + hex;
-  }
-  // Validate hex characters - if any invalid char, return zero hash (matches Go behavior)
-  if (!/^[0-9a-fA-F]*$/.test(hex)) {
-    return pad('0x00', { size: 32 }) as Hex;
-  }
-  // If empty, return zero hash
-  if (hex.length === 0) {
-    return pad('0x00', { size: 32 }) as Hex;
-  }
-  // Truncate to 32 bytes max (64 hex chars)
-  if (hex.length > 64) {
-    hex = hex.slice(hex.length - 64);
-  }
-  // Left-pad to 64 hex chars (32 bytes)
-  const padded = hex.padStart(64, '0');
-  return `0x${padded}` as Hex;
-}
-
-/**
  * PackAppSessionKeyStateV1 packs the app session key state for signing using ABI encoding.
  * Matches Go SDK's PackAppSessionKeyStateV1.
+ *
+ * Application and app-session IDs are hashed with keccak256(utf8(id)) so that every
+ * distinct string produces a unique bytes32 — human-readable IDs like "app-1" and
+ * "app-2" can no longer collide in the signed payload.
  *
  * @param state - The app session key state to pack
  * @returns Keccak256 hash of the ABI-encoded state (excluding user_sig)
  */
 export function packAppSessionKeyStateV1(state: AppSessionKeyStateV1): `0x${string}` {
-  const applicationIDHashes = state.application_ids.map(hexToBytes32);
-  const appSessionIDHashes = state.app_session_ids.map(hexToBytes32);
+  const applicationIDHashes = state.application_ids.map((id) => keccak256(toHex(id)));
+  const appSessionIDHashes = state.app_session_ids.map((id) => keccak256(toHex(id)));
 
   const packed = encodeAbiParameters(
     [

--- a/sdk/ts/src/client.ts
+++ b/sdk/ts/src/client.ts
@@ -1279,6 +1279,11 @@ export class Client {
   /**
    * GetEscrowChannel retrieves escrow channel information for a specific channel ID.
    *
+   * Note: when the escrow channel has been closed by the on-chain purge queue
+   * (no signed FINALIZE_ESCROW_DEPOSIT was received before expiry), `stateVersion`
+   * on the returned channel reflects the initiate version (N) and does not advance
+   * to the finalize version (N+1).
+   *
    * @param escrowChannelId - The escrow channel ID to query
    * @returns Channel information for the escrow channel
    *

--- a/sdk/ts/src/core/utils.ts
+++ b/sdk/ts/src/core/utils.ts
@@ -437,12 +437,23 @@ export function getChannelSessionKeyAuthMetadataHashV1(
 }
 
 /**
- * Packs a channel session key state for signing.
- * Matches Go SDK's PackChannelKeyStateV1.
+ * Type hash for SessionKeyAuthorization, matching the Solidity constant
+ * SESSION_KEY_AUTH_TYPEHASH in SessionKeyValidator.sol.
+ * Prepended to the authorization payload to prevent reuse of unrelated
+ * abi.encode(address, bytes32) signatures as session-key authorizations.
+ */
+export const SESSION_KEY_AUTH_TYPEHASH: Hex = keccak256(
+  toHex('Nitrolite.SessionKey(address sessionKey,bytes32 metadataHash)')
+);
+
+/**
+ * Packs a channel session key authorization payload for signing.
+ * Matches Go SDK's PackChannelKeyStateV1 and Solidity's toSigningData(SessionKeyAuthorization).
+ * The payload is abi.encode(SESSION_KEY_AUTH_TYPEHASH, sessionKey, metadataHash) — 96 bytes total.
  *
  * @param sessionKey - The session key address
  * @param metadataHash - The metadata hash from getChannelSessionKeyAuthMetadataHashV1
- * @returns ABI-encoded (sessionKey, metadataHash) ready for EIP-191 signing
+ * @returns ABI-encoded (typehash, sessionKey, metadataHash) ready for EIP-191 signing
  */
 export function packChannelKeyStateV1(
   sessionKey: Address,
@@ -450,10 +461,11 @@ export function packChannelKeyStateV1(
 ): `0x${string}` {
   return encodeAbiParameters(
     [
+      { type: 'bytes32' },  // SESSION_KEY_AUTH_TYPEHASH
       { type: 'address' },  // session_key
       { type: 'bytes32' },  // hashed metadata
     ],
-    [sessionKey, metadataHash]
+    [SESSION_KEY_AUTH_TYPEHASH, sessionKey, metadataHash]
   );
 }
 

--- a/sdk/ts/test/unit/__snapshots__/public-api-drift.test.ts.snap
+++ b/sdk/ts/test/unit/__snapshots__/public-api-drift.test.ts.snap
@@ -1955,6 +1955,11 @@ exports[`SDK public runtime API drift guard keeps root TypeScript public API sig
     ],
   },
   {
+    "kind": "const",
+    "name": "SESSION_KEY_AUTH_TYPEHASH",
+    "type": "\`0x\${string}\`",
+  },
+  {
     "kind": "interface",
     "name": "SessionKey",
     "properties": [
@@ -2577,6 +2582,7 @@ exports[`SDK public runtime API drift guard keeps root runtime exports intention
   "NodeV1PingMethod",
   "RPCClient",
   "RPCError",
+  "SESSION_KEY_AUTH_TYPEHASH",
   "StateAdvancerV1",
   "StatePackerV1",
   "TransactionType",

--- a/sdk/ts/test/unit/app-signing-drift.test.ts
+++ b/sdk/ts/test/unit/app-signing-drift.test.ts
@@ -130,7 +130,7 @@ describe('Go/TS app signing drift vectors', () => {
 
     it('matches Go PackAppSessionKeyStateV1 vector', () => {
         expect(packAppSessionKeyStateV1(sessionKeyState)).toBe(
-            '0x9fedfbcd577c5e677b95b1273e38f52ffdeee096e98f731c5455e4c73e0274aa'
+            '0x6d404fa628918dbe4abec4ae2808c7ea01dc880ad4ad392ca2d0c4ce21f706c1'
         );
     });
 
@@ -236,6 +236,40 @@ describe('Go/TS app signing drift vectors', () => {
         });
 
         expect(normalized).not.toBe(canonical);
+    });
+
+    it('proves human-readable application IDs produce distinct hashes (no collision)', () => {
+        const base: AppSessionKeyStateV1 = {
+            user_address: user,
+            session_key: app,
+            version: '1',
+            application_ids: [],
+            app_session_ids: [],
+            expires_at: '1739812234',
+            user_sig: '',
+            session_key_sig: '',
+        };
+
+        const ids = ['app-1', 'app-2', 'trading', 'gaming', 'defi'];
+        const appIdHashes = new Set<string>();
+        for (const id of ids) {
+            const h = packAppSessionKeyStateV1({ ...base, application_ids: [id] });
+            expect(appIdHashes.has(h)).toBe(false);
+            appIdHashes.add(h);
+        }
+
+        // Same uniqueness requirement holds for app_session_ids.
+        const sessionIdHashes = new Set<string>();
+        for (const id of ids) {
+            const h = packAppSessionKeyStateV1({ ...base, app_session_ids: [id] });
+            expect(sessionIdHashes.has(h)).toBe(false);
+            sessionIdHashes.add(h);
+        }
+
+        // Empty string and whitespace must also be distinct.
+        const hashEmpty = packAppSessionKeyStateV1({ ...base, application_ids: [''] });
+        const hashSpace = packAppSessionKeyStateV1({ ...base, application_ids: [' '] });
+        expect(hashEmpty).not.toBe(hashSpace);
     });
 
     it('proves adversarial session-key ID placement changes the signed hash', () => {

--- a/sdk/ts/test/unit/core/utils.test.ts
+++ b/sdk/ts/test/unit/core/utils.test.ts
@@ -7,6 +7,8 @@ import {
   generateChannelMetadata,
   transitionToIntent,
   getStateTransitionHash,
+  SESSION_KEY_AUTH_TYPEHASH,
+  packChannelKeyStateV1,
 } from '../../../src/core/utils';
 import {
   TransitionType,
@@ -551,4 +553,30 @@ describe('getStateTransitionHash', () => {
     const hash = getStateTransitionHash(transition);
     expect(hash).toBeDefined();
   });
+});
+
+describe('SESSION_KEY_AUTH_TYPEHASH', () => {
+    // Golden value cross-checked against Solidity: keccak256("Nitrolite.SessionKey(address sessionKey,bytes32 metadataHash)")
+    // Verified by running Solidity test test_log_toSigningData in SessionKeyValidator.t.sol.
+    const EXPECTED = '0x251773da8b8949935ef07284d20cc8605ad7d6f4cf6b5e040ce07dae857f0b6c';
+
+    test('matches_solidity_constant', () => {
+        expect(SESSION_KEY_AUTH_TYPEHASH).toBe(EXPECTED);
+    });
+});
+
+describe('packChannelKeyStateV1', () => {
+    const sessionKey = '0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF' as `0x${string}`;
+    const metadataHash = '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890' as `0x${string}`;
+    // abi.encode(SESSION_KEY_AUTH_TYPEHASH, sessionKey, metadataHash)
+    const EXPECTED =
+        '0x' +
+        '251773da8b8949935ef07284d20cc8605ad7d6f4cf6b5e040ce07dae857f0b6c' + // typehash
+        '000000000000000000000000deadbeefdeadbeefdeadbeefdeadbeefdeadbeef' + // address padded
+        'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890';  // metadataHash
+
+    test('golden_value', () => {
+        const packed = packChannelKeyStateV1(sessionKey, metadataHash);
+        expect(packed.toLowerCase()).toBe(EXPECTED);
+    });
 });


### PR DESCRIPTION
## Fixes

*Addresses audit findings from round 2: C01/C02 (Critical), H01–H03 (High), M01/M02 (Medium), L01/L03 (Low), I02/I03 (Informational). Note: the H01 commit is the fix for audit finding H02.*

- **MF2-C01**: Preserves the post-Finalize closing marker across a full challenge-close cycle, preventing it from being silently dropped.

- **MF2-C02**: Validates ledger values against Solidity `uint256`/`int256` bounds before signing, preventing silent overflow.

- **MF2-H01** *(also fixes audit H02)*: Blocks receiver-state co-signing while a channel is under dispute. Also introduces `challenge_rescue` — when a channel closes on-chain while still in challenged status (without a cooperative Finalize), the node computes the net value of all transitions that occurred above the closure version but were never enforced on-chain, and issues it as a single credit to the user in a fresh epoch so no legitimate value is stranded.

- **MF2-H03**: Guards `challenge_rescue` from being invoked on already-finalized channels, blocking invalid post-Finalize state transitions.

- **MF2-M01** (SDK): Fixes session key application ID hashing to use `keccak256(utf8)`, replacing the previously incorrect hashing method.

- **MF2-M02**: Accepts the pre-finalize escrow version in the ongoing-channel check, fixing a false rejection during the finalization window.

- **MF2-L01**: `transfer_send` is now rejected during channel creation, preventing fund transfers before the channel is fully established.

- **MF2-L03** (docs): Documents home chain migration as not yet active in the off-chain protocol.

- **MF2-I02**: Adds `SESSION_KEY_AUTH_TYPEHASH` to the session key authorization payload, ensuring proper EIP-712 type-safe signing.

- **MF2-I03**: Rejects incoming connections that reuse an existing home channel ID, preventing channel ID collision/replay.