### PR TITLE
Fix npm audit findings in TypeScript SDK packages

### DIFF
--- a/sdk/ts/examples/app_sessions/package-lock.json
+++ b/sdk/ts/examples/app_sessions/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "@yellow-org/sdk": "file:../..",
         "decimal.js": "^10.4.3",
-        "viem": "^2.46.2",
-        "ws": "^8.18.3"
+        "viem": "^2.50.4",
+        "ws": "^8.20.1"
       },
       "devDependencies": {
         "@types/node": "^22.10.2",
@@ -28,7 +28,7 @@
         "abitype": "^1.2.3",
         "decimal.js": "^10.4.3",
         "jest-util": "^30.3.0",
-        "viem": "^2.46.1",
+        "viem": "^2.50.4",
         "zod": "^4.3.6"
       },
       "devDependencies": {

--- a/sdk/ts/examples/app_sessions/package.json
+++ b/sdk/ts/examples/app_sessions/package.json
@@ -9,8 +9,8 @@
   "dependencies": {
     "@yellow-org/sdk": "file:../..",
     "decimal.js": "^10.4.3",
-    "viem": "^2.46.2",
-    "ws": "^8.18.3"
+    "viem": "^2.50.4",
+    "ws": "^8.20.1"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/sdk/ts/examples/example-app/package-lock.json
+++ b/sdk/ts/examples/example-app/package-lock.json
@@ -19,7 +19,7 @@
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "tailwind-merge": "^3.6.0",
-        "viem": "^2.47.4"
+        "viem": "^2.50.4"
       },
       "devDependencies": {
         "@types/react": "^19.2.15",
@@ -40,7 +40,7 @@
         "abitype": "^1.2.3",
         "decimal.js": "^10.4.3",
         "jest-util": "^30.3.0",
-        "viem": "^2.46.1",
+        "viem": "^2.50.4",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -63,7 +63,7 @@
         "ts-jest": "^29.1.2",
         "ts-node": "^10.9.2",
         "typescript": "^6.0.3",
-        "ws": "8.20.1"
+        "ws": "8.21.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -1445,9 +1445,9 @@
       "license": "MIT"
     },
     "node_modules/ox": {
-      "version": "0.14.17",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.17.tgz",
-      "integrity": "sha512-jOzNb2Wlfzsr8z/GoCtd1bf6OSRuWuysvbhnHGD+7fV1WRbcBR6B0RYoe3xWnUedF7zp4l5APmS7CzAhUok/lA==",
+      "version": "0.14.25",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.25.tgz",
+      "integrity": "sha512-8DoibKtxE8yw63Y2jjMhlbjaURev6WCx4QR4MWLusl2/qIaeTzMJMBIYIDl1KOF45+8H1Ur6eLTdPlUoO8PlRw==",
       "funding": [
         {
           "type": "github",
@@ -1689,9 +1689,9 @@
       }
     },
     "node_modules/viem": {
-      "version": "2.48.1",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.48.1.tgz",
-      "integrity": "sha512-GJC3gKV1Hngeo1IB9YanJKHH2pcmoqDymyPxddmzDtG8boXA7eFw8qdnn1PSaToJ93f3LpOZPlLLJ9beAF/Lzg==",
+      "version": "2.51.2",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.51.2.tgz",
+      "integrity": "sha512-2x4YAtr3PUPIW++Ov96clnWtRsyqMfpFfooQRIxCpAMsTgxioJTdIQ0ywbjhlHDCUJEGM6M8q8ILOeaPRViH9w==",
       "funding": [
         {
           "type": "github",
@@ -1706,8 +1706,8 @@
         "@scure/bip39": "1.6.0",
         "abitype": "1.2.3",
         "isows": "1.0.7",
-        "ox": "0.14.17",
-        "ws": "8.18.3"
+        "ox": "0.14.25",
+        "ws": "8.20.1"
       },
       "peerDependencies": {
         "typescript": ">=5.0.4"
@@ -1797,9 +1797,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/sdk/ts/examples/example-app/package.json
+++ b/sdk/ts/examples/example-app/package.json
@@ -21,7 +21,7 @@
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "tailwind-merge": "^3.6.0",
-    "viem": "^2.47.4"
+    "viem": "^2.50.4"
   },
   "devDependencies": {
     "@types/react": "^19.2.15",

--- a/sdk/ts/package-lock.json
+++ b/sdk/ts/package-lock.json
@@ -676,9 +676,9 @@
             }
         },
         "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3300,9 +3300,9 @@
             }
         },
         "node_modules/diff": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+            "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
@@ -3475,9 +3475,9 @@
             }
         },
         "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-            "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3968,9 +3968,9 @@
             }
         },
         "node_modules/glob/node_modules/brace-expansion": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-            "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/sdk/ts/package-lock.json
+++ b/sdk/ts/package-lock.json
@@ -12,7 +12,7 @@
                 "abitype": "^1.2.3",
                 "decimal.js": "^10.4.3",
                 "jest-util": "^30.3.0",
-                "viem": "^2.46.1",
+                "viem": "^2.50.4",
                 "zod": "^4.3.6"
             },
             "devDependencies": {
@@ -3673,28 +3673,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/ethers/node_modules/ws": {
-            "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-            "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": ">=5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/eventemitter3": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
@@ -6455,27 +6433,6 @@
                     "optional": true
                 },
                 "zod": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/viem/node_modules/ws": {
-            "version": "8.20.1",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-            "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": ">=5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
                     "optional": true
                 }
             }

--- a/sdk/ts/package.json
+++ b/sdk/ts/package.json
@@ -64,7 +64,7 @@
         "abitype": "^1.2.3",
         "decimal.js": "^10.4.3",
         "jest-util": "^30.3.0",
-        "viem": "^2.46.1",
+        "viem": "^2.50.4",
         "zod": "^4.3.6"
     },
     "devDependencies": {
@@ -87,6 +87,9 @@
         "ts-jest": "^29.1.2",
         "ts-node": "^10.9.2",
         "typescript": "^6.0.3",
+        "ws": "8.21.0"
+    },
+    "overrides": {
         "ws": "8.21.0"
     }
 }


### PR DESCRIPTION
## Summary
- Update TypeScript SDK and example package `viem` ranges so they resolve `ws@8.20.1`.
- Pin direct `ws` usage in `sdk/ts` and `app_sessions` to the patched `8.20.1` release.
- Add an npm override in `sdk/ts` so the dev-only `ethers` dependency dedupes to `ws@8.20.1` instead of keeping a vulnerable nested copy.
- Refresh `sdk/ts/package-lock.json` dev-tool transitive dependencies so `brace-expansion` resolves to `5.0.6` and `diff` resolves to `4.0.4`.

## Validation
- `cd sdk/ts && npm audit --package-lock-only --json` reports 0 vulnerabilities
- Package-lock audits for `sdk/ts`, `sdk/ts/examples/app_sessions`, and `sdk/ts/examples/example-app` all report 0 vulnerabilities
- `cd sdk/ts && npm run typecheck`
- `cd sdk/ts && npm test` (12 suites, 180 tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `viem` dependency to version 2.50.4 across SDK and example packages
  * Updated `ws` dependency to versions 2.20.1 and 2.21.0 in example packages
  * Added dependency override configuration for `ws` in main SDK package

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/layer-3/nitrolite/pull/781?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->