### PR TITLE
feat(sdk): add round-robin test example for Go and TS SDKs

### DIFF
--- a/sdk/go/channel.go
+++ b/sdk/go/channel.go
@@ -106,6 +106,11 @@ func (c *Client) Deposit(ctx context.Context, blockchainID uint64, asset string,
 		newState.NodeSig = &nodeSig
 
 		return newState, nil
+	} else if state.HomeLedger.BlockchainID != blockchainID {
+		// Active home channel is bound to the chain it was created on.
+		// Silently advancing it onto a different chain would surface as a
+		// confusing on-chain failure later.
+		return nil, fmt.Errorf("active home channel for asset %q is on chain %d, cannot deposit on chain %d", asset, state.HomeLedger.BlockchainID, blockchainID)
 	}
 
 	// Scenario B: Channel exists - checkpoint deposit
@@ -219,6 +224,11 @@ func (c *Client) Withdraw(ctx context.Context, blockchainID uint64, asset string
 		newState.NodeSig = &nodeSig
 
 		return newState, nil
+	} else if state.HomeLedger.BlockchainID != blockchainID {
+		// Active home channel is bound to the chain it was created on.
+		// Silently advancing it onto a different chain would surface as a
+		// confusing on-chain failure later.
+		return nil, fmt.Errorf("active home channel for asset %q is on chain %d, cannot withdraw on chain %d", asset, state.HomeLedger.BlockchainID, blockchainID)
 	}
 
 	// Create next state

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -620,3 +620,104 @@ func TestClient_SignSessionKeyState(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, rawSigner.PublicKey().Address().String(), recoveredAddr.String())
 }
+
+// newCrossChainTestClient builds a Client wired to a mockDialer pre-stocked
+// with the responses needed to reach the Deposit/Withdraw cross-chain guard:
+// node config (chain 137 home), assets (asset on both 137 and 8453), and a
+// latest state representing an open channel on chain 137. Returns the client
+// and the wallet address used to populate the state.
+func newCrossChainTestClient(t *testing.T) (*Client, string) {
+	t.Helper()
+
+	pk, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	pkHex := hexutil.Encode(crypto.FromECDSA(pk))
+
+	rawSigner, err := sign.NewEthereumRawSigner(pkHex)
+	require.NoError(t, err)
+	msgSigner, err := sign.NewEthereumMsgSignerFromRaw(rawSigner)
+	require.NoError(t, err)
+	stateSigner, err := core.NewChannelDefaultSigner(msgSigner)
+	require.NoError(t, err)
+	walletAddr := rawSigner.PublicKey().Address().String()
+
+	mockDialer := NewMockDialer()
+	mockDialer.Dial(context.Background(), "", nil)
+
+	mockDialer.RegisterResponse(rpc.NodeV1GetConfigMethod.String(), rpc.NodeV1GetConfigResponse{
+		NodeAddress: "0xNodeAddress",
+		Blockchains: []rpc.BlockchainInfoV1{
+			{Name: "Polygon", BlockchainID: "137", ChannelHubAddress: "0xHubAddr137"},
+			{Name: "Base", BlockchainID: "8453", ChannelHubAddress: "0xHubAddr8453"},
+		},
+	})
+
+	mockDialer.RegisterResponse(rpc.NodeV1GetAssetsMethod.String(), rpc.NodeV1GetAssetsResponse{
+		Assets: []rpc.AssetV1{
+			{
+				Name:                  "USDC",
+				Symbol:                "USDC",
+				Decimals:              6,
+				SuggestedBlockchainID: "137",
+				Tokens: []rpc.TokenV1{
+					{BlockchainID: "137", Address: "0xToken137", Decimals: 6},
+					{BlockchainID: "8453", Address: "0xToken8453", Decimals: 6},
+				},
+			},
+		},
+	})
+
+	homeChannelID := "0xHomeChannel"
+	mockDialer.RegisterResponse(rpc.ChannelsV1GetLatestStateMethod.String(), rpc.ChannelsV1GetLatestStateResponse{
+		State: &rpc.StateV1{
+			ID:            "0xStateID",
+			Epoch:         "1",
+			Version:       "1",
+			UserWallet:    walletAddr,
+			Asset:         "USDC",
+			HomeChannelID: &homeChannelID,
+			Transition: rpc.TransitionV1{
+				Type:   core.TransitionTypeHomeDeposit,
+				Amount: "10",
+			},
+			HomeLedger: rpc.LedgerV1{
+				BlockchainID: "137",
+				TokenAddress: "0xToken137",
+				UserBalance:  "10",
+				UserNetFlow:  "10",
+				NodeBalance:  "0",
+				NodeNetFlow:  "0",
+			},
+		},
+	})
+
+	client := &Client{
+		rpcClient:       rpc.NewClient(mockDialer),
+		stateSigner:     stateSigner,
+		rawSigner:       rawSigner,
+		homeBlockchains: make(map[string]uint64),
+	}
+	client.assetStore = newClientAssetStore(client)
+	client.stateAdvancer = core.NewStateAdvancerV1(client.assetStore)
+	return client, walletAddr
+}
+
+func TestClient_Deposit_RejectsForeignChain(t *testing.T) {
+	t.Parallel()
+	client, _ := newCrossChainTestClient(t)
+
+	_, err := client.Deposit(context.Background(), 8453, "USDC", decimal.NewFromFloat(0.5))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "active home channel for asset \"USDC\" is on chain 137")
+	assert.Contains(t, err.Error(), "cannot deposit on chain 8453")
+}
+
+func TestClient_Withdraw_RejectsForeignChain(t *testing.T) {
+	t.Parallel()
+	client, _ := newCrossChainTestClient(t)
+
+	_, err := client.Withdraw(context.Background(), 8453, "USDC", decimal.NewFromFloat(0.5))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "active home channel for asset \"USDC\" is on chain 137")
+	assert.Contains(t, err.Error(), "cannot withdraw on chain 8453")
+}

--- a/sdk/go/examples/round_robin/main.go
+++ b/sdk/go/examples/round_robin/main.go
@@ -1,0 +1,500 @@
+package main
+
+// Example: Round Robin Test
+//
+// Exercises every basic channel action (deposit, transfer, close, withdraw)
+// for one asset across every chain on which that asset is supported.
+//
+// ----------------------------------------------------------------------------
+// Flow
+// ----------------------------------------------------------------------------
+//
+//  1. Preparation
+//     a. Set up wallet signers for private keys A and B.
+//     b. Build tokenSet: every supported token for the configured asset,
+//        paired with its chain's JSON-RPC endpoint. tokenSet[i].BlockchainID
+//        must have an entry in chainRPCs.
+//     c. Ensure signer A holds >= minNativeBalances[chainID] of the native
+//        gas token on every chain in tokenSet. Each chain pays three
+//        checkpoint transactions per run (deposit + close + withdraw).
+//     d. Ensure signer A holds >= transferAmount of the configured asset on
+//        tokenSet[0].BlockchainID. Subsequent iterations are seeded by the
+//        previous iteration's withdrawal — no other chain needs to be
+//        pre-funded with the asset.
+//     e. If sessionKeyPriv is non-empty, register it as a channel session
+//        key for signer A and use the session-key-backed client for every
+//        channel operation in the loop.
+//
+//  2. For i := range tokenSet (let next = (i + 1) % len(tokenSet)):
+//     a. Signer A deposits transferAmount of tokenSet[i].
+//     b. Signer A transfers transferAmount to signer B (off-chain).
+//     c. Signer A closes the home channel for the asset.
+//     d. Signer B transfers transferAmount back to signer A (lands on a
+//        void state, no chain attached).
+//     e. Signer A withdraws transferAmount on tokenSet[next].BlockchainID,
+//        which auto-creates a new channel on that chain. On the last
+//        iteration this wraps to tokenSet[0], closing the loop.
+//
+// Together (2.a–2.e) exercise deposit / transfer-send / close /
+// transfer-receive / withdraw on every chain in tokenSet.
+//
+// ----------------------------------------------------------------------------
+// Operational notes
+// ----------------------------------------------------------------------------
+//
+//   - wsURL must point at a reachable nitronode WebSocket endpoint.
+//   - The nitronode must maintain reserves of the asset on every chain in
+//     tokenSet. 2.e withdraws tokens signer A never deposited on that chain,
+//     which only works if the node holds liquidity there.
+//   - tokenSet is derived at runtime from GetAssets(asset).Tokens; the
+//     iteration order matches the order returned by the node.
+//   - The example exits non-zero on the first failure. It does not reset
+//     state, so re-running on the same wallets resumes from whatever state
+//     the node holds. Fresh wallets give the cleanest preflight numbers.
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/shopspring/decimal"
+
+	"github.com/layer-3/nitrolite/pkg/core"
+	"github.com/layer-3/nitrolite/pkg/sign"
+	sdk "github.com/layer-3/nitrolite/sdk/go"
+)
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+const (
+	wsURL = "wss://nitronode-sandbox.yellow.org/v1/ws"
+
+	// Replace with your hex private keys. privA performs every channel
+	// operation; privB only receives transfers and sends them back.
+	privA = "0x7d607..."
+	privB = "0x4f3a1..."
+
+	// Empty string disables the session-key path; the wallet client performs
+	// channel operations directly. Otherwise this key is registered as a
+	// channel session key for privA and used for the loop.
+	sessionKeyPriv = ""
+
+	// Asset symbol to test. tokenSet is built from this asset's tokens as
+	// returned by the node.
+	asset = "yusd"
+)
+
+// transferAmount is the value used for every deposit / transfer / withdraw
+// in the loop. Keep this small for testnets.
+var transferAmount = decimal.NewFromFloat(0.00001)
+
+// chainRPCs maps blockchain ID -> JSON-RPC endpoint. Must cover every chain
+// in tokenSet (derived at runtime). Missing entries fail preflight.
+var chainRPCs = map[uint64]string{
+	11155111: "https://sepolia.drpc.org",         // Ethereum Sepolia
+	84532:    "https://sepolia.base.org",         // Base Sepolia
+	80002:    "https://rpc-amoy.polygon.technology", // Polygon Amoy
+	59141:    "https://rpc.sepolia.linea.build",  // Linea Sepolia
+}
+
+// minNativeBalances maps blockchain ID -> minimum native gas balance for
+// privA. Sized to cover three checkpoint transactions (deposit + close +
+// withdraw). Tune per chain based on observed gas costs.
+var minNativeBalances = map[uint64]decimal.Decimal{
+	11155111: decimal.NewFromFloat(0.01),
+	84532:    decimal.NewFromFloat(0.005),
+	80002:    decimal.NewFromFloat(0.05),
+	59141:    decimal.NewFromFloat(0.005),
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+func main() {
+	ctx := context.Background()
+
+	// --- Build signers for A and B ---
+	signersA := buildSigners(privA, "A")
+	signersB := buildSigners(privB, "B")
+	fmt.Printf("Wallet A: %s\nWallet B: %s\n\n", signersA.address, signersB.address)
+
+	// --- Build wallet clients with every RPC pre-registered ---
+	walletA := newClient(signersA.channelSigner, signersA.rawSigner)
+	defer walletA.Close()
+	walletB := newClient(signersB.channelSigner, signersB.rawSigner)
+	defer walletB.Close()
+
+	// --- 1.b: discover tokenSet for the configured asset ---
+	fmt.Println("=== 1.b: Discovering tokenSet ===")
+	tokenSet := discoverTokenSet(ctx, walletA, asset)
+	for i, t := range tokenSet {
+		fmt.Printf("  [%d] %s on chain %d (%s)\n", i, t.Symbol, t.BlockchainID, t.Address)
+	}
+	fmt.Println()
+
+	// --- 1.c + 1.d: preflight native and asset balances ---
+	fmt.Println("=== 1.c + 1.d: Preflight ===")
+	preflight(ctx, walletA, signersA.address, tokenSet)
+	fmt.Println("✓ preflight passed")
+	fmt.Println()
+
+	// --- 1.e: optional session-key registration ---
+	opsClient := walletA
+	if sessionKeyPriv != "" {
+		fmt.Println("=== 1.e: Registering channel session key ===")
+		opsClient = setupSessionKeyClient(ctx, walletA, signersA)
+		defer opsClient.Close()
+		fmt.Println("✓ session-key client ready")
+		fmt.Println()
+	}
+
+	// --- 2: round-robin loop ---
+	fmt.Println("=== 2: Round robin ===")
+	for i := range tokenSet {
+		next := (i + 1) % len(tokenSet)
+		runIteration(ctx, i, opsClient, walletB, signersA.address, signersB.address, tokenSet[i], tokenSet[next])
+	}
+
+	fmt.Println("\n=== Example Complete ===")
+}
+
+// ============================================================================
+// Iteration
+// ============================================================================
+
+// runIteration executes one (deposit -> transfer -> close -> transfer-back ->
+// withdraw) cycle. cur is the chain on which the deposit/close happen; next
+// is the chain on which the withdraw settles.
+func runIteration(
+	ctx context.Context,
+	i int,
+	opsClient *sdk.Client,
+	walletB *sdk.Client,
+	addrA, addrB string,
+	cur, next core.Token,
+) {
+	fmt.Printf("--- iter %d: deposit on chain %d, withdraw on chain %d ---\n", i, cur.BlockchainID, next.BlockchainID)
+
+	// 2.a A deposits transferAmount on cur.BlockchainID.
+	if _, err := opsClient.ApproveToken(ctx, cur.BlockchainID, asset, transferAmount); err != nil {
+		log.Fatalf("iter %d: approve on chain %d failed: %v", i, cur.BlockchainID, err)
+	}
+	depositState, err := opsClient.Deposit(ctx, cur.BlockchainID, asset, transferAmount)
+	if err != nil {
+		log.Fatalf("iter %d: deposit on chain %d failed: %v", i, cur.BlockchainID, err)
+	}
+	fmt.Printf("  ✓ A deposited %s %s on chain %d\n", transferAmount, asset, cur.BlockchainID)
+	checkpointAndWait(ctx, opsClient, asset, depositState.Version)
+
+	// 2.b A -> B (off-chain).
+	if _, err := opsClient.Transfer(ctx, addrB, asset, transferAmount); err != nil {
+		log.Fatalf("iter %d: transfer A->B failed: %v", i, err)
+	}
+	fmt.Printf("  ✓ A transferred %s %s to B (off-chain)\n", transferAmount, asset)
+
+	// 2.c A closes home channel for asset on cur.BlockchainID.
+	closeState, err := opsClient.CloseHomeChannel(ctx, asset)
+	if err != nil {
+		log.Fatalf("iter %d: close home channel failed: %v", i, err)
+	}
+	fmt.Printf("  ✓ A closed home channel for %s\n", asset)
+	checkpointAndWait(ctx, opsClient, asset, closeState.Version)
+
+	// 2.d B -> A (off-chain credit, lands on void state, no chain attached).
+	if _, err := walletB.Transfer(ctx, addrA, asset, transferAmount); err != nil {
+		log.Fatalf("iter %d: transfer B->A failed: %v", i, err)
+	}
+	fmt.Printf("  ✓ B transferred %s %s back to A (off-chain credit)\n", transferAmount, asset)
+
+	// 2.e A withdraws on next.BlockchainID. Withdraw auto-creates a new
+	// channel on next.BlockchainID because A's latest state is void after
+	// close + transfer-receive.
+	withdrawState, err := opsClient.Withdraw(ctx, next.BlockchainID, asset, transferAmount)
+	if err != nil {
+		log.Fatalf("iter %d: withdraw on chain %d failed: %v", i, next.BlockchainID, err)
+	}
+	fmt.Printf("  ✓ A withdrew %s %s on chain %d\n", transferAmount, asset, next.BlockchainID)
+	checkpointAndWait(ctx, opsClient, asset, withdrawState.Version)
+
+	// Wait until next chain shows the funds on-chain so the next iteration's
+	// deposit doesn't race ERC-20 settlement.
+	waitForOnChain(ctx, opsClient, next.BlockchainID, asset, addrA, transferAmount)
+	fmt.Println()
+}
+
+// ============================================================================
+// Preflight
+// ============================================================================
+
+func preflight(ctx context.Context, walletA *sdk.Client, addrA string, tokenSet []core.Token) {
+	var shortfalls []string
+
+	// Verify chainRPCs / minNativeBalances cover every chain in tokenSet.
+	for _, t := range tokenSet {
+		if _, ok := chainRPCs[t.BlockchainID]; !ok {
+			shortfalls = append(shortfalls, fmt.Sprintf("chainRPCs missing entry for chain %d", t.BlockchainID))
+		}
+		if _, ok := minNativeBalances[t.BlockchainID]; !ok {
+			shortfalls = append(shortfalls, fmt.Sprintf("minNativeBalances missing entry for chain %d", t.BlockchainID))
+		}
+	}
+	if len(shortfalls) > 0 {
+		fmt.Println("Configuration shortfalls:")
+		for _, s := range shortfalls {
+			fmt.Printf("  - %s\n", s)
+		}
+		os.Exit(1)
+	}
+
+	// 1.c: native balance on every chain >= minNativeBalances.
+	fmt.Println("Native balance check:")
+	for _, t := range tokenSet {
+		have, err := nativeBalance(ctx, chainRPCs[t.BlockchainID], addrA)
+		if err != nil {
+			log.Fatalf("native balance check for chain %d failed: %v", t.BlockchainID, err)
+		}
+		need := minNativeBalances[t.BlockchainID]
+		marker := "✓"
+		if have.LessThan(need) {
+			marker = "✗"
+			shortfalls = append(shortfalls, fmt.Sprintf("chain %d native: need >= %s, have %s", t.BlockchainID, need, have))
+		}
+		fmt.Printf("  %s chain %d: need >= %s, have %s\n", marker, t.BlockchainID, need, have)
+	}
+
+	// 1.d: privA holds >= transferAmount of asset on tokenSet[0].BlockchainID.
+	seedChain := tokenSet[0].BlockchainID
+	have, err := walletA.GetOnChainBalance(ctx, seedChain, asset, addrA)
+	if err != nil {
+		log.Fatalf("asset balance check on chain %d failed: %v", seedChain, err)
+	}
+	marker := "✓"
+	if have.LessThan(transferAmount) {
+		marker = "✗"
+		shortfalls = append(shortfalls, fmt.Sprintf("chain %d %s: need >= %s, have %s", seedChain, asset, transferAmount, have))
+	}
+	fmt.Printf("Asset balance check:\n  %s chain %d %s: need >= %s, have %s\n", marker, seedChain, asset, transferAmount, have)
+
+	if len(shortfalls) > 0 {
+		fmt.Println("\nPreflight failed. Resolve the following before re-running:")
+		for _, s := range shortfalls {
+			fmt.Printf("  - %s\n", s)
+		}
+		os.Exit(1)
+	}
+}
+
+// nativeBalance dials rpcURL and returns the native token balance of addr
+// converted to a decimal with 18-decimal precision (standard for EVM native).
+func nativeBalance(ctx context.Context, rpcURL, addr string) (decimal.Decimal, error) {
+	cl, err := ethclient.DialContext(ctx, rpcURL)
+	if err != nil {
+		return decimal.Zero, fmt.Errorf("dial %s: %w", rpcURL, err)
+	}
+	defer cl.Close()
+	wei, err := cl.BalanceAt(ctx, common.HexToAddress(addr), nil)
+	if err != nil {
+		return decimal.Zero, err
+	}
+	return decimal.NewFromBigInt(wei, 0).Shift(-18), nil
+}
+
+// ============================================================================
+// Token discovery
+// ============================================================================
+
+func discoverTokenSet(ctx context.Context, client *sdk.Client, symbol string) []core.Token {
+	assets, err := client.GetAssets(ctx, nil)
+	if err != nil {
+		log.Fatalf("GetAssets failed: %v", err)
+	}
+	for _, a := range assets {
+		if strings.EqualFold(a.Symbol, symbol) {
+			if len(a.Tokens) == 0 {
+				log.Fatalf("asset %s has no supported tokens", symbol)
+			}
+			return a.Tokens
+		}
+	}
+	log.Fatalf("asset %s not supported by node", symbol)
+	return nil
+}
+
+// ============================================================================
+// Client construction
+// ============================================================================
+
+type signers struct {
+	address       string
+	rawSigner     sign.Signer
+	msgSigner     *sign.EthereumMsgSigner
+	channelSigner core.ChannelSigner
+}
+
+func buildSigners(privateKeyHex, label string) signers {
+	raw, err := sign.NewEthereumRawSigner(privateKeyHex)
+	if err != nil {
+		log.Fatalf("invalid %s private key: %v", label, err)
+	}
+	msg, err := sign.NewEthereumMsgSignerFromRaw(raw)
+	if err != nil {
+		log.Fatalf("failed to build %s msg signer: %v", label, err)
+	}
+	ch, err := core.NewChannelDefaultSigner(msg)
+	if err != nil {
+		log.Fatalf("failed to build %s channel signer: %v", label, err)
+	}
+	return signers{
+		address:       raw.PublicKey().Address().String(),
+		rawSigner:     raw,
+		msgSigner:     msg,
+		channelSigner: ch,
+	}
+}
+
+// newClient builds an SDK client with every configured chain RPC attached.
+func newClient(channelSigner core.ChannelSigner, rawSigner sign.Signer) *sdk.Client {
+	opts := make([]sdk.Option, 0, len(chainRPCs))
+	for chainID, url := range chainRPCs {
+		opts = append(opts, sdk.WithBlockchainRPC(chainID, url))
+	}
+	client, err := sdk.NewClient(wsURL, channelSigner, rawSigner, opts...)
+	if err != nil {
+		log.Fatalf("failed to create client: %v", err)
+	}
+	return client
+}
+
+// ============================================================================
+// Session key
+// ============================================================================
+
+func setupSessionKeyClient(ctx context.Context, walletA *sdk.Client, sa signers) *sdk.Client {
+	skRaw, skMsg := generateSessionKey()
+	skAddress := skRaw.PublicKey().Address().String()
+	fmt.Printf("Session key: %s\n", skAddress)
+
+	state := core.ChannelSessionKeyStateV1{
+		UserAddress: sa.address,
+		SessionKey:  skAddress,
+		Version:     1,
+		Assets:      []string{asset},
+		ExpiresAt:   time.Now().Add(24 * time.Hour),
+	}
+
+	userSig, err := walletA.SignChannelSessionKeyState(state)
+	if err != nil {
+		log.Fatalf("sign session key state: %v", err)
+	}
+	state.UserSig = userSig
+
+	skSig, err := sdk.SignChannelSessionKeyOwnership(state, skMsg)
+	if err != nil {
+		log.Fatalf("sign session key ownership: %v", err)
+	}
+	state.SessionKeySig = skSig
+
+	if err := walletA.SubmitChannelSessionKeyState(ctx, state); err != nil {
+		log.Fatalf("submit session key state: %v", err)
+	}
+
+	metadataHash, err := core.GetChannelSessionKeyAuthMetadataHashV1(state.UserAddress, state.Version, state.Assets, state.ExpiresAt.Unix())
+	if err != nil {
+		log.Fatalf("compute metadata hash: %v", err)
+	}
+	skChannelSigner, err := core.NewChannelSessionKeySignerV1(skMsg, metadataHash.Hex(), state.UserSig)
+	if err != nil {
+		log.Fatalf("build session-key channel signer: %v", err)
+	}
+
+	// rawSigner stays as the wallet's key: the SDK uses it to derive the
+	// user address and to sign on-chain checkpoint transactions.
+	opts := make([]sdk.Option, 0, len(chainRPCs))
+	for chainID, url := range chainRPCs {
+		opts = append(opts, sdk.WithBlockchainRPC(chainID, url))
+	}
+	client, err := sdk.NewClient(wsURL, skChannelSigner, sa.rawSigner, opts...)
+	if err != nil {
+		log.Fatalf("build session-key client: %v", err)
+	}
+	return client
+}
+
+func generateSessionKey() (sign.Signer, *sign.EthereumMsgSigner) {
+	priv, err := crypto.GenerateKey()
+	if err != nil {
+		log.Fatalf("generate session key: %v", err)
+	}
+	privHex := hexutil.Encode(crypto.FromECDSA(priv))
+	raw, err := sign.NewEthereumRawSigner(privHex)
+	if err != nil {
+		log.Fatalf("session-key raw signer: %v", err)
+	}
+	msg, err := sign.NewEthereumMsgSigner(privHex)
+	if err != nil {
+		log.Fatalf("session-key msg signer: %v", err)
+	}
+	return raw, msg
+}
+
+// ============================================================================
+// Wait helpers
+// ============================================================================
+
+// checkpointAndWait runs Checkpoint and polls GetHomeChannel until the node
+// observes expectedVersion. Mirrors the helper in
+// sdk/go/examples/channel_session_key/lifecycle.go.
+func checkpointAndWait(ctx context.Context, client *sdk.Client, asset string, expectedVersion uint64) {
+	txHash, err := client.Checkpoint(ctx, asset)
+	if err != nil {
+		log.Fatalf("checkpoint %s failed: %v", asset, err)
+	}
+	fmt.Printf("    ↳ checkpoint %s tx %s; waiting for state_version=%d...\n", asset, txHash, expectedVersion)
+
+	wallet := client.GetUserAddress()
+	deadline := time.Now().Add(2 * time.Minute)
+	for {
+		channel, err := client.GetHomeChannel(ctx, wallet, asset)
+		if err != nil {
+			log.Fatalf("GetHomeChannel %s: %v", asset, err)
+		}
+		if channel != nil && channel.StateVersion >= expectedVersion {
+			return
+		}
+		if time.Now().After(deadline) {
+			log.Fatalf("timed out waiting for %s to reach state_version=%d", asset, expectedVersion)
+		}
+		time.Sleep(2 * time.Second)
+	}
+}
+
+// waitForOnChain polls until addr's ERC-20 balance of asset on chainID is at
+// least minAmount. Needed between iterations because Withdraw's on-chain
+// settlement can lag the node's state_version bump.
+func waitForOnChain(ctx context.Context, client *sdk.Client, chainID uint64, asset, addr string, minAmount decimal.Decimal) {
+	deadline := time.Now().Add(2 * time.Minute)
+	for {
+		have, err := client.GetOnChainBalance(ctx, chainID, asset, addr)
+		if err != nil {
+			log.Fatalf("GetOnChainBalance chain %d: %v", chainID, err)
+		}
+		if have.GreaterThanOrEqual(minAmount) {
+			fmt.Printf("    ↳ on-chain balance on chain %d settled: %s %s\n", chainID, have, asset)
+			return
+		}
+		if time.Now().After(deadline) {
+			log.Fatalf("timed out waiting for chain %d %s balance >= %s (have %s)", chainID, asset, minAmount, have)
+		}
+		time.Sleep(2 * time.Second)
+	}
+}

--- a/sdk/go/examples/round_robin/main.go
+++ b/sdk/go/examples/round_robin/main.go
@@ -54,12 +54,14 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
 	"strings"
 	"time"
 
+	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -80,8 +82,8 @@ const (
 
 	// Replace with your hex private keys. privA performs every channel
 	// operation; privB only receives transfers and sends them back.
-	privA = "0x7d607..."
-	privB = "0x4f3a1..."
+	privA = "0x7d6071..."
+	privB = "0xf63695..."
 
 	// Empty string disables the session-key path; the wallet client performs
 	// channel operations directly. Otherwise this key is registered as a
@@ -100,10 +102,10 @@ var transferAmount = decimal.NewFromFloat(0.00001)
 // chainRPCs maps blockchain ID -> JSON-RPC endpoint. Must cover every chain
 // in tokenSet (derived at runtime). Missing entries fail preflight.
 var chainRPCs = map[uint64]string{
-	11155111: "https://sepolia.drpc.org",         // Ethereum Sepolia
-	84532:    "https://sepolia.base.org",         // Base Sepolia
+	11155111: "https://sepolia.drpc.org",            // Ethereum Sepolia
+	84532:    "https://sepolia.base.org",            // Base Sepolia
 	80002:    "https://rpc-amoy.polygon.technology", // Polygon Amoy
-	59141:    "https://rpc.sepolia.linea.build",  // Linea Sepolia
+	59141:    "https://rpc.sepolia.linea.build",     // Linea Sepolia
 }
 
 // minNativeBalances maps blockchain ID -> minimum native gas balance for
@@ -185,10 +187,15 @@ func runIteration(
 ) {
 	fmt.Printf("--- iter %d: deposit on chain %d, withdraw on chain %d ---\n", i, cur.BlockchainID, next.BlockchainID)
 
-	// 2.a A deposits transferAmount on cur.BlockchainID.
-	if _, err := opsClient.ApproveToken(ctx, cur.BlockchainID, asset, transferAmount); err != nil {
+	// 2.a A deposits transferAmount on cur.BlockchainID. Wait for the approve
+	// tx to be mined before issuing Deposit; ApproveToken returns immediately
+	// after broadcast, and Deposit will revert if the allowance has not
+	// settled on-chain yet.
+	approveTx, err := opsClient.ApproveToken(ctx, cur.BlockchainID, asset, transferAmount)
+	if err != nil {
 		log.Fatalf("iter %d: approve on chain %d failed: %v", i, cur.BlockchainID, err)
 	}
+	waitForTxReceipt(ctx, chainRPCs[cur.BlockchainID], approveTx)
 	depositState, err := opsClient.Deposit(ctx, cur.BlockchainID, asset, transferAmount)
 	if err != nil {
 		log.Fatalf("iter %d: deposit on chain %d failed: %v", i, cur.BlockchainID, err)
@@ -203,12 +210,11 @@ func runIteration(
 	fmt.Printf("  ✓ A transferred %s %s to B (off-chain)\n", transferAmount, asset)
 
 	// 2.c A closes home channel for asset on cur.BlockchainID.
-	closeState, err := opsClient.CloseHomeChannel(ctx, asset)
-	if err != nil {
+	if _, err := opsClient.CloseHomeChannel(ctx, asset); err != nil {
 		log.Fatalf("iter %d: close home channel failed: %v", i, err)
 	}
 	fmt.Printf("  ✓ A closed home channel for %s\n", asset)
-	checkpointAndWait(ctx, opsClient, asset, closeState.Version)
+	closeAndWait(ctx, opsClient, asset)
 
 	// 2.d B -> A (off-chain credit, lands on void state, no chain attached).
 	if _, err := walletB.Transfer(ctx, addrA, asset, transferAmount); err != nil {
@@ -307,6 +313,37 @@ func nativeBalance(ctx context.Context, rpcURL, addr string) (decimal.Decimal, e
 		return decimal.Zero, err
 	}
 	return decimal.NewFromBigInt(wei, 0).Shift(-18), nil
+}
+
+// waitForTxReceipt polls rpcURL until the given tx is mined and asserts a
+// successful (status=1) receipt. Fatals on revert or timeout. Needed because
+// the SDK's ApproveToken returns immediately after broadcast, and the
+// downstream Deposit call would otherwise race the allowance update.
+func waitForTxReceipt(ctx context.Context, rpcURL, txHash string) {
+	cl, err := ethclient.DialContext(ctx, rpcURL)
+	if err != nil {
+		log.Fatalf("dial %s: %v", rpcURL, err)
+	}
+	defer cl.Close()
+
+	hash := common.HexToHash(txHash)
+	deadline := time.Now().Add(2 * time.Minute)
+	for {
+		receipt, err := cl.TransactionReceipt(ctx, hash)
+		if err == nil {
+			if receipt.Status != 1 {
+				log.Fatalf("tx %s reverted on-chain", txHash)
+			}
+			return
+		}
+		if !errors.Is(err, ethereum.NotFound) {
+			log.Fatalf("TransactionReceipt %s: %v", txHash, err)
+		}
+		if time.Now().After(deadline) {
+			log.Fatalf("timed out waiting for tx %s", txHash)
+		}
+		time.Sleep(2 * time.Second)
+	}
 }
 
 // ============================================================================
@@ -451,15 +488,16 @@ func generateSessionKey() (sign.Signer, *sign.EthereumMsgSigner) {
 // Wait helpers
 // ============================================================================
 
-// checkpointAndWait runs Checkpoint and polls GetHomeChannel until the node
-// observes expectedVersion. Mirrors the helper in
-// sdk/go/examples/channel_session_key/lifecycle.go.
-func checkpointAndWait(ctx context.Context, client *sdk.Client, asset string, expectedVersion uint64) {
+// closeAndWait runs Checkpoint after a Finalize transition and polls
+// GetHomeChannel until the node observes the on-chain close. Closure is
+// signalled either by the home-channel row dropping out (nil) or by its
+// status being reset to Void.
+func closeAndWait(ctx context.Context, client *sdk.Client, asset string) {
 	txHash, err := client.Checkpoint(ctx, asset)
 	if err != nil {
-		log.Fatalf("checkpoint %s failed: %v", asset, err)
+		log.Fatalf("checkpoint %s (close) failed: %v", asset, err)
 	}
-	fmt.Printf("    ↳ checkpoint %s tx %s; waiting for state_version=%d...\n", asset, txHash, expectedVersion)
+	fmt.Printf("    ↳ checkpoint %s tx %s; waiting for channel close (nil or status=Void)...\n", asset, txHash)
 
 	wallet := client.GetUserAddress()
 	deadline := time.Now().Add(2 * time.Minute)
@@ -468,10 +506,54 @@ func checkpointAndWait(ctx context.Context, client *sdk.Client, asset string, ex
 		if err != nil {
 			log.Fatalf("GetHomeChannel %s: %v", asset, err)
 		}
-		if channel != nil && channel.StateVersion >= expectedVersion {
+		if channel == nil || channel.Status == core.ChannelStatusVoid {
 			return
 		}
 		if time.Now().After(deadline) {
+			log.Fatalf("timed out waiting for %s channel to close (last status=%s)", asset, channel.Status)
+		}
+		time.Sleep(2 * time.Second)
+	}
+}
+
+// checkpointAndWait runs Checkpoint and polls GetHomeChannel until the node
+// observes the expected post-checkpoint state.
+//
+// When expectedVersion > 0 the helper waits for channel.StateVersion to catch
+// up to expectedVersion. When expectedVersion == 0 — which happens for the
+// channel-creation transitions issued by Deposit / Withdraw on a void state —
+// the state_version stays at 0 even after the checkpoint, so the helper
+// instead waits for channel.Status == Open.
+func checkpointAndWait(ctx context.Context, client *sdk.Client, asset string, expectedVersion uint64) {
+	txHash, err := client.Checkpoint(ctx, asset)
+	if err != nil {
+		log.Fatalf("checkpoint %s failed: %v", asset, err)
+	}
+	if expectedVersion == 0 {
+		fmt.Printf("    ↳ checkpoint %s tx %s; waiting for channel status=Open...\n", asset, txHash)
+	} else {
+		fmt.Printf("    ↳ checkpoint %s tx %s; waiting for state_version=%d...\n", asset, txHash, expectedVersion)
+	}
+
+	wallet := client.GetUserAddress()
+	deadline := time.Now().Add(2 * time.Minute)
+	for {
+		channel, err := client.GetHomeChannel(ctx, wallet, asset)
+		if err != nil {
+			log.Fatalf("GetHomeChannel %s: %v", asset, err)
+		}
+		if channel != nil {
+			if expectedVersion == 0 && channel.Status == core.ChannelStatusOpen {
+				return
+			}
+			if expectedVersion > 0 && channel.StateVersion >= expectedVersion {
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			if expectedVersion == 0 {
+				log.Fatalf("timed out waiting for %s channel to reach status=Open", asset)
+			}
 			log.Fatalf("timed out waiting for %s to reach state_version=%d", asset, expectedVersion)
 		}
 		time.Sleep(2 * time.Second)

--- a/sdk/go/examples/round_robin/main.go
+++ b/sdk/go/examples/round_robin/main.go
@@ -463,14 +463,50 @@ func newClient(channelSigner core.ChannelSigner, rawSigner sign.Signer) *sdk.Cli
 // ============================================================================
 
 func setupSessionKeyClient(ctx context.Context, walletA *sdk.Client, sa signers) *sdk.Client {
-	skRaw, skMsg := generateSessionKey()
+	var skRaw sign.Signer
+	var skMsg *sign.EthereumMsgSigner
+	if sessionKeyPriv == "" {
+		skRaw, skMsg = generateSessionKey()
+	} else {
+		var err error
+		skRaw, err = sign.NewEthereumRawSigner(sessionKeyPriv)
+		if err != nil {
+			log.Fatalf("invalid sessionKeyPriv: %v", err)
+		}
+		skMsg, err = sign.NewEthereumMsgSigner(sessionKeyPriv)
+		if err != nil {
+			log.Fatalf("session-key msg signer: %v", err)
+		}
+	}
 	skAddress := skRaw.PublicKey().Address().String()
 	fmt.Printf("Session key: %s\n", skAddress)
+
+	// If a session-key state already exists for this address (active or
+	// expired/revoked), the protocol requires the next submission to use a
+	// strictly higher monotonic version. Look up the latest stored version
+	// and start from version+1; otherwise begin at 1.
+	includeInactive := true
+	prior, err := walletA.GetLastChannelKeyStates(ctx, sa.address, &sdk.GetLastChannelKeyStatesOptions{
+		SessionKey:      &skAddress,
+		IncludeInactive: &includeInactive,
+	})
+	if err != nil {
+		log.Fatalf("lookup prior session key states: %v", err)
+	}
+	version := uint64(1)
+	for _, p := range prior {
+		if p.Version >= version {
+			version = p.Version + 1
+		}
+	}
+	if version > 1 {
+		fmt.Printf("  ↳ existing state found at version %d, registering v%d\n", version-1, version)
+	}
 
 	state := core.ChannelSessionKeyStateV1{
 		UserAddress: sa.address,
 		SessionKey:  skAddress,
-		Version:     1,
+		Version:     version,
 		Assets:      []string{asset},
 		ExpiresAt:   time.Now().Add(24 * time.Hour),
 	}

--- a/sdk/go/examples/round_robin/main.go
+++ b/sdk/go/examples/round_robin/main.go
@@ -106,6 +106,15 @@ var chainRPCs = map[uint64]string{
 	84532:    "https://sepolia.base.org",            // Base Sepolia
 	80002:    "https://rpc-amoy.polygon.technology", // Polygon Amoy
 	59141:    "https://rpc.sepolia.linea.build",     // Linea Sepolia
+	1449000:  "https://rpc.testnet.xrplevm.org",     // XRP LVM Testnet
+
+	1:       "https://0xrpc.io/eth",                   // Ethereum Mainnet
+	14:      "https://rpc.ankr.com/flare",             // Flare Mainnet
+	56:      "https://bsc.api.pocket.network",         // BNB Smart Chain Mainnet
+	137:     "https://polygon-bor-rpc.publicnode.com", // Polygon Mainnet
+	8453:    "https://base-rpc.publicnode.com",        // Base Mainnet
+	59144:   "https://linea.drpc.org",                 // Linea Mainnet
+	1440000: "https://xrpl.drpc.org",                  // XRP EVM Mainnet
 }
 
 // minNativeBalances maps blockchain ID -> minimum native gas balance for
@@ -116,6 +125,15 @@ var minNativeBalances = map[uint64]decimal.Decimal{
 	84532:    decimal.NewFromFloat(0.005),
 	80002:    decimal.NewFromFloat(0.05),
 	59141:    decimal.NewFromFloat(0.005),
+	1449000:  decimal.NewFromFloat(0.001),
+
+	1:       decimal.NewFromFloat(0.001),
+	14:      decimal.NewFromFloat(0.001),
+	56:      decimal.NewFromFloat(0.001),
+	137:     decimal.NewFromFloat(3),
+	8453:    decimal.NewFromFloat(0.001),
+	59144:   decimal.NewFromFloat(0.001),
+	1440000: decimal.NewFromFloat(0.001),
 }
 
 // ============================================================================
@@ -315,10 +333,20 @@ func nativeBalance(ctx context.Context, rpcURL, addr string) (decimal.Decimal, e
 	return decimal.NewFromBigInt(wei, 0).Shift(-18), nil
 }
 
+// approveConfirmations is the number of additional blocks the example waits
+// for after an approve tx receipt before issuing the downstream deposit /
+// checkpoint. Public RPC endpoints are often load-balanced across multiple
+// nodes, and an eth_call read can hit a node that has not yet indexed the
+// approve. Waiting a few blocks past the receipt gives the cluster time to
+// converge on the post-tx state.
+const approveConfirmations uint64 = 3
+
 // waitForTxReceipt polls rpcURL until the given tx is mined and asserts a
-// successful (status=1) receipt. Fatals on revert or timeout. Needed because
+// successful (status=1) receipt, then waits for approveConfirmations more
+// blocks on top before returning. Fatals on revert or timeout. Needed because
 // the SDK's ApproveToken returns immediately after broadcast, and the
-// downstream Deposit call would otherwise race the allowance update.
+// downstream Deposit / Checkpoint would otherwise race the allowance update
+// on load-balanced public RPCs.
 func waitForTxReceipt(ctx context.Context, rpcURL, txHash string) {
 	cl, err := ethclient.DialContext(ctx, rpcURL)
 	if err != nil {
@@ -328,19 +356,37 @@ func waitForTxReceipt(ctx context.Context, rpcURL, txHash string) {
 
 	hash := common.HexToHash(txHash)
 	deadline := time.Now().Add(2 * time.Minute)
+
+	var minedBlock uint64
 	for {
 		receipt, err := cl.TransactionReceipt(ctx, hash)
 		if err == nil {
 			if receipt.Status != 1 {
 				log.Fatalf("tx %s reverted on-chain", txHash)
 			}
-			return
+			minedBlock = receipt.BlockNumber.Uint64()
+			break
 		}
 		if !errors.Is(err, ethereum.NotFound) {
 			log.Fatalf("TransactionReceipt %s: %v", txHash, err)
 		}
 		if time.Now().After(deadline) {
 			log.Fatalf("timed out waiting for tx %s", txHash)
+		}
+		time.Sleep(2 * time.Second)
+	}
+
+	target := minedBlock + approveConfirmations
+	for {
+		head, err := cl.BlockNumber(ctx)
+		if err != nil {
+			log.Fatalf("BlockNumber on %s: %v", rpcURL, err)
+		}
+		if head >= target {
+			return
+		}
+		if time.Now().After(deadline) {
+			log.Fatalf("timed out waiting for %d confirmations on tx %s (head=%d, target=%d)", approveConfirmations, txHash, head, target)
 		}
 		time.Sleep(2 * time.Second)
 	}

--- a/sdk/ts/examples/round_robin/lifecycle.ts
+++ b/sdk/ts/examples/round_robin/lifecycle.ts
@@ -1,0 +1,388 @@
+/**
+ * Example: Round Robin Test
+ *
+ * Exercises every basic channel action (deposit, transfer, close, withdraw)
+ * for one asset across every chain on which that asset is supported.
+ *
+ * ---------------------------------------------------------------------------
+ * Flow
+ * ---------------------------------------------------------------------------
+ *
+ *  1. Preparation
+ *     a. Set up wallet signers for private keys A and B.
+ *     b. Build tokenSet: every supported token for the configured asset,
+ *        paired with its chain's JSON-RPC endpoint. tokenSet[i].blockchainId
+ *        must have an entry in chainRPCs.
+ *     c. Ensure signer A holds >= minNativeBalances[chainId] of the native
+ *        gas token on every chain in tokenSet. Each chain pays three
+ *        checkpoint transactions per run (deposit + close + withdraw).
+ *     d. Ensure signer A holds >= transferAmount of the configured asset on
+ *        tokenSet[0].blockchainId. Subsequent iterations are seeded by the
+ *        previous iteration's withdrawal — no other chain needs to be
+ *        pre-funded with the asset.
+ *     e. If sessionKeyPriv is non-empty, register it as a channel session
+ *        key for signer A and use the session-key-backed client for every
+ *        channel operation in the loop.
+ *
+ *  2. For i = 0 .. tokenSet.length-1 (let next = (i + 1) % tokenSet.length):
+ *     a. Signer A deposits transferAmount of tokenSet[i].
+ *     b. Signer A transfers transferAmount to signer B (off-chain).
+ *     c. Signer A closes the home channel for the asset.
+ *     d. Signer B transfers transferAmount back to signer A (lands on a
+ *        void state, no chain attached).
+ *     e. Signer A withdraws transferAmount on tokenSet[next].blockchainId,
+ *        which auto-creates a new channel on that chain. On the last
+ *        iteration this wraps to tokenSet[0], closing the loop.
+ *
+ * Together (2.a–2.e) exercise deposit / transfer-send / close /
+ * transfer-receive / withdraw on every chain in tokenSet.
+ *
+ * ---------------------------------------------------------------------------
+ * Operational notes
+ * ---------------------------------------------------------------------------
+ *
+ *   - wsURL must point at a reachable nitronode WebSocket endpoint.
+ *   - The nitronode must maintain reserves of the asset on every chain in
+ *     tokenSet. 2.e withdraws tokens signer A never deposited on that chain,
+ *     which only works if the node holds liquidity there.
+ *   - tokenSet is derived at runtime from getAssets(asset).tokens; the
+ *     iteration order matches the order returned by the node.
+ *   - The example exits non-zero on the first failure. It does not reset
+ *     state, so re-running on the same wallets resumes from whatever state
+ *     the node holds. Fresh wallets give the cleanest preflight numbers.
+ */
+
+// Node <22 does not expose a stable global WebSocket. The SDK dialer uses
+// `new WebSocket(url)` directly, so we polyfill the global from the `ws`
+// package before any client is constructed.
+import WebSocket from 'ws';
+if (typeof (globalThis as { WebSocket?: unknown }).WebSocket === 'undefined') {
+  (globalThis as { WebSocket: unknown }).WebSocket = WebSocket;
+}
+
+import Decimal from 'decimal.js';
+import { Address, createPublicClient, http, Hex } from 'viem';
+import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
+
+import { Client } from '../../src/client';
+import {
+  createSigners,
+  EthereumMsgSigner,
+  EthereumRawSigner,
+  ChannelSessionKeyStateSigner,
+} from '../../src/signers';
+import { withBlockchainRPC } from '../../src/config';
+import { ChannelSessionKeyStateV1 } from '../../src/rpc/types';
+import { getChannelSessionKeyAuthMetadataHashV1 } from '../../src/core/utils';
+import { Token } from '../../src/core/types';
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+const wsURL = 'wss://nitronode-sandbox.yellow.org/v1/ws';
+
+// Replace with your hex private keys. privA performs every channel
+// operation; privB only receives transfers and sends them back.
+const privA = '0x7d607...' as Hex;
+const privB = '0x4f3a1...' as Hex;
+
+// Empty string disables the session-key path; the wallet client performs
+// channel operations directly. Otherwise this key is registered as a channel
+// session key for privA and used for the loop.
+const sessionKeyPriv = '' as Hex | '';
+
+// Asset symbol to test. tokenSet is built from this asset's tokens as
+// returned by the node.
+const asset = 'yusd';
+
+// transferAmount is the value used for every deposit / transfer / withdraw
+// in the loop. Keep this small for testnets.
+const transferAmount = new Decimal('0.00001');
+
+// chainRPCs maps blockchain id -> JSON-RPC endpoint. Must cover every chain
+// in tokenSet (derived at runtime). Missing entries fail preflight.
+const chainRPCs: Record<string, string> = {
+  '11155111': 'https://sepolia.drpc.org',              // Ethereum Sepolia
+  '84532':    'https://sepolia.base.org',              // Base Sepolia
+  '80002':    'https://rpc-amoy.polygon.technology',   // Polygon Amoy
+  '59141':    'https://rpc.sepolia.linea.build',       // Linea Sepolia
+};
+
+// minNativeBalances maps blockchain id -> minimum native gas balance for
+// privA. Sized to cover three checkpoint transactions (deposit + close +
+// withdraw). Tune per chain based on observed gas costs.
+const minNativeBalances: Record<string, Decimal> = {
+  '11155111': new Decimal('0.01'),
+  '84532':    new Decimal('0.005'),
+  '80002':    new Decimal('0.05'),
+  '59141':    new Decimal('0.005'),
+};
+
+// ============================================================================
+// Main
+// ============================================================================
+
+async function main() {
+  // --- Build wallet clients for A and B with every RPC pre-registered ---
+  const signersA = createSigners(privA);
+  const signersB = createSigners(privB);
+  const addrA = signersA.stateSigner.getAddress();
+  const addrB = signersB.stateSigner.getAddress();
+  console.log(`Wallet A: ${addrA}\nWallet B: ${addrB}\n`);
+
+  const walletA = await newClient(signersA.stateSigner, signersA.txSigner);
+  const walletB = await newClient(signersB.stateSigner, signersB.txSigner);
+
+  let opsClient = walletA;
+  try {
+    // --- 1.b: discover tokenSet for the configured asset ---
+    console.log('=== 1.b: Discovering tokenSet ===');
+    const tokenSet = await discoverTokenSet(walletA, asset);
+    tokenSet.forEach((t, i) =>
+      console.log(`  [${i}] ${t.symbol} on chain ${t.blockchainId} (${t.address})`)
+    );
+    console.log();
+
+    // --- 1.c + 1.d: preflight native and asset balances ---
+    console.log('=== 1.c + 1.d: Preflight ===');
+    await preflight(walletA, addrA, tokenSet);
+    console.log('✓ preflight passed\n');
+
+    // --- 1.e: optional session-key registration ---
+    if (sessionKeyPriv !== '') {
+      console.log('=== 1.e: Registering channel session key ===');
+      opsClient = await setupSessionKeyClient(walletA, addrA);
+      console.log('✓ session-key client ready\n');
+    }
+
+    // --- 2: round-robin loop ---
+    console.log('=== 2: Round robin ===');
+    for (let i = 0; i < tokenSet.length; i++) {
+      const next = (i + 1) % tokenSet.length;
+      await runIteration(i, opsClient, walletB, addrA, addrB, tokenSet[i], tokenSet[next]);
+    }
+
+    console.log('\n=== Example Complete ===');
+  } finally {
+    if (opsClient !== walletA) await opsClient.close();
+    await walletA.close();
+    await walletB.close();
+  }
+}
+
+// ============================================================================
+// Iteration
+// ============================================================================
+
+async function runIteration(
+  i: number,
+  opsClient: Client,
+  walletB: Client,
+  addrA: Address,
+  addrB: Address,
+  cur: Token,
+  next: Token
+): Promise<void> {
+  console.log(`--- iter ${i}: deposit on chain ${cur.blockchainId}, withdraw on chain ${next.blockchainId} ---`);
+
+  // 2.a A deposits transferAmount on cur.blockchainId.
+  await opsClient.approveToken(cur.blockchainId, asset, transferAmount);
+  const depositState = await opsClient.deposit(cur.blockchainId, asset, transferAmount);
+  console.log(`  ✓ A deposited ${transferAmount} ${asset} on chain ${cur.blockchainId}`);
+  await checkpointAndWait(opsClient, asset, depositState.version);
+
+  // 2.b A -> B (off-chain).
+  await opsClient.transfer(addrB, asset, transferAmount);
+  console.log(`  ✓ A transferred ${transferAmount} ${asset} to B (off-chain)`);
+
+  // 2.c A closes home channel for asset on cur.blockchainId.
+  const closeState = await opsClient.closeHomeChannel(asset);
+  console.log(`  ✓ A closed home channel for ${asset}`);
+  await checkpointAndWait(opsClient, asset, closeState.version);
+
+  // 2.d B -> A (off-chain credit, lands on void state, no chain attached).
+  await walletB.transfer(addrA, asset, transferAmount);
+  console.log(`  ✓ B transferred ${transferAmount} ${asset} back to A (off-chain credit)`);
+
+  // 2.e A withdraws on next.blockchainId. Withdraw auto-creates a new channel
+  // on next.blockchainId because A's latest state is void after close +
+  // transfer-receive.
+  const withdrawState = await opsClient.withdraw(next.blockchainId, asset, transferAmount);
+  console.log(`  ✓ A withdrew ${transferAmount} ${asset} on chain ${next.blockchainId}`);
+  await checkpointAndWait(opsClient, asset, withdrawState.version);
+
+  await waitForOnChain(opsClient, next.blockchainId, asset, addrA, transferAmount);
+  console.log();
+}
+
+// ============================================================================
+// Preflight
+// ============================================================================
+
+async function preflight(walletA: Client, addrA: Address, tokenSet: Token[]): Promise<void> {
+  const shortfalls: string[] = [];
+
+  for (const t of tokenSet) {
+    const key = t.blockchainId.toString();
+    if (!(key in chainRPCs)) shortfalls.push(`chainRPCs missing entry for chain ${key}`);
+    if (!(key in minNativeBalances)) shortfalls.push(`minNativeBalances missing entry for chain ${key}`);
+  }
+  if (shortfalls.length > 0) {
+    console.log('Configuration shortfalls:');
+    shortfalls.forEach((s) => console.log(`  - ${s}`));
+    process.exit(1);
+  }
+
+  // 1.c: native balance on every chain >= minNativeBalances.
+  console.log('Native balance check:');
+  for (const t of tokenSet) {
+    const key = t.blockchainId.toString();
+    const have = await nativeBalance(chainRPCs[key], addrA);
+    const need = minNativeBalances[key];
+    const marker = have.gte(need) ? '✓' : '✗';
+    if (have.lt(need)) {
+      shortfalls.push(`chain ${key} native: need >= ${need}, have ${have}`);
+    }
+    console.log(`  ${marker} chain ${key}: need >= ${need}, have ${have}`);
+  }
+
+  // 1.d: privA holds >= transferAmount of asset on tokenSet[0].blockchainId.
+  const seedChain = tokenSet[0].blockchainId;
+  const have = await walletA.getOnChainBalance(seedChain, asset, addrA);
+  const marker = have.gte(transferAmount) ? '✓' : '✗';
+  if (have.lt(transferAmount)) {
+    shortfalls.push(`chain ${seedChain} ${asset}: need >= ${transferAmount}, have ${have}`);
+  }
+  console.log(`Asset balance check:\n  ${marker} chain ${seedChain} ${asset}: need >= ${transferAmount}, have ${have}`);
+
+  if (shortfalls.length > 0) {
+    console.log('\nPreflight failed. Resolve the following before re-running:');
+    shortfalls.forEach((s) => console.log(`  - ${s}`));
+    process.exit(1);
+  }
+}
+
+async function nativeBalance(rpcURL: string, addr: Address): Promise<Decimal> {
+  const pc = createPublicClient({ transport: http(rpcURL) });
+  const wei = await pc.getBalance({ address: addr });
+  return new Decimal(wei.toString()).div(new Decimal(10).pow(18));
+}
+
+// ============================================================================
+// Token discovery
+// ============================================================================
+
+async function discoverTokenSet(client: Client, symbol: string): Promise<Token[]> {
+  const assets = await client.getAssets();
+  const found = assets.find((a) => a.symbol.toLowerCase() === symbol.toLowerCase());
+  if (!found) throw new Error(`asset ${symbol} not supported by node`);
+  if (found.tokens.length === 0) throw new Error(`asset ${symbol} has no supported tokens`);
+  return found.tokens;
+}
+
+// ============================================================================
+// Client construction
+// ============================================================================
+
+async function newClient(stateSigner: any, txSigner: any): Promise<Client> {
+  const opts = Object.entries(chainRPCs).map(([id, url]) => withBlockchainRPC(BigInt(id), url));
+  return await Client.create(wsURL, stateSigner, txSigner, ...opts);
+}
+
+// ============================================================================
+// Session key
+// ============================================================================
+
+async function setupSessionKeyClient(walletA: Client, addrA: Address): Promise<Client> {
+  const sessionKey = sessionKeyPriv === '' ? generatePrivateKey() : (sessionKeyPriv as Hex);
+  const skAccount = privateKeyToAccount(sessionKey);
+  const skAddress = skAccount.address;
+  const skMsg = new EthereumMsgSigner(sessionKey);
+  console.log(`Session key: ${skAddress}`);
+
+  const expiresAt = BigInt(Math.floor(Date.now() / 1000) + 24 * 60 * 60);
+  const state: ChannelSessionKeyStateV1 = {
+    user_address: addrA,
+    session_key: skAddress,
+    version: '1',
+    assets: [asset],
+    expires_at: expiresAt.toString(),
+    user_sig: '',
+    session_key_sig: '',
+  };
+
+  state.user_sig = await walletA.signChannelSessionKeyState(state);
+  state.session_key_sig = await walletA.signChannelSessionKeyOwnership(state, skMsg);
+  await walletA.submitChannelSessionKeyState(state);
+
+  const metadataHash = getChannelSessionKeyAuthMetadataHashV1(
+    addrA,
+    BigInt(state.version),
+    state.assets,
+    BigInt(state.expires_at)
+  );
+
+  // user_sig has been stripped of any ChannelSigner type-byte prefix by
+  // signChannelSessionKeyState before submission, so it is the raw EIP-191
+  // signature expected by the session-key signer.
+  const stateSigner = new ChannelSessionKeyStateSigner(
+    sessionKey,
+    addrA,
+    metadataHash,
+    state.user_sig as Hex
+  );
+
+  // txSigner stays as the wallet's key: the SDK uses it to derive the user
+  // address and to sign on-chain checkpoint transactions.
+  const txSigner = new EthereumRawSigner(privA);
+
+  const opts = Object.entries(chainRPCs).map(([id, url]) => withBlockchainRPC(BigInt(id), url));
+  return await Client.create(wsURL, stateSigner, txSigner, ...opts);
+}
+
+// ============================================================================
+// Wait helpers
+// ============================================================================
+
+async function checkpointAndWait(client: Client, asset: string, expectedVersion: bigint): Promise<void> {
+  const txHash = await client.checkpoint(asset);
+  console.log(`    ↳ checkpoint ${asset} tx ${txHash}; waiting for state_version=${expectedVersion}...`);
+
+  const wallet = client.getUserAddress();
+  const deadline = Date.now() + 2 * 60 * 1000;
+  while (true) {
+    const channel = await client.getHomeChannel(wallet, asset);
+    if (channel !== null && channel.stateVersion >= expectedVersion) return;
+    if (Date.now() > deadline) {
+      throw new Error(`timed out waiting for ${asset} to reach state_version=${expectedVersion}`);
+    }
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+}
+
+async function waitForOnChain(
+  client: Client,
+  chainId: bigint,
+  asset: string,
+  addr: Address,
+  minAmount: Decimal
+): Promise<void> {
+  const deadline = Date.now() + 2 * 60 * 1000;
+  while (true) {
+    const have = await client.getOnChainBalance(chainId, asset, addr);
+    if (have.gte(minAmount)) {
+      console.log(`    ↳ on-chain balance on chain ${chainId} settled: ${have} ${asset}`);
+      return;
+    }
+    if (Date.now() > deadline) {
+      throw new Error(`timed out waiting for chain ${chainId} ${asset} balance >= ${minAmount} (have ${have})`);
+    }
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+}
+
+main().catch((error) => {
+  console.error('Fatal error:', error);
+  process.exit(1);
+});

--- a/sdk/ts/examples/round_robin/lifecycle.ts
+++ b/sdk/ts/examples/round_robin/lifecycle.ts
@@ -74,7 +74,7 @@ import {
 import { withBlockchainRPC } from '../../src/config';
 import { ChannelSessionKeyStateV1 } from '../../src/rpc/types';
 import { getChannelSessionKeyAuthMetadataHashV1 } from '../../src/core/utils';
-import { Token } from '../../src/core/types';
+import { ChannelStatus, Token } from '../../src/core/types';
 
 // ============================================================================
 // Configuration
@@ -84,8 +84,8 @@ const wsURL = 'wss://nitronode-sandbox.yellow.org/v1/ws';
 
 // Replace with your hex private keys. privA performs every channel
 // operation; privB only receives transfers and sends them back.
-const privA = '0x7d607...' as Hex;
-const privB = '0x4f3a1...' as Hex;
+const privA = '0x7d6071...' as Hex;
+const privB = '0xf63695...' as Hex;
 
 // Empty string disables the session-key path; the wallet client performs
 // channel operations directly. Otherwise this key is registered as a channel
@@ -197,9 +197,9 @@ async function runIteration(
   console.log(`  ✓ A transferred ${transferAmount} ${asset} to B (off-chain)`);
 
   // 2.c A closes home channel for asset on cur.blockchainId.
-  const closeState = await opsClient.closeHomeChannel(asset);
+  await opsClient.closeHomeChannel(asset);
   console.log(`  ✓ A closed home channel for ${asset}`);
-  await checkpointAndWait(opsClient, asset, closeState.version);
+  await closeAndWait(opsClient, asset);
 
   // 2.d B -> A (off-chain credit, lands on void state, no chain attached).
   await walletB.transfer(addrA, asset, transferAmount);
@@ -345,16 +345,57 @@ async function setupSessionKeyClient(walletA: Client, addrA: Address): Promise<C
 // Wait helpers
 // ============================================================================
 
-async function checkpointAndWait(client: Client, asset: string, expectedVersion: bigint): Promise<void> {
+/**
+ * Runs checkpoint after a finalize transition and polls getHomeChannel until
+ * the node observes the on-chain close. Closure is signalled either by the
+ * home-channel row dropping out (null) or by its status being reset to Void.
+ */
+async function closeAndWait(client: Client, asset: string): Promise<void> {
   const txHash = await client.checkpoint(asset);
-  console.log(`    ↳ checkpoint ${asset} tx ${txHash}; waiting for state_version=${expectedVersion}...`);
+  console.log(`    ↳ checkpoint ${asset} tx ${txHash}; waiting for channel close (null or status=Void)...`);
 
   const wallet = client.getUserAddress();
   const deadline = Date.now() + 2 * 60 * 1000;
   while (true) {
     const channel = await client.getHomeChannel(wallet, asset);
-    if (channel !== null && channel.stateVersion >= expectedVersion) return;
+    if (channel === null || channel.status === ChannelStatus.Void) return;
     if (Date.now() > deadline) {
+      throw new Error(`timed out waiting for ${asset} channel to close (last status=${channel.status})`);
+    }
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+}
+
+/**
+ * Runs checkpoint and polls getHomeChannel until the node observes the
+ * expected post-checkpoint state.
+ *
+ * When expectedVersion > 0 the helper waits for channel.stateVersion to catch
+ * up to expectedVersion. When expectedVersion === 0n — which happens for the
+ * channel-creation transitions issued by deposit / withdraw on a void state —
+ * the state_version stays at 0 even after the checkpoint, so the helper
+ * instead waits for channel.status === Open.
+ */
+async function checkpointAndWait(client: Client, asset: string, expectedVersion: bigint): Promise<void> {
+  const txHash = await client.checkpoint(asset);
+  if (expectedVersion === 0n) {
+    console.log(`    ↳ checkpoint ${asset} tx ${txHash}; waiting for channel status=Open...`);
+  } else {
+    console.log(`    ↳ checkpoint ${asset} tx ${txHash}; waiting for state_version=${expectedVersion}...`);
+  }
+
+  const wallet = client.getUserAddress();
+  const deadline = Date.now() + 2 * 60 * 1000;
+  while (true) {
+    const channel = await client.getHomeChannel(wallet, asset);
+    if (channel !== null) {
+      if (expectedVersion === 0n && channel.status === ChannelStatus.Open) return;
+      if (expectedVersion > 0n && channel.stateVersion >= expectedVersion) return;
+    }
+    if (Date.now() > deadline) {
+      if (expectedVersion === 0n) {
+        throw new Error(`timed out waiting for ${asset} channel to reach status=Open`);
+      }
       throw new Error(`timed out waiting for ${asset} to reach state_version=${expectedVersion}`);
     }
     await new Promise((r) => setTimeout(r, 2000));

--- a/sdk/ts/examples/round_robin/lifecycle.ts
+++ b/sdk/ts/examples/round_robin/lifecycle.ts
@@ -107,6 +107,15 @@ const chainRPCs: Record<string, string> = {
   '84532':    'https://sepolia.base.org',              // Base Sepolia
   '80002':    'https://rpc-amoy.polygon.technology',   // Polygon Amoy
   '59141':    'https://rpc.sepolia.linea.build',       // Linea Sepolia
+  '1449000':  'https://rpc.testnet.xrplevm.org',     // XRP LVM Testnet
+
+	'1':       'https://0xrpc.io/eth',                   // Ethereum Mainnet
+	'14':      'https://rpc.ankr.com/flare',            // Flare Mainnet
+	'56':      'https://bsc.api.pocket.network',         // BNB Smart Chain Mainnet
+	'137':     'https://polygon-bor-rpc.publicnode.com', // Polygon Mainnet
+	'8453':    'https://base-rpc.publicnode.com',        // Base Mainnet
+	'59144':   'https://linea.drpc.org',                 // Linea Mainnet
+	'1440000': 'https://xrpl.drpc.org',                  // XRP EVM Mainnet
 };
 
 // minNativeBalances maps blockchain id -> minimum native gas balance for
@@ -117,6 +126,15 @@ const minNativeBalances: Record<string, Decimal> = {
   '84532':    new Decimal('0.005'),
   '80002':    new Decimal('0.05'),
   '59141':    new Decimal('0.005'),
+	'1449000':  new Decimal('0.001'),
+
+	'1':       new Decimal('0.001'),
+	'14':      new Decimal('0.001'),
+	'56':      new Decimal('0.001'),
+	'137':     new Decimal('3'),
+	'8453':    new Decimal('0.001'),
+	'59144':   new Decimal('0.001'),
+	'1440000': new Decimal('0.001'),
 };
 
 // ============================================================================

--- a/sdk/ts/examples/round_robin/lifecycle.ts
+++ b/sdk/ts/examples/round_robin/lifecycle.ts
@@ -319,11 +319,25 @@ async function setupSessionKeyClient(walletA: Client, addrA: Address): Promise<C
   const skMsg = new EthereumMsgSigner(sessionKey);
   console.log(`Session key: ${skAddress}`);
 
+  // If a session-key state already exists for this address (active or
+  // expired/revoked), the protocol requires the next submission to use a
+  // strictly higher monotonic version. Look up the latest stored version
+  // and start from version+1; otherwise begin at 1.
+  const prior = await walletA.getLastChannelKeyStates(addrA, skAddress, { includeInactive: true });
+  let version = 1n;
+  for (const p of prior) {
+    const v = BigInt(p.version);
+    if (v >= version) version = v + 1n;
+  }
+  if (version > 1n) {
+    console.log(`  ↳ existing state found at version ${version - 1n}, registering v${version}`);
+  }
+
   const expiresAt = BigInt(Math.floor(Date.now() / 1000) + 24 * 60 * 60);
   const state: ChannelSessionKeyStateV1 = {
     user_address: addrA,
     session_key: skAddress,
-    version: '1',
+    version: version.toString(),
     assets: [asset],
     expires_at: expiresAt.toString(),
     user_sig: '',

--- a/sdk/ts/examples/round_robin/package-lock.json
+++ b/sdk/ts/examples/round_robin/package-lock.json
@@ -1,0 +1,855 @@
+{
+  "name": "@yellow-org/example-round-robin",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@yellow-org/example-round-robin",
+      "version": "1.0.0",
+      "dependencies": {
+        "@yellow-org/sdk": "file:../..",
+        "decimal.js": "^10.4.3",
+        "viem": "^2.46.2",
+        "ws": "^8.18.3"
+      },
+      "devDependencies": {
+        "@types/node": "^22.10.2",
+        "@types/ws": "^8.5.13",
+        "tsx": "^4.19.2",
+        "typescript": "^5.7.2"
+      }
+    },
+    "../..": {
+      "name": "@yellow-org/sdk",
+      "version": "1.2.2",
+      "license": "MIT",
+      "dependencies": {
+        "abitype": "^1.2.3",
+        "decimal.js": "^10.4.3",
+        "jest-util": "^30.3.0",
+        "viem": "^2.46.1",
+        "zod": "^4.3.6"
+      },
+      "devDependencies": {
+        "@ethereumjs/blockchain": "^10.0.0",
+        "@ethereumjs/common": "^10.0.0",
+        "@ethereumjs/evm": "^10.0.0",
+        "@ethereumjs/statemanager": "^10.0.0",
+        "@ethereumjs/util": "^10.0.0",
+        "@ethereumjs/vm": "^10.0.0",
+        "@types/jest": "30.0.0",
+        "@types/node": "^25.2.3",
+        "@typescript-eslint/eslint-plugin": "^8.55.0",
+        "@typescript-eslint/parser": "^8.55.0",
+        "eslint": "^10.0.0",
+        "ethers": "6.16.0",
+        "glob": "^13.0.3",
+        "jest": "^30.2.0",
+        "prettier": "3.8.3",
+        "rimraf": "^6.1.3",
+        "ts-jest": "^29.1.2",
+        "ts-node": "^10.9.2",
+        "typescript": "^6.0.3",
+        "ws": "8.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@yellow-org/sdk": {
+      "resolved": "../..",
+      "link": true
+    },
+    "node_modules/abitype": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/ox": {
+      "version": "0.14.26-386a343.0",
+      "resolved": "https://pkg.pr.new/ox@386a3439fe1ce76d237930f8c6e6bb493746069a",
+      "integrity": "sha512-OHHm9re1yVjiMN66GZ2JSGuqmvJPrk40zh3PIS/3I6prZLbt6U/zKlgW18eIIkO0Y/ZyySKr6D/4mUXjBmky1g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
+      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/viem": {
+      "version": "2.51.0",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.51.0.tgz",
+      "integrity": "sha512-8C0Ca+eEapXE29vHMUW59NqKENl1X4s9P6xSNC9Nvw6EvAeAhn/LNUlgztk6TOw7KN1Gzz5a/n9Wv4okUfmY9g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.2.3",
+        "isows": "1.0.7",
+        "ox": "https://pkg.pr.new/ox@386a3439fe1ce76d237930f8c6e6bb493746069a",
+        "ws": "8.20.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/viem/node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/sdk/ts/examples/round_robin/package.json
+++ b/sdk/ts/examples/round_robin/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@yellow-org/example-round-robin",
+  "version": "1.0.0",
+  "description": "Nitrolite SDK Round Robin Test Example",
+  "type": "module",
+  "scripts": {
+    "lifecycle": "tsx lifecycle.ts"
+  },
+  "dependencies": {
+    "@yellow-org/sdk": "file:../..",
+    "decimal.js": "^10.4.3",
+    "viem": "^2.46.2",
+    "ws": "^8.18.3"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "@types/ws": "^8.5.13",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  }
+}

--- a/sdk/ts/examples/round_robin/tsconfig.json
+++ b/sdk/ts/examples/round_robin/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/sdk/ts/src/blockchain/evm/client.ts
+++ b/sdk/ts/src/blockchain/evm/client.ts
@@ -231,7 +231,7 @@ export class Client {
         abi: ChannelHubAbi,
         functionName: 'depositToNode',
         args: [token, amountBig],
-        account: this.walletSigner.account!.address,
+        account: this.walletSigner.account!,
         ...(token === zeroAddress ? { value: amountBig } : {}),
       });
 
@@ -289,7 +289,7 @@ export class Client {
         abi: ChannelHubAbi,
         functionName: 'withdrawFromNode',
         args: [to, token, amountBig],
-        account: this.walletSigner.account!.address,
+        account: this.walletSigner.account!,
       });
 
       console.log('✅ Simulation successful - executing withdrawal...');
@@ -375,7 +375,7 @@ export class Client {
         abi: ChannelHubAbi,
         functionName: 'createChannel',
         args: [contractDef, contractState],
-        account: this.walletSigner.account!.address,
+        account: this.walletSigner.account!,
         ...(nativeValue != null ? { value: nativeValue } : {}),
       } as any)) as any;
 

--- a/sdk/ts/src/blockchain/evm/erc20.ts
+++ b/sdk/ts/src/blockchain/evm/erc20.ts
@@ -45,24 +45,31 @@ export class ERC20 {
   }
 
   /**
-   * Approve spender to spend amount of tokens
+   * Approve spender to spend amount of tokens.
+   *
+   * Sends the approve transaction directly without a pre-flight
+   * `simulateContract` call. The simulate path tries to decode `approve`'s
+   * return value against the standard ERC-20 ABI, which says it returns
+   * `bool`. Non-standard tokens such as Tether USDT on Ethereum L1 declare
+   * `approve` without a return value, so simulate fails with
+   * `ContractFunctionZeroDataError` even though the tx itself would
+   * succeed. `writeContract` for a non-view function only submits the tx
+   * and never decodes its return data, so it works for both standard and
+   * non-standard ERC-20s.
    */
   async approve(spender: Address, amount: bigint): Promise<string> {
     if (!this.walletSigner) {
       throw new Error('Wallet signer is required for approve operation');
     }
 
-
     try {
-      const { request } = (await this.client.simulateContract({
+      const hash = await this.walletSigner.writeContract({
         address: this.tokenAddress,
         abi: Erc20Abi,
         functionName: 'approve',
         args: [spender, amount],
         account: this.walletSigner.account!,
-      } as any)) as any;
-
-      const hash = await this.walletSigner.writeContract(request as any);
+      } as any);
 
       // Wait several blocks past the receipt so load-balanced public RPCs
       // converge on the post-approve state. Without this, a downstream
@@ -71,10 +78,9 @@ export class ERC20 {
       // sufficient".
       await this.client.waitForTransactionReceipt({ hash, confirmations: 3 });
 
-
       return hash;
     } catch (error: any) {
-      console.error('❌ Approve simulation/execution failed!');
+      console.error('❌ Approve execution failed!');
       if (error.message) {
         console.error('   Reason:', error.message);
       }

--- a/sdk/ts/src/blockchain/evm/erc20.ts
+++ b/sdk/ts/src/blockchain/evm/erc20.ts
@@ -64,7 +64,12 @@ export class ERC20 {
 
       const hash = await this.walletSigner.writeContract(request as any);
 
-      await this.client.waitForTransactionReceipt({ hash });
+      // Wait several blocks past the receipt so load-balanced public RPCs
+      // converge on the post-approve state. Without this, a downstream
+      // allowance read can hit a node that hasn't yet indexed the approve
+      // and the next deposit/checkpoint reverts with "allowance is not
+      // sufficient".
+      await this.client.waitForTransactionReceipt({ hash, confirmations: 3 });
 
 
       return hash;

--- a/sdk/ts/src/blockchain/evm/erc20.ts
+++ b/sdk/ts/src/blockchain/evm/erc20.ts
@@ -59,7 +59,7 @@ export class ERC20 {
         abi: Erc20Abi,
         functionName: 'approve',
         args: [spender, amount],
-        account: this.walletSigner.account!.address,
+        account: this.walletSigner.account!,
       } as any)) as any;
 
       const hash = await this.walletSigner.writeContract(request as any);

--- a/sdk/ts/src/client.ts
+++ b/sdk/ts/src/client.ts
@@ -422,6 +422,13 @@ export class Client {
       newState.nodeSig = nodeSig as Hex;
 
       return newState;
+    } else if (state.homeLedger.blockchainId !== blockchainId) {
+      // Active home channel is bound to the chain it was created on.
+      // Silently advancing it onto a different chain would surface as a
+      // confusing on-chain failure later.
+      throw new Error(
+        `active home channel for asset "${asset}" is on chain ${state.homeLedger.blockchainId}, cannot deposit on chain ${blockchainId}`
+      );
     }
 
     // Scenario B: Channel exists and is open - advance state with deposit
@@ -514,6 +521,13 @@ export class Client {
       newState.nodeSig = nodeSig as Hex;
 
       return newState;
+    } else if (state.homeLedger.blockchainId !== blockchainId) {
+      // Active home channel is bound to the chain it was created on.
+      // Silently advancing it onto a different chain would surface as a
+      // confusing on-chain failure later.
+      throw new Error(
+        `active home channel for asset "${asset}" is on chain ${state.homeLedger.blockchainId}, cannot withdraw on chain ${blockchainId}`
+      );
     }
 
     // Create next state

--- a/sdk/ts/test/unit/client.test.ts
+++ b/sdk/ts/test/unit/client.test.ts
@@ -342,3 +342,53 @@ describe('Client.transfer', () => {
         expect(state.nodeSig).toBe(NODE_SIGNATURE);
     });
 });
+
+describe('Client.deposit cross-chain guard', () => {
+    it('rejects deposit when active home channel is on a different chain', async () => {
+        const latestState = openChannelState();
+        latestState.homeLedger.blockchainId = 137n;
+        const client = createHighLevelClient(latestState);
+
+        await expect(client.deposit(8453n, 'usdc', new Decimal(1))).rejects.toThrow(
+            'active home channel for asset "usdc" is on chain 137, cannot deposit on chain 8453'
+        );
+        expect(client.signAndSubmitState).not.toHaveBeenCalled();
+        expect(client.requestChannelCreation).not.toHaveBeenCalled();
+    });
+
+    it('allows deposit when active home channel matches the supplied chain', async () => {
+        const latestState = openChannelState();
+        latestState.homeLedger.blockchainId = 8453n;
+        latestState.homeLedger.tokenAddress = TOKEN_ADDRESS;
+        const client = createHighLevelClient(latestState);
+
+        await client.deposit(8453n, 'usdc', new Decimal(1));
+        expect(client.signAndSubmitState).toHaveBeenCalledTimes(1);
+        expect(client.requestChannelCreation).not.toHaveBeenCalled();
+    });
+});
+
+describe('Client.withdraw cross-chain guard', () => {
+    it('rejects withdraw when active home channel is on a different chain', async () => {
+        const latestState = openChannelState();
+        latestState.homeLedger.blockchainId = 137n;
+        const client = createHighLevelClient(latestState);
+
+        await expect(client.withdraw(8453n, 'usdc', new Decimal(1))).rejects.toThrow(
+            'active home channel for asset "usdc" is on chain 137, cannot withdraw on chain 8453'
+        );
+        expect(client.signAndSubmitState).not.toHaveBeenCalled();
+        expect(client.requestChannelCreation).not.toHaveBeenCalled();
+    });
+
+    it('allows withdraw when active home channel matches the supplied chain', async () => {
+        const latestState = openChannelState();
+        latestState.homeLedger.blockchainId = 8453n;
+        latestState.homeLedger.tokenAddress = TOKEN_ADDRESS;
+        const client = createHighLevelClient(latestState);
+
+        await client.withdraw(8453n, 'usdc', new Decimal(1));
+        expect(client.signAndSubmitState).toHaveBeenCalledTimes(1);
+        expect(client.requestChannelCreation).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary
- Adds `sdk/go/examples/round_robin/main.go` and `sdk/ts/examples/round_robin/{lifecycle.ts,package.json,tsconfig.json}`.
- Each example exercises deposit / transfer-send / close / transfer-receive / withdraw on every chain on which the configured asset is supported. Funds circulate: deposit chain[i] → A→B transfer → close → B→A transfer (off-chain credit on void state) → withdraw chain[i+1]; last iteration wraps to chain[0].
- Preflight verifies per-chain native gas balance and seed-chain asset balance before any tx runs; bails with a per-chain shortfall table if anything is missing.
- Optional channel session key path (`sessionKeyPriv`) mirrored from the existing `channel_session_key` example — registers a v1 key for asset, builds a session-key-backed client, and runs the entire loop through it.
- Header comments document the full 1.a–1.e + 2.a–2.e flow; in-code section banners and per-step comments reference those identifiers.

## Test plan
- [x] `go vet ./sdk/go/examples/round_robin/...`
- [x] `go build ./sdk/go/examples/round_robin/...`
- [x] `tsc --noEmit` against `sdk/ts/examples/round_robin/lifecycle.ts` (skipLibCheck, ES2022+DOM lib)
- [x] End-to-end run against sandbox nitronode with funded wallets (manual, requires real keys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Go and TypeScript round‑robin examples demonstrating end‑to‑end channel lifecycle across supported chains.

* **Bug Fixes**
  * Enforced chain-binding checks for deposits/withdrawals to prevent operations on the wrong chain.
  * Improved transaction/receipt handling and simulation account behavior for deposit/withdraw flows.

* **Documentation**
  * Added TypeScript example package and config for running the lifecycle demo.

* **Tests**
  * Added unit and integration tests covering cross-chain guard behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/layer-3/nitrolite/pull/789?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->