### PR TITLE
MF3-I01: document listener ordering invariant guarding receiver credits

### DIFF
--- a/nitronode/api/app_session_v1/handler.go
+++ b/nitronode/api/app_session_v1/handler.go
@@ -170,6 +170,16 @@ func (h *Handler) issueReleaseReceiverState(ctx context.Context, tx Store, recei
 		// unsigned so the challenge-rescue squash at close (Challenged path) can pick
 		// it up, and so terminal-status channels never receive a node-signed credit
 		// that won't settle.
+		//
+		// MF3-I01 (release path): same reasoning as channel_v1. The listener
+		// ordering & idempotency invariant (pkg/blockchain/evm/listener.go,
+		// processEvents doc) guarantees HandleHomeChannelChallenged precedes
+		// HandleHomeChannelClosed for any Path-1 (challenge-timeout) close, so
+		// an unsigned release credit either lands before the close handler runs
+		// (and is squashed into the rescue sum) or after it (and reads the
+		// rescue row as currentState, with HomeChannelID=nil). The wedge state
+		// where currentState transitively points at a Closed channel is not
+		// reachable through the supported event-ingestion path.
 		_, channelStatus, err := tx.CheckActiveChannel(receiverWallet, asset)
 		if err != nil {
 			return rpc.Errorf("failed to check receiver active channel: %v", err)

--- a/nitronode/api/channel_v1/handler.go
+++ b/nitronode/api/channel_v1/handler.go
@@ -123,6 +123,17 @@ func (h *Handler) issueTransferReceiverState(ctx context.Context, tx Store, send
 		// candidate (Challenged) or commit a credit that will never settle (Closed,
 		// Closing). The unsigned row is still persisted so the challenge-rescue
 		// squash at close can pick it up.
+		//
+		// MF3-I01: persisting an unsigned row whose HomeChannelID still references
+		// a now-Closed channel is safe under the listener ordering & idempotency
+		// invariant (pkg/blockchain/evm/listener.go, processEvents doc). For any
+		// Path-1 (challenge-timeout) close, HandleHomeChannelChallenged has
+		// already run before HandleHomeChannelClosed, so the rescue issued from
+		// HandleHomeChannelClosed has overwritten currentState with a fresh-epoch
+		// row whose HomeChannelID is nil, and the next call here reads that row
+		// rather than the wedge state. The unsigned credit issued here can only
+		// land on a Closed channel if it commits before the close handler runs
+		// — in which case the close handler's rescue sum picks it up.
 		_, channelStatus, err := tx.CheckActiveChannel(receiverWallet, senderState.Asset)
 		if err != nil {
 			return nil, rpc.Errorf("failed to check receiver active channel: %v", err)

--- a/nitronode/event_handlers/service.go
+++ b/nitronode/event_handlers/service.go
@@ -322,6 +322,20 @@ func (s *EventHandlerService) HandleHomeChannelChallenged(ctx context.Context, t
 // — issuing a rescue at (epoch+1, version=1) would either overwrite the lone receiver
 // credit or collide on deterministic state ID with an existing row, so the rescue is
 // skipped entirely in that case.
+//
+// MF3-I01 recovery anchor. This handler is the single recovery point for the
+// wedge state described in audit finding MF3-I01: a receiver credit issued
+// during the challenge window inherits HomeChannelID from currentState via
+// NextState(), so the user's latest stored state can transiently point at a
+// channel that closes via Path-1 (challenge-timeout) before the next
+// receiver-credit issuance reads currentState again. The listener ordering &
+// idempotency invariant (pkg/blockchain/evm/listener.go, see processEvents
+// doc) guarantees HandleHomeChannelChallenged has already run for any Path-1
+// close, so wasChallenged is true here and the rescue moves the user to a
+// fresh epoch with HomeChannelID=nil. Subsequent receiver-credit issuance
+// reads the rescue row as currentState and no longer carries the closed
+// channel reference, so request_creation can reopen on the same (wallet,
+// asset) through the normal flow.
 func (s *EventHandlerService) HandleHomeChannelClosed(ctx context.Context, tx core.ChannelHubEventHandlerStore, event *core.HomeChannelClosedEvent) error {
 	logger := log.FromContext(ctx)
 	chanID := event.ChannelID

--- a/pkg/blockchain/evm/listener.go
+++ b/pkg/blockchain/evm/listener.go
@@ -189,6 +189,43 @@ func (l *Listener) listenEvents(ctx context.Context) error {
 // events are checked via IsContractEventPresent; once a non-present event is found
 // the check is skipped for the rest of that phase (events are strictly ordered).
 // Returns nil on subscription loss (reconnect), non-nil on handler/check failure.
+//
+// Listener ordering & idempotency invariant
+// -----------------------------------------
+// Downstream handlers (and any code reasoning about the relative arrival order
+// of on-chain events) may rely on the following guarantees provided by this
+// loop. Changes that weaken any of them must update every consumer that cites
+// this invariant by name.
+//
+//  1. Strict per-contract ordering. Within a single Listener, events are
+//     delivered to handleEvent in ascending (block_number, log_index) order
+//     across the historical → live transition. Phase 1 drains historicalCh to
+//     completion before phase 2 reads from currentCh, and the upstream
+//     reconcileBlockRange + live subscription preserve chain order within each
+//     phase.
+//
+//  2. Idempotent resume. On restart, IsContractEventPresent gates the first
+//     event of each phase: events already persisted in a prior run are skipped
+//     rather than reprocessed. Once a non-present event is seen the check is
+//     dropped for the remainder of the phase (safe because of guarantee 1).
+//
+//  3. Cursor advances only on handler success. lastBlock is updated on each
+//     live event, but a non-nil return from handleEvent unsubscribes and
+//     surfaces the error to the caller without persisting any state past the
+//     failed event; the next Listen invocation re-fetches from the same
+//     cursor. Transient handler failures retry instead of silently dropping.
+//
+//  4. Reorged-out logs are discarded. Live deliveries with Removed=true are
+//     dropped. A reorg that fully removes a ChannelChallenged log also
+//     removes the matching on-chain status transition to DISPUTED, so the
+//     contract's Path-1 (challenge-timeout) close cannot subsequently fire
+//     for the same channel.
+//
+// A consequence used by the nitronode event handlers: for any channel that
+// closes via Path-1 (challenge-timeout, ChannelHub Closed-from-DISPUTED),
+// HandleHomeChannelChallenged is guaranteed to run before HandleHomeChannelClosed
+// for that channel. See nitronode/event_handlers/service.go (audit finding
+// MF3-I01) for the wedge case this rules out.
 func (l *Listener) processEvents(
 	ctx context.Context,
 	eventSubscription interface {


### PR DESCRIPTION
## Summary
- Promotes the implicit "events processed in strict (block, log_index) order with idempotent resume" property of `pkg/blockchain/evm/listener.go` into a named, citeable invariant.
- Adds cross-references at every consumer that depends on it (receiver-credit issuance + close handler), explaining why the MF3-I01 wedge state — a receiver credit persisted with `HomeChannelID` pointing at a Closed channel — is unreachable under the supported event-ingestion path.
- Doc-only; no behavior change. Auditor reframed MF3-I01 as Informational defense-in-depth in [the finding thread](https://www.notion.so/guardianaudits/I-01-3688bda5828c81e5b36dc3d6c8a48504).

## Anchors
- `pkg/blockchain/evm/listener.go` — canonical "Listener ordering & idempotency invariant" block on `processEvents`, four numbered guarantees plus the Path-1 consequence (`HandleHomeChannelChallenged` precedes `HandleHomeChannelClosed` for any challenge-timeout close).
- `nitronode/event_handlers/service.go` — `HandleHomeChannelClosed` doc names itself as the MF3-I01 recovery anchor and cites the invariant.
- `nitronode/api/channel_v1/handler.go` — `issueTransferReceiverState` `HomeChannelID!=nil` branch cites the invariant.
- `nitronode/api/app_session_v1/handler.go` — `issueReleaseReceiverState` mirror.

## Rationale
The exploit chain in the finding requires `ChannelClosed` to be processed without the prior `ChannelChallenged` for the same channel. The listener loop in `processEvents` rules that out: events are delivered in strict chain order, the cursor only advances after a handler returns nil, idempotent resume via `IsContractEventPresent` prevents reprocessing, and reorg-removed logs are dropped (a reorg that removes `ChannelChallenged` also removes the on-chain DISPUTED status, so Path-1 close cannot fire). That invariant was implicit before; downstream comments referenced "challenge-rescue squash at close" without naming what made it sufficient. Future changes that weaken any of the four guarantees now have to update the named consumers.

## Test plan
- [x] `go vet ./nitronode/event_handlers/... ./nitronode/api/channel_v1/... ./nitronode/api/app_session_v1/... ./pkg/blockchain/evm/...` — clean.
- [x] CI green (no behavior change, but Go test job will run anyway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)