### PR TITLE
MF3-L01: validate aggregate net-flow and allocation ranges

### DIFF
--- a/pkg/core/state_packer.go
+++ b/pkg/core/state_packer.go
@@ -41,6 +41,14 @@ func (l contractLedger) Validate() error {
 	if err := checkInt256(l.NodeNetFlow); err != nil {
 		return fmt.Errorf("node net flow: %w", err)
 	}
+	allocSum := new(big.Int).Add(l.UserAllocation, l.NodeAllocation)
+	if err := checkUint256(allocSum); err != nil {
+		return fmt.Errorf("allocation sum: %w", err)
+	}
+	netFlowSum := new(big.Int).Add(l.UserNetFlow, l.NodeNetFlow)
+	if err := checkInt256(netFlowSum); err != nil {
+		return fmt.Errorf("net flow sum: %w", err)
+	}
 	return nil
 }
 

--- a/pkg/core/state_packer_test.go
+++ b/pkg/core/state_packer_test.go
@@ -205,3 +205,77 @@ func TestPackState_RejectsOutOfRangeValues(t *testing.T) {
 		assert.Contains(t, err.Error(), "int256")
 	})
 }
+
+// TestContractLedger_Validate covers the ABI-layer guard directly, bypassing
+// Ledger.Validate. Solidity computes `userAllocation + nodeAllocation` as
+// uint256 and `userNetFlow + nodeNetFlow` as int256; individually-valid scaled
+// values can still overflow these aggregates, so the packer's last-chance
+// check must reject them before signing.
+func TestContractLedger_Validate(t *testing.T) {
+	t.Parallel()
+
+	maxUint256 := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1))
+
+	t.Run("happy_path", func(t *testing.T) {
+		t.Parallel()
+		l := contractLedger{
+			UserAllocation: big.NewInt(10),
+			NodeAllocation: big.NewInt(20),
+			UserNetFlow:    big.NewInt(10),
+			NodeNetFlow:    big.NewInt(20),
+		}
+		assert.NoError(t, l.Validate())
+	})
+
+	t.Run("net_flow_sum_overflows_int256", func(t *testing.T) {
+		t.Parallel()
+		l := contractLedger{
+			UserAllocation: big.NewInt(0),
+			NodeAllocation: big.NewInt(0),
+			UserNetFlow:    new(big.Int).Set(maxInt256),
+			NodeNetFlow:    big.NewInt(1),
+		}
+		err := l.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "net flow sum")
+	})
+
+	t.Run("net_flow_sum_underflows_int256", func(t *testing.T) {
+		t.Parallel()
+		l := contractLedger{
+			UserAllocation: big.NewInt(0),
+			NodeAllocation: big.NewInt(0),
+			UserNetFlow:    new(big.Int).Set(minInt256),
+			NodeNetFlow:    big.NewInt(-1),
+		}
+		err := l.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "net flow sum")
+	})
+
+	t.Run("allocation_sum_overflows_uint256", func(t *testing.T) {
+		t.Parallel()
+		l := contractLedger{
+			UserAllocation: new(big.Int).Set(maxUint256),
+			NodeAllocation: big.NewInt(1),
+			UserNetFlow:    big.NewInt(0),
+			NodeNetFlow:    big.NewInt(0),
+		}
+		err := l.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "allocation sum")
+	})
+
+	t.Run("net_flow_sum_at_boundary", func(t *testing.T) {
+		t.Parallel()
+		half := new(big.Int).Rsh(maxInt256, 1)
+		other := new(big.Int).Sub(maxInt256, half)
+		l := contractLedger{
+			UserAllocation: big.NewInt(0),
+			NodeAllocation: big.NewInt(0),
+			UserNetFlow:    half,
+			NodeNetFlow:    other,
+		}
+		assert.NoError(t, l.Validate())
+	})
+}

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -686,6 +686,17 @@ func (l Ledger) Validate(assetDecimals uint8) error {
 		return fmt.Errorf("node net flow out of int256 range: %w", err)
 	}
 
+	// Solidity computes `userAllocation + nodeAllocation` as uint256 and
+	// `userNetFlow + nodeNetFlow` as int256. Individually-valid scaled values
+	// can still overflow these aggregates, producing a state the contract will
+	// reject.
+	if _, err := DecimalToUint256(sumBalances, assetDecimals); err != nil {
+		return fmt.Errorf("allocation sum out of uint256 range: %w", err)
+	}
+	if _, err := DecimalToInt256(sumNetFlows, assetDecimals); err != nil {
+		return fmt.Errorf("net flow sum out of int256 range: %w", err)
+	}
+
 	return nil
 }
 

--- a/pkg/core/types_test.go
+++ b/pkg/core/types_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/shopspring/decimal"
@@ -464,6 +465,34 @@ func TestLedger_Equal_Validate(t *testing.T) {
 	lInvalid = l1
 	lInvalid.UserNetFlow = decimal.NewFromInt(999) // Mismatch
 	assert.Error(t, lInvalid.Validate(6))
+
+	// Each net-flow field fits int256, but their sum does not. Solidity computes
+	// `userNetFlow + nodeNetFlow` as int256, so an unchecked sum overflow would
+	// produce a state the contract panics on.
+	lSumOverflow := Ledger{
+		TokenAddress: "0xT",
+		BlockchainID: 1,
+		UserBalance:  decimal.NewFromBigInt(maxInt256, 0),
+		NodeBalance:  decimal.NewFromInt(1),
+		UserNetFlow:  decimal.NewFromBigInt(maxInt256, 0),
+		NodeNetFlow:  decimal.NewFromInt(1),
+	}
+	err := lSumOverflow.Validate(0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "net flow sum out of int256 range")
+
+	// Sum exactly at the int256 boundary must pass.
+	halfMax := new(big.Int).Rsh(maxInt256, 1) // (2^255-1)/2
+	otherHalf := new(big.Int).Sub(maxInt256, halfMax)
+	lBoundary := Ledger{
+		TokenAddress: "0xT",
+		BlockchainID: 1,
+		UserBalance:  decimal.NewFromBigInt(halfMax, 0),
+		NodeBalance:  decimal.NewFromBigInt(otherHalf, 0),
+		UserNetFlow:  decimal.NewFromBigInt(halfMax, 0),
+		NodeNetFlow:  decimal.NewFromBigInt(otherHalf, 0),
+	}
+	assert.NoError(t, lBoundary.Validate(0))
 }
 
 func TestTransactionType_String(t *testing.T) {


### PR DESCRIPTION
## Summary

- Solidity computes `userNetFlow + nodeNetFlow` as `int256` and `userAllocation + nodeAllocation` as `uint256`. Individually-valid scaled fields can still overflow these aggregates, producing a state the contract will always reject.
- Adds aggregate bounds checks in both validation layers so the offchain/onchain mismatch is caught before signing:
  - `Ledger.Validate` (`pkg/core/types.go`) — checks scaled `sumBalances` against uint256 and `sumNetFlows` against int256.
  - `contractLedger.Validate` (`pkg/core/state_packer.go`) — checks scaled `*big.Int` sums via existing `checkUint256` / `checkInt256` helpers.
- Defense in depth: domain layer fires via `state_advancer` before packing; ABI layer fires in `packSigningData` for any caller bypassing the advancer.

## Test plan

- [x] `go test ./pkg/core/... -run "TestLedger|TestContractLedger|TestPackState" -v`
- [x] `go test ./...`
- [x] `go vet ./pkg/core/...`
- [x] `go build ./...`

New cases cover net-flow sum overflow / underflow, allocation sum overflow, and a boundary-pass case at exactly `maxInt256`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)