### PR TITLE
feat(playground): session key management tab

### DIFF
--- a/playground/.gitignore
+++ b/playground/.gitignore
@@ -5,3 +5,8 @@ dist/
 .env.*.local
 *.log
 .DS_Store
+.vite
+PLAN.md
+TASKS.md
+TODO.md
+layout-options.md

--- a/playground/REFERENCE.md
+++ b/playground/REFERENCE.md
@@ -10,10 +10,14 @@ Developer-facing playground for Nitrolite — wallet, channel, and state channel
 
 Single-page app. Sticky header, scrollable body.
 
-- **Header**: Wallet connection bar + session key status + node health indicator
-- **Body (2-col on desktop)**:
-  - Left: Action panel (deposit / withdraw / transfer tabs)
+- **Header**: Wallet connection bar (left: brand + node status; center: Main/History tabs when connected; right: SK chip + chain + address + disconnect)
+- **Body — Main tab (2-col on desktop)**:
+  - Left: Action panel (deposit / withdraw / transfer / faucet tabs)
   - Right: Channel list (includes incoming unacknowledged channels at the top)
+- **Body — History tab (full-width)**:
+  - Transaction history table with column-filter popovers, per-cell quick filter, expandable row detail, and pagination (25/page)
+
+Tab selector only appears when a wallet is connected. Switching tabs preserves state in both panels.
 
 **Gating overlays** (modals) appear on top when:
 - Wallet is on an unsupported chain
@@ -36,13 +40,15 @@ Single-page app. Sticky header, scrollable body.
 - **Deposit tab** — move on-chain funds into a channel (requires MetaMask approval + transaction)
 - **Withdraw tab** — move channel funds back on-chain
 - **Transfer tab** — send channel funds to another address (requires recipient address input)
+- **Faucet tab** — visible only for assets in `FAUCET_ASSETS` (currently YUSD); shows a "Request drip" button that calls the faucet endpoint (mock until endpoint is configured)
 - Token selector (custom dropdown via TokenSelector), amount input, Max button (auto-fills from relevant balance)
 - Enforces amount limits: cannot exceed on-chain balance (deposit) or channel balance (withdraw/transfer)
-- **Cross-chain guard**: if the selected asset has a home channel on a different chain than the wallet's current chain, the tabs and form are blurred and a "Select {chain}" button appears to switch chains (cross-chain operations are not supported)
+- **Cross-chain guard**: if the selected asset has a home channel on a different chain than the wallet's current chain, the deposit/withdraw/transfer form is blurred and a "Select {chain}" button appears to switch chains; the Faucet tab remains accessible regardless of chain state
 
 ### TokenSelector
 **For**: Custom asset/token picker used inside ActionPanel.
 - Displays each asset as a row: token icon + symbol + supported chain icons
+- Assets in `FAUCET_ASSETS` show a small drip icon (Droplets) with a "Faucet available" tooltip next to the symbol
 - Token and chain icons are loaded from CDN (see `src/icons.ts`); unknown symbols fall back to a letter avatar
 - If a non-closed home channel exists for an asset, all chain icons except the home chain are dimmed (greyscale + low opacity)
 
@@ -96,6 +102,14 @@ Single-page app. Sticky header, scrollable body.
 **For**: Guiding the user off an unsupported chain.
 - Appears when the connected wallet's chain is not recognized by the node
 - Lists supported chains; clicking one triggers a wallet chain-switch request
+
+### HistoryTab
+**For**: Full-width transaction history view, shown when the History tab is active.
+- Fetches up to 200 recent transactions via `client.getTransactions(address, { pageSize: 200 })`; sorts newest-first; paginates at 25/page client-side
+- Column header popovers (funnel icon) for Type (multi-select checkboxes), Asset (multi-select), From/To (text input); Apply/Clear buttons in each popover
+- Per-cell quick filter: clicking a Type badge, Asset name, or From/To address immediately adds/removes an exact-value filter with tooltip feedback
+- Expandable rows: clicking a row reveals Sender new state ID, Receiver new state ID, Timestamp, and a Confirmation timeline (Signed → Co-signed for off-chain; Signed → Broadcasted → Confirmed for on-chain)
+- All filtering is client-side after the initial fetch; Refresh button re-fetches from the node
 
 ### CopyButton
 **For**: One-click copy of addresses or hashes throughout the UI.
@@ -154,6 +168,7 @@ Single-page app. Sticky header, scrollable body.
 - `tokenIconUrl(symbol)` / `chainIconUrl(chainId)` return `null` for unknown entries; callers render a fallback
 
 ### utils.ts
+- `FAUCET_ASSETS` — Set of lowercase asset symbols that have a test faucet (currently `yusd`)
 - Address formatting (abbreviated display)
 - Balance formatting (thousands separators, 2 decimal places)
 - Relative time ("just now", "5m ago", "2h ago")

--- a/playground/REFERENCE.md
+++ b/playground/REFERENCE.md
@@ -69,6 +69,7 @@ Tab selector only appears when a wallet is connected. Switching tabs preserves s
 - Expand/collapse to see channel state detail (StateViewer) or a closed notice
 - Inline prompt to switch wallet chain when it doesn't match the channel's home chain
 - Close channel button
+- Does **not** show a session-key selector — the active SK is wallet-global (not per-channel); manage it via WalletBar chip + Session Keys tab
 
 ### StateViewer
 **For**: Inspecting and acting on the three layers of channel state.
@@ -91,14 +92,17 @@ Tab selector only appears when a wallet is connected. Switching tabs preserves s
 - "Set up" button navigates to the Session Keys tab
 
 ### SessionKeysTab
-**For**: Full management of session keys (list, register, update/renew, revoke).
+**For**: Full management of session keys (list, register, update/renew, revoke, reactivate).
 - Fetches all session keys (active + inactive) from the node via `useSessionKeyManagement`
 - Displays a table with address (truncated + copy), assets, expiration (3-way format toggle: relative / UTC date / Unix), status badge, version, and per-row actions
 - "Expiring Soon" banner at the top when any key has < 1 hour remaining
 - Register New opens `SessionKeyRegisterForm` in register mode
-- Update/Renew opens `SessionKeyRegisterForm` in update mode (pre-filled assets + expiry)
+- Per-row actions depend on status and whether the key's private key is still in localStorage (`hasLocalKey`):
+  - **active** → Update, Revoke, Use (if not current)
+  - **expiring** → Renew, Revoke, Use (if not current)
+  - **expired/revoked + hasLocalKey** → Reactivate (re-registers via update flow at version+1 with future expiry)
+  - **expired/revoked + !hasLocalKey** → no row actions (cannot update without the private key)
 - Revoke opens `SessionKeyRevokeModal` (sets expiresAt to past)
-- "Use" button on non-current active keys calls `onSelectKey` to switch the active signing key
 - "IN USE" badge on the currently active key
 
 ### SessionKeySetupModal

--- a/playground/REFERENCE.md
+++ b/playground/REFERENCE.md
@@ -10,12 +10,15 @@ Developer-facing playground for Nitrolite — wallet, channel, and state channel
 
 Single-page app. Sticky header, scrollable body.
 
-- **Header**: Wallet connection bar (left: brand + node status; center: Main/History tabs when connected; right: SK chip + chain + address + disconnect)
+- **Header**: Wallet connection bar (left: brand + node status; center: Main/History/Session Keys tabs when connected; right: SK chip + chain + address + disconnect)
 - **Body — Main tab (2-col on desktop)**:
   - Left: Action panel (deposit / withdraw / transfer / faucet tabs)
   - Right: Channel list (includes incoming unacknowledged channels at the top)
 - **Body — History tab (full-width)**:
   - Transaction history table with column-filter popovers, per-cell quick filter, expandable row detail, and pagination (25/page)
+- **Body — Session Keys tab (full-width)**:
+  - Table of all session keys (active, expiring, expired, revoked) fetched from the node
+  - Register, update (renew), and revoke keys via modals
 
 Tab selector only appears when a wallet is connected. Switching tabs preserves state in both panels.
 
@@ -34,6 +37,7 @@ Tab selector only appears when a wallet is connected. Switching tabs preserves s
 - Display current address and active chain
 - Session key chip: shows time remaining, allows clearing the key
 - Node status: shows last successful communication timestamp, or error if unreachable
+- Tab selector: Main / History / Session Keys (shown when wallet is connected)
 
 ### ActionPanel
 **For**: All channel money operations initiated by the user.
@@ -84,10 +88,21 @@ Tab selector only appears when a wallet is connected. Switching tabs preserves s
 ### SessionKeyBanner
 **For**: Nudging the user to set up a session key when none is active.
 - Appears when wallet is connected but no session key exists
-- "Set up" button opens SessionKeySetupModal
+- "Set up" button navigates to the Session Keys tab
+
+### SessionKeysTab
+**For**: Full management of session keys (list, register, update/renew, revoke).
+- Fetches all session keys (active + inactive) from the node via `useSessionKeyManagement`
+- Displays a table with address (truncated + copy), assets, expiration (3-way format toggle: relative / UTC date / Unix), status badge, version, and per-row actions
+- "Expiring Soon" banner at the top when any key has < 1 hour remaining
+- Register New opens `SessionKeyRegisterForm` in register mode
+- Update/Renew opens `SessionKeyRegisterForm` in update mode (pre-filled assets + expiry)
+- Revoke opens `SessionKeyRevokeModal` (sets expiresAt to past)
+- "Use" button on non-current active keys calls `onSelectKey` to switch the active signing key
+- "IN USE" badge on the currently active key
 
 ### SessionKeySetupModal
-**For**: Explaining and confirming session key creation or renewal.
+**For**: Legacy modal for quick session key creation (still present but no longer wired from the banner).
 - Clarifies what a session key is (24h authorization stored locally, avoids MetaMask popups per state op)
 - Confirm triggers one MetaMask signature, then session key is stored in localStorage
 - Cancel dismisses without changes
@@ -153,10 +168,19 @@ Tab selector only appears when a wallet is connected. Switching tabs preserves s
 
 ### useSessionKey
 **Owns**: Session key storage and registration.
-- Loads session key from localStorage on address change
+- Loads session key from localStorage on address change; also loads `allKeys` (all stored keys)
 - Registers a new key: generates keypair, finds next version, signs ownership with wallet, submits to node
+- `selectKey(address)` — switches the active signing key among locally stored keys
 - Clears key from storage
 - Re-checks expiry every 60s so the banner re-appears in the same session if a key expires
+
+### useSessionKeyManagement
+**Owns**: Server-side session key fetching and register/update/revoke operations.
+- `fetchKeys()` — fetches all keys (including inactive) from the node via `client.getLastChannelKeyStates`
+- `register(client, walletAddress, assets, expiresAt)` — registers a new key, saves to localStorage, returns StoredSessionKey
+- `update(client, walletAddress, currentKey, assets, expiresAt)` — re-registers with new assets/expiry at the next version
+- `revoke(client, walletAddress, currentKey)` — re-registers with `expiresAt` in the past to invalidate the key
+- Exposes `serverKeys`, `isLoading`, `isSubmitting`
 
 ---
 
@@ -209,7 +233,13 @@ Tab selector only appears when a wallet is connected. Switching tabs preserves s
 1. In ActionPanel or ChannelRow → Close → MetaMask: close transaction → checkpoint
 
 **Session key setup**
-1. Banner appears → "Set up" → modal → confirm → one MetaMask signature → key stored locally → future state ops (acknowledge, checkpoint) skip MetaMask
+1. Banner appears → "Set up" → navigates to Session Keys tab → "Register New" → `SessionKeyRegisterForm` → confirm → one MetaMask signature → key stored locally + submitted to node → future state ops (acknowledge, checkpoint) skip MetaMask
+
+**Session key management**
+1. Session Keys tab → table of all keys from node (active, expiring, expired, revoked)
+2. Update/Renew key → `SessionKeyRegisterForm` in update mode (new version registered on node)
+3. Revoke key → `SessionKeyRevokeModal` confirm → re-registers with expiresAt in the past
+4. Switch active key → "Use" button → `selectKey` updates localStorage active flag + SDK switches signer
 
 **Acknowledge issued state**
 1. Expand channel → StateViewer → Acknowledge button (issued row) → signs with session key or wallet → issued becomes signed

--- a/playground/add-session-key-support.md
+++ b/playground/add-session-key-support.md
@@ -1,0 +1,831 @@
+# Session Key Management Tab — Implementation Plan
+
+**Objective**: Add a dedicated "Session Keys" tab to the Nitrolite Playground that allows users to register, update, revoke, and manage channel session keys through a first-class UI, plus integrate session key selection into the Channels tab for per-channel usage.
+
+---
+
+## Section 1: Functionality
+
+### User-Requested Features
+1. **Register session key**: Create a new session key tied to specific assets with a custom expiry duration
+2. **Update session key**: Change the assets authorized or extend the expiry of an active key
+3. **Revoke session key**: Immediately deactivate the current session key
+4. **View session keys**: List all session keys (active and revoked) with their metadata
+
+### Recommended Enhancements
+1. **Status indicators**: Show each key's status (Active, Expired, Revoked, Expiring Soon)
+2. **Version tracking**: Display the version number of each registered state for audit clarity
+3. **Asset granularity**: Register different keys for different asset subsets (not just "all assets") — user selects assets via checkboxes at registration time
+4. **Session key selection per channel** (in Channels tab): Let users choose which session key to use when signing for a specific channel, or fall back to wallet
+5. **Auto-renewal prompts**: Warn users when a session key is within 1 hour of expiry and offer renewal
+6. **Revocation history**: Maintain a local record of revoked keys with timestamps (for transparency)
+7. **Multiple keys per wallet**: Support registering multiple session keys (e.g., for different apps or signing patterns)
+8. **Clickable expiration display** (table column): Cycles between three formats on click — human-readable date, time-until-expiry, and raw unix timestamp. Hover shows hint for next format. Same pattern as the "Timestamp" column in HistoryTab.
+9. **Copy session key address**: Allow users to copy the session key address for debugging/auditing
+10. **Rate limit feedback**: If server rejects registration (e.g., max keys exceeded), show a clear error
+
+**Rationale for enhancements**:
+- **Asset granularity** is important because users may want one restricted key for a mobile app and another full-featured key for desktop. The current banner only registers "all assets," which is fine for v1 but the tab should support subsets.
+- **Multiple keys per wallet** aligns with the server's design (version scoping per `(user_address, session_key, kind)` triplet), and it's common in key management UIs (e.g., SSH keys on GitHub).
+- **Revocation history** is useful for debugging: "I revoked a key but did my app stop using it?" A local list (cleared on disconnect) answers that.
+- **Auto-renewal prompts** reduce friction. Users appreciate a gentle nudge before lockout.
+- **Per-channel selection** is a stretch goal but powerful: it lets users e.g. sign transfers with one key and deposits with another (though the v1 UI can start simpler — just a global selector).
+- **Clickable expiration** avoids wasting column space on a fixed format and matches the existing HistoryTab UX pattern users already know.
+
+---
+
+## Section 2: UI Description
+
+### 2.1 Session Keys Tab (New Top-Level Tab)
+
+**Location**: Parallel to "Main" and "History" tabs in the tab bar at the top of WalletBar (only visible when wallet connected).
+
+**Tab Name**: "Session Keys" (or "Keys" if space is tight).
+
+**Layout**: Single card on desktop/mobile, scrollable if many keys.
+
+#### 2.1.1 Key Management Table/List
+
+**Container**: `SessionKeysTab.tsx` (new component)
+
+**Columns** (table on desktop, expandable rows on mobile):
+1. **Address**: Truncated session key address with copy button and icon (key icon from lucide)
+2. **Assets**: Comma-separated list of asset symbols (e.g. "USDC, ETH"). Truncate/ellipsis if > 3 assets; show full list on hover in a tooltip
+3. **Expiration**: Clickable value that cycles through three formats on each click:
+   - `date` — human-readable UTC date/time: `2026-05-28 10:30:00 UTC`
+   - `relative` — time until expiry: `23h 15m` (or `expired` if past)
+   - `unix` — raw unix seconds: `1748424600`
+   - Hover tooltip shows what the next click will switch to (e.g. `"Show as relative time"`, `"Show as Unix timestamp"`, `"Show as UTC date"`)
+   - Default format: `relative`
+   - Format state is global to the tab (one click changes all rows), same pattern as HistoryTab's `tsFormat` state
+   - Styled with `.ts-toggle` CSS class (already defined in `index.css`): `cursor: pointer`, accent color on hover, tooltip via `data-tip` + CSS `::after`
+   - `relative` format does **not** live-tick; it is a static snapshot rendered at mount/refresh (no `setInterval`)
+4. **Status**: Pill badge (Active, Expired, Revoked, Expiring Soon, Pending). Color-coded (green=Active, gray=Expired, red=Revoked, orange=Expiring Soon, blue=Pending)
+5. **Version**: Display the stored version number (e.g. "v1", "v3") for reference
+6. **Actions**: Button group: [Update] [Revoke] (grayed out if already expired/revoked)
+
+**Table styling**: Use the same card/chip styling as ChannelRow. Rows are clickable to expand detail or inline actions.
+
+**Column filtering**: Each column header has a minimal popover for filtering (e.g. filter by status "Active"), similar to HistoryTab.
+
+#### 2.1.2 "Register New Key" Button
+
+**Location**: Top right of card header, next to the "Refresh" button (if a refresh button is added).
+
+**Label**: "Register New" or "+ New Key"
+
+**Action**: Opens an inline form or modal (`SessionKeyRegisterForm` component, new).
+
+#### 2.1.3 Register Form (Inline or Modal)
+
+**Title**: "Register a new session key"
+
+**Fields**:
+1. **Assets** (required, multi-select):
+   - Rendered as checkboxes (not a dropdown, so users can pick subsets)
+   - List all supported assets (e.g. USDC, ETH, YUSD)
+   - Default: all checked
+   - Validation: at least one asset must be selected
+   - Display asset icons and symbols (reuse TokenSelector's asset icon logic if possible)
+
+2. **Expiration** (required):
+   - Three input modes, switchable via a small segmented control / tab: **Date**, **Duration**, **Unix**
+   - **Date mode**: datetime-local input (or date + time two-field). User picks a calendar date and time. Validation: must be in the future.
+   - **Duration mode**: text input with a unit selector (hours / days). Pre-filled with `24` hours as default. Displays the calculated absolute expiry below the field: `"Expires: 2026-05-28 10:30:00 UTC"`. Validation: result must be > now + 1 minute.
+   - **Unix mode**: plain number input for a unix timestamp (seconds). Displays the human-readable equivalent below: `"2026-05-28 10:30:00 UTC"`. Validation: must be > now + 60.
+   - All three modes resolve to the same `expires_at` (unix seconds bigint) sent to the SDK.
+   - Switching between modes converts the current value where possible (e.g. switching from Duration to Date pre-fills the date with the computed value).
+
+3. **Summary** (read-only):
+   - "This key will authorize: [asset list] and expire in [duration]"
+   - "On-chain operations (deposit, checkpoint, approve) will still require MetaMask"
+
+**Buttons**:
+- Cancel (dismisses form, clears state)
+- Register & Sign (disabled until at least one asset is selected and expiry is valid; shows spinner during registration)
+
+**Flow**:
+1. User clicks "Register New"
+2. Form opens (modal or inline below the table; modal is less disruptive for busy layouts)
+3. User selects assets and expiry
+4. User clicks "Register & Sign"
+5. SDK is called (via `useNitrolite` client); MetaMask pops up once for wallet signature
+6. Key is stored locally (already done via `useSessionKey` and `sessionKey.ts`)
+7. Table refreshes and shows the new key
+8. Toast: "Session key registered successfully"
+9. Form closes
+
+**Error handling**:
+- If registration fails (e.g., max keys exceeded), show error toast with server message
+- If user rejects MetaMask, show toast "Cancelled" (already done in `useSessionKey`)
+- If network error, show "Registration failed — check your connection"
+
+#### 2.1.4 Update Flow
+
+**Trigger**: "Update" button on a key row
+
+**What can be updated**:
+- Assets: remove/add (keep the same private key; submit new version with updated asset list)
+- Expiry: extend (set new expiry to future; version increments)
+
+**UI**: Opens a modal similar to Register Form, but:
+- Prefilled with current assets and expiry
+- Title: "Update session key"
+- Fields are editable
+- Shows current version (e.g. "Updating from v2 to v3")
+- Buttons: Cancel, Update & Sign
+- Behavior is identical to registration (version check, wallet signature, etc.)
+
+**Post-update**:
+- Old key is still usable until the update is submitted; both versions exist momentarily on the server
+- Updated key replaces the old one in the table (same session key address, higher version)
+- Toast: "Session key updated"
+
+#### 2.1.5 Revoke Flow
+
+**Trigger**: "Revoke" button on a key row
+
+**UI**: Confirmation modal
+- Title: "Revoke session key"
+- Message: "Are you sure? This key will no longer authorize any operations."
+- Address of key being revoked (truncated, copyable)
+- Buttons: Cancel, Revoke & Sign
+
+**Backend**: Same registration flow, but `expires_at` is set to `<= now()` (e.g. current unix time), which tells the server to revoke immediately
+
+**Post-revoke**:
+- Key status changes to "Revoked"
+- Buttons disabled
+- Toast: "Session key revoked"
+- If this was the active key in the global session, it's automatically cleared (see WalletBar integration below)
+
+#### 2.1.6 Empty State
+
+**When no keys exist**:
+- Centered message: "No session keys yet. Register one to sign state updates without MetaMask prompts."
+- Large "Register New" button
+
+#### 2.1.7 Refresh Button
+
+**Location**: Card header, right side (next to "Refresh" in ChannelList pattern)
+
+**Action**: Re-fetch the list of keys from the server via `client.getLastChannelKeyStates(address, undefined, { includeInactive: true })` (already exists in SDK)
+
+**Behavior**: Shows spinner while loading; updates the table
+
+**Why needed**: User may revoke a key from another device; refresh brings the UI in sync.
+
+---
+
+### 2.2 Channels Tab Changes
+
+**Goal**: Let users see and select which session key is active for signing operations in each channel.
+
+**Approach** (recommended for MVP; can be simplified):
+1. **Global session key selector** (simpler): One dropdown in the Channels card header that selects the active session key for all channels
+   - Options: [No Key] (wallet only), [Active Key], [Other Registered Keys]
+   - Display: Truncated address of selected key
+   - If user switches, the SDK client is rebuilt with the new key
+
+2. **Per-channel selector** (stretch goal, more complex): Each ChannelRow has a small session key picker
+   - Allows different keys for different channels (e.g. USDC uses Key1, ETH uses Key2)
+   - Requires storing a mapping in localStorage: `{ channelId -> sessionKeyAddress }`
+   - Requires changes to `useChannelStates` and `useChannelOps` to pass the per-channel key choice to the signing functions
+   - More flexibility but increases complexity; recommend for v2
+
+**Recommendation for v1**: Implement the **global selector** in Channels card header. It's simpler, aligns with the current WalletBar "SK · 23h" chip design, and covers the main use case.
+
+**UI** (global selector approach):
+
+#### 2.2.1 Session Key Selector in ChannelList Header
+
+**Location**: Channels card header, left side (next to the "Channels" title and count)
+
+**Rendering**: Dropdown/select similar to the chain selector in WalletBar
+- Label: "Key: " or just an icon (key from lucide)
+- Selected value: Truncated address of active key, or "Wallet" if none
+- Options list:
+  - "Wallet (no key)" — always first, forces re-build of client with wallet signer only
+  - Separator
+  - [List of all non-expired keys, grouped by status]
+  - Separator
+  - [List of expired/revoked keys, grayed out]
+
+**Example**:
+```
+Key: 0x1a2B…c3dE
+  v
+[ Wallet (no key)
+  ──────────────
+  ✓ 0x1a2B…c3dE (active, expires 23h)
+    0x9fEd…A1b2 (expires 2h) ← orange badge "Expiring Soon"
+  ──────────────
+  0xAbCd…1234 (expired)
+]
+```
+
+**On selection change**:
+1. Call `sk.selectKey(selectedAddress)` or similar in useSessionKey (new action)
+2. Rebuild the SDK Client in `useNitrolite` with the new key (if a key is selected) or wallet signer (if "Wallet" is selected)
+3. Clear old key from session state if a different one is selected
+4. Toast: "Switched to [address]" or "Using wallet only"
+
+#### 2.2.2 Visual Indicator
+
+**In ChannelRow**: Small badge or icon next to the channel name indicating which key is active
+- Example: Green key icon if an SK is active, or nothing if wallet only
+- Tooltip on hover: "Signed with: [key address] / Wallet"
+
+**Rationale**: Users should know at a glance whether they're using a key or wallet for a channel.
+
+---
+
+### 2.3 WalletBar / Global Session Key Indicator
+
+**Current state**: Already has a chip showing active SK with expiry countdown and clear button.
+
+**Changes**:
+1. Update the chip to link to the Session Keys tab (e.g., click the chip to switch to "Session Keys" tab, or add a "Manage" link next to the chip)
+2. If a key expires while the tab is active, refresh the chip in real-time (already done via `setInterval` in `useSessionKey`)
+3. If a key is revoked from the server (detected on next refresh), clear it from state and show banner again
+
+**No major changes needed**; the current design is good.
+
+---
+
+### 2.4 Action Panel Changes
+
+**Current state**: Deposit, withdraw, transfer, faucet tabs; all signing is invisible (handled by `useChannelOps`).
+
+**Changes**: None required for v1. The Client already uses the active session key (or wallet) transparently.
+
+**Future enhancement** (v2):
+- Show a badge on the Action Panel indicating which key is signing (e.g. "Signing with SK: 0x1a2B…c3dE" or "Signing with wallet")
+- Allows users to switch keys mid-operation without re-selecting the asset
+
+---
+
+## Section 3: Implementation Plan
+
+### 3.1 Files to Create
+
+#### 1. `src/components/SessionKeysTab.tsx`
+**Purpose**: Main tab UI, displays list of session keys and register form.
+
+**Responsibilities**:
+- Fetch list of keys from server on mount (via `client.getLastChannelKeyStates`)
+- Render table/list with columns (address, assets, expires, status, version, actions)
+- Render "Register New" button and form modal
+- Handle register/update/revoke flows
+- Manage local revocation history (Set of revoked addresses) for quick visual feedback
+- Refresh action
+
+**State**:
+- `keys: ChannelSessionKeyStateV1[]` — list from server
+- `showRegisterModal: boolean` — toggle form modal
+- `selectedKeyForUpdate: ChannelSessionKeyStateV1 | null` — for update flow
+- `isLoading: boolean` — while fetching keys
+- `isSubmitting: boolean` — while registering/updating/revoking
+- `revokedLocally: Set<Address>` — addresses revoked in this session (cleared on disconnect)
+
+**Props**:
+- `client: Client | null`
+- `address: Address | null`
+- `sessionKey: StoredSessionKey | null` (from App.tsx)
+- `onSessionKeyChanged: (key: StoredSessionKey | null) => void` (triggers client rebuild in App)
+- `supportedAssets: Asset[]`
+
+#### 2. `src/components/SessionKeyRegisterForm.tsx`
+**Purpose**: Reusable form for registering and updating session keys.
+
+**Responsibilities**:
+- Render asset checkboxes, expiry picker, summary
+- Validate inputs
+- Call registration/update flow via `useSessionKey` or new hook
+- Handle loading/error states
+
+**Props**:
+- `mode: 'register' | 'update'`
+- `initialAssets?: string[]` (for update mode)
+- `initialExpirySeconds?: number` (for update mode)
+- `supportedAssets: Asset[]`
+- `isSubmitting: boolean`
+- `onSubmit: (assets: string[], expirySeconds: number) => Promise<void>`
+- `onCancel: () => void`
+
+#### 3. `src/hooks/useSessionKeyManagement.ts`
+**Purpose**: High-level session key operations beyond basic registration/clearing.
+
+**Responsibilities**:
+- Fetch list of keys from server
+- Handle registration flow (calls existing `useSessionKey.register`)
+- Handle update flow (version increment, re-sign, submit)
+- Handle revoke flow (version increment, expires_at = now, submit)
+- Track loading/error states per operation
+
+**Interface**:
+```typescript
+interface UseSessionKeyManagementResult {
+  keys: ChannelSessionKeyStateV1[];
+  isLoading: boolean;
+  isSubmitting: boolean;
+  fetchKeys: () => Promise<void>;
+  register: (assets: string[], expirySeconds: number) => Promise<void>;
+  update: (key: ChannelSessionKeyStateV1, assets: string[], expirySeconds: number) => Promise<void>;
+  revoke: (key: ChannelSessionKeyStateV1) => Promise<void>;
+}
+
+function useSessionKeyManagement(
+  client: Client | null,
+  address: Address | null,
+): UseSessionKeyManagementResult
+```
+
+---
+
+### 3.2 Files to Modify
+
+#### 1. `src/App.tsx`
+**Changes**:
+- Add "Session Keys" to `AppTab` type: `type AppTab = 'main' | 'history' | 'keys'`
+- Update WalletBar to show the new tab button
+- Render `<SessionKeysTab>` when `activeTab === 'keys'`
+- Pass `onSessionKeyChanged` callback to SessionKeysTab to allow it to select a different key globally
+
+**Code snippet** (pseudo):
+```typescript
+type AppTab = 'main' | 'history' | 'keys';
+
+<WalletBar
+  // ... existing props
+  activeTab={activeTab}
+  onTabChange={setActiveTab}
+/>
+
+// In main body:
+{activeTab === 'history' ? (
+  <HistoryTab ... />
+) : activeTab === 'keys' ? (
+  <SessionKeysTab
+    client={nitro.client}
+    address={wallet.address}
+    sessionKey={sk.sessionKey}
+    supportedAssets={nitro.supportedAssets}
+    onSessionKeyChanged={(key) => {
+      if (key) sk.sessionKey is already set, but allow switching
+      // Actually, switching keys = selecting different key to use for signing
+      // This requires a new action in useSessionKey: selectKey(address)
+    }}
+  />
+) : (
+  <div className="grid ...">
+    <ActionPanel ... />
+    <ChannelList ... />
+  </div>
+)}
+```
+
+#### 2. `src/components/WalletBar.tsx`
+**Changes**:
+- Add "Session Keys" tab button to the center tab selector (only when wallet connected)
+- Make the session key chip clickable to navigate to Session Keys tab (optional enhancement)
+
+**Code snippet** (pseudo):
+```typescript
+<button
+  className={`tab${activeTab === 'keys' ? ' active' : ''}`}
+  onClick={() => onTabChange('keys')}
+>
+  Session Keys
+</button>
+```
+
+#### 3. `src/hooks/useSessionKey.ts`
+**Changes**:
+- Add new action: `selectKey(sessionKeyAddress: Address) -> void`
+  - Finds the stored key by address in localStorage
+  - Sets it as the active session key (triggers re-render)
+  - Used when user selects a different key from the Channels dropdown
+
+- Add new action: `getAllStoredKeys() -> StoredSessionKey[]`
+  - Scans localStorage for all keys matching the node URL and wallet address (e.g., multiple versions of the same key)
+  - Returns all non-expired keys (or optionally includes expired for the Session Keys tab)
+
+**Updated interface**:
+```typescript
+export interface UseSessionKeyResult {
+  sessionKey: StoredSessionKey | null;
+  allKeys: StoredSessionKey[];  // NEW: all registered keys for this wallet
+  isRegistering: boolean;
+  register: (client: Client, assetSymbols: string[]) => Promise<void>;
+  selectKey: (sessionKeyAddress: Address) => void;  // NEW: switch to a different key
+  clear: () => void;
+}
+```
+
+#### 4. `src/hooks/useNitrolite.ts`
+**Changes**:
+- Update Client rebuild logic to watch for changes in the selected session key (already tracks `sessionKey` prop, but may need to support selecting a different key without clearing the old one)
+- When `sessionKey` prop changes (or new `selectKey` is called), rebuild the client with the new key
+
+**No major changes needed**; the existing dependency on `sessionKey` in the useEffect should handle this.
+
+#### 5. `src/components/ChannelList.tsx`
+**Changes**:
+- Add session key selector dropdown in the card header (global selector for v1)
+- Pass `onSessionKeySelected` callback to SessionKeysTab or accept it as a prop and expose a dropdown
+
+**Code snippet** (pseudo):
+```typescript
+<div className="card-header">
+  <div className="flex items-center gap-2">
+    <span className="card-title">Channels</span>
+    <span className="text-text-muted text-sm mono">({channels.length})</span>
+    
+    {/* NEW: Session Key Selector */}
+    <select
+      value={activeSessionKeyAddress ?? 'wallet'}
+      onChange={(e) => {
+        if (e.target.value === 'wallet') sk.clear();
+        else sk.selectKey(e.target.value as Address);
+      }}
+      className="chip mono text-xs cursor-pointer"
+    >
+      <option value="wallet">Wallet (no key)</option>
+      {/* List keys */}
+    </select>
+  </div>
+  {/* Refresh button */}
+</div>
+```
+
+#### 6. `src/sessionKey.ts`
+**Changes**:
+- No major changes. Existing `registerSessionKey` can be reused for registration and updates (the caller just increments the version before calling)
+- Add helper function: `getStoredSessionKeys(nodeUrl: string, walletAddress: Address) -> StoredSessionKey[]`
+  - Returns all non-expired keys from localStorage for this wallet (or add `includeExpired` param)
+
+#### 7. `src/utils.ts`
+**Changes**:
+- Add helper: `formatSessionKeyAddress(address: Address, length: number = 4) -> string`
+  - Returns truncated address like "0x1a2B…c3dE"
+- Add helper: `formatExpiryCountdown(expiresAt: number) -> string`
+  - Returns "23h", "2h 15m", "45m", "15s", "expired"
+  - Used in SessionKeysTab and WalletBar chip
+
+#### 8. `REFERENCE.md`
+**Changes**:
+- Add new section: "### SessionKeysTab" with description of purpose, state, and user flows
+- Update "### WalletBar" to mention the Session Keys tab button and global key selector in ChannelList
+- Update "## Key User Flows" to add new flow: "Set up multiple session keys" or "Switch between session keys"
+
+**New entry** (pseudo):
+```markdown
+### SessionKeysTab
+**For**: Registering, managing, and selecting session keys for signing state operations.
+- List all registered keys (active, expired, revoked) with assets, expiry, and version
+- "Register New" button opens a form to pick assets and expiry duration
+- "Update" button allows changing assets or extending expiry (version increment)
+- "Revoke" button deactivates a key immediately
+- Global session key selector in ChannelList header to choose which key signs for all channels
+
+### ChannelList Changes
+- Added session key selector dropdown (global, for v1)
+- Allows switching between active session keys or wallet-only mode
+- Rebuilds SDK Client when selection changes
+```
+
+---
+
+### 3.3 New Dependencies / SDK Calls
+
+**No new npm packages required.** The implementation uses:
+- Existing `@yellow-org/sdk` methods: `getLastChannelKeyStates`, `submitChannelSessionKeyState`
+- Existing React hooks and Tailwind CSS
+- `lucide-react` icons (already in use)
+
+---
+
+### 3.4 State Management Summary
+
+| State | Owner | Scope | Notes |
+|-------|-------|-------|-------|
+| Active session key | `useSessionKey` | Wallet + node | Persisted in localStorage; used to build Client |
+| All stored keys | `useSessionKey` (new) | Wallet + node | Non-expired keys only, for selector dropdown |
+| Keys from server | `useSessionKeyManagement` (new) | Session only | Fetched via `getLastChannelKeyStates`; includes inactive |
+| Session key selector choice | `App.tsx` (or `useSessionKey`) | Session only | Which key is actively signing; impacts Client rebuild |
+| Register form visibility | `SessionKeysTab` | Component | Local state for modal |
+| Revoked locally | `SessionKeysTab` | Session only | Set of addresses revoked in this session for instant UI feedback |
+
+---
+
+### 3.5 Order of Implementation
+
+**Recommended sequence**:
+
+1. **Phase 1 — Core UI**:
+   - Create `SessionKeysTab.tsx` (minimal: list only, no forms)
+   - Create `useSessionKeyManagement.ts` hook for fetching keys
+   - Update `App.tsx` to add "Session Keys" tab
+   - Update `WalletBar.tsx` to show the tab button
+   - Update `REFERENCE.md` with new components
+
+2. **Phase 2 — Register/Update/Revoke Forms**:
+   - Create `SessionKeyRegisterForm.tsx`
+   - Add form modal to `SessionKeysTab`
+   - Implement register, update, revoke flows (call SDK methods, handle errors, toasts)
+   - Test with actual Nitronode
+
+3. **Phase 3 — Key Selection**:
+   - Update `useSessionKey.ts` to add `selectKey` and `getAllStoredKeys` actions
+   - Add session key selector dropdown to `ChannelList` header
+   - Wire up Client rebuild when key selection changes
+   - Test switching keys mid-session
+
+4. **Phase 4 — Polish**:
+   - Add status badges (Active, Expired, Revoked, Expiring Soon)
+   - Add column filtering in SessionKeysTab (optional, MVP may skip)
+   - Add per-channel session key indicator (optional, stretch goal)
+   - Add auto-renewal prompts when key is < 1 hour from expiry
+   - Add copy buttons and tooltips
+
+---
+
+## Section 4: Technical Notes
+
+### 4.1 Version Increment Logic
+
+When registering, updating, or revoking a key:
+1. Call `client.getLastChannelKeyStates(address, undefined, { includeInactive: true })`
+2. Find the highest `version` among results for this `(session_key, kind)` pair
+3. Increment to `nextVersion = highest + 1` (or `1` if no results)
+4. Submit with `version: nextVersion.toString()`
+5. If the server rejects with "expected version N, got M", it means a race condition occurred (another tab/device registered a version). Retry step 1-4.
+
+The `registerSessionKey` function in `sessionKey.ts` already does this; reuse it for update/revoke too.
+
+### 4.2 Expiry and Renewal
+
+- **Expiry time**: Unix seconds (bigint)
+- **Renewal buffer**: 5 minutes (already in `sessionKey.ts`)
+- **Client-side check**: `isExpired(sk)` returns true if `expiresAt - 5min <= now`
+- **Server-side check**: `expiresAt > now` required at transaction time
+- **Auto-renewal**: When key is < 1 hour from expiry, show a banner or button in SessionKeysTab; clicking "Renew" opens the Update form with the same assets pre-filled and Duration mode defaulting to `24 hours`
+
+### 4.6 Expiration Column Formatting
+
+Three-way cycling format, global to the SessionKeysTab component (one `expFmt` state, same pattern as `tsFormat` in HistoryTab):
+
+```typescript
+type ExpFormat = 'relative' | 'date' | 'unix';
+
+function formatExpiry(expiresAt: number, fmt: ExpFormat): string {
+  const now = Math.floor(Date.now() / 1000);
+  if (fmt === 'unix') return expiresAt.toString();
+  if (fmt === 'date') return new Date(expiresAt * 1000).toISOString().replace('T', ' ').slice(0, 19) + ' UTC';
+  // relative
+  const diff = expiresAt - now;
+  if (diff <= 0) return 'expired';
+  const h = Math.floor(diff / 3600);
+  const m = Math.floor((diff % 3600) / 60);
+  return h > 0 ? `${h}h ${m}m` : `${m}m`;
+}
+
+const NEXT_FMT: Record<ExpFormat, ExpFormat> = {
+  relative: 'date',
+  date: 'unix',
+  unix: 'relative',
+};
+
+const FMT_HINT: Record<ExpFormat, string> = {
+  relative: 'Show as UTC date',
+  date: 'Show as Unix timestamp',
+  unix: 'Show as relative time',
+};
+```
+
+The clickable `<span>` uses the existing `.ts-toggle` CSS class from `index.css` (cursor pointer, accent color on hover, tooltip via `data-tip` attribute + `::after` pseudo-element). No new CSS needed.
+
+### 4.3 localStorage Key Scheme
+
+Current: `nitrolite_playground_sk_{nodeUrl}::{walletAddress}` (single key per wallet per node)
+
+For multiple keys: Consider extending to `nitrolite_playground_sk_{nodeUrl}::{walletAddress}::{sessionKeyAddress}` to store each version/address separately. Alternatively, store a JSON array of keys under a single localStorage key.
+
+**Recommendation**: Use an array approach: `nitrolite_playground_sk_{nodeUrl}::{walletAddress}` = `[{ sessionKeyAddress, privateKey, ... }, ...]`. This way:
+- Single localStorage entry per wallet per node
+- Easy to iterate and filter
+- Existing `loadSessionKey` becomes `loadActiveSessionKey` (returns the one in use); new `loadAllSessionKeys` returns the array
+
+### 4.4 Error Handling
+
+**Common errors from server**:
+- `invalid_session_key_state: expected version N, got M` → Retry with correct version (race condition)
+- `session key does not have permission to sign for this data` → Asset not in registered list; update key
+- `max_session_keys_exceeded` → User hit server's per-wallet limit; show error and suggest revoking an old key
+- `Token signature invalid` → Shouldn't happen if SDK is correct; check key freshness
+
+**Client-side validation**:
+- Expiry must be in the future (at least 1 minute)
+- At least one asset must be selected
+- Form disables submit until valid
+
+### 4.5 Testing Checklist
+
+- [ ] Register a session key with all assets, 24h expiry
+- [ ] Register a second key with subset of assets (e.g., USDC only), 7 days expiry
+- [ ] Update the first key to remove an asset
+- [ ] Extend the second key's expiry
+- [ ] Revoke the first key (status changes to "Revoked", buttons disabled)
+- [ ] Switch to the second key via ChannelList dropdown; perform a deposit (should use second key for signing)
+- [ ] Switch back to wallet-only; perform a withdraw (should use MetaMask for signing)
+- [ ] Let a key expire in real-time; verify status badge updates every second
+- [ ] Disconnect and reconnect wallet; verify correct key is loaded from localStorage
+- [ ] Manually modify localStorage to corrupt a key; verify app handles it gracefully (clears key, shows error or banner)
+- [ ] Revoke a key from another device/session; refresh SessionKeysTab; verify status updates
+
+---
+
+## Section 5: Future Enhancements
+
+1. **Per-channel session key assignment**: Allow selecting different keys for different channels (requires mapping in localStorage, changes to signing logic)
+2. **Cloud backup**: Encrypt and backup session keys to a secure server (requires new backend, key derivation, security review)
+3. **Session key templates**: Pre-configured keys (e.g., "Mobile Read-Only: USDC only, 7d expiry") for common patterns
+4. **Key rotation automation**: Schedule a key to be rotated/renewed every N days without user intervention
+5. **Audit log**: Per-key log of operations signed (requires server support)
+6. **Hardware wallet integration**: Support signing session key ownership with hardware wallet (Ledger, Trezor)
+7. **Key expiry notifications**: Email/push notif when key expires or is revoked from another device
+
+---
+
+## Summary
+
+This plan delivers a production-ready "Session Keys" tab that gives users fine-grained control over session key registration, updates, revocation, and selection. The UI is consistent with the existing Nitrolite design, the implementation reuses existing SDK capabilities, and the phased approach allows for MVP launch followed by polish and stretch goals.
+
+**MVP Scope** (Phase 1 + 2):
+- Session Keys tab with list and register form
+- Update and revoke flows
+- Integration with existing session key storage
+
+**Nice-to-Have** (Phase 3 + 4):
+- Per-channel key selection
+- Status badges and auto-renewal prompts
+- Multiple keys per wallet support
+
+---
+
+## Section 6: Mockup Specifications
+
+Mockups live in `mockups/session-keys/`. Each file is a self-contained HTML + CSS document using the exact design tokens, fonts, and class patterns from the live app (`src/index.css`). Use these as the pixel-level reference for implementation.
+
+---
+
+### 6.1 `mockup-1-key-list.html` — Session Keys tab, key list view
+
+**What it shows**: The steady-state Session Keys tab with four keys in all possible statuses.
+
+#### WalletBar changes
+- "Session Keys" added as the **third tab** in the center tab group: `[Main] [History] [Session Keys]`
+- Tab uses the same `.tab` / `.tab.active` pill classes as the existing tabs
+- The existing SK chip in the top-right WalletBar (`SK · 23h ×`) remains unchanged; it still shows the active key and expiry
+
+#### Expiring Soon banner
+- Rendered above the card when any registered key is within the warning threshold of expiry
+- Layout: orange icon circle (32px, `rgba(249,115,22,0.18)` background with orange key SVG) + text block + "Renew Key" ghost button
+- Container: `border-radius: 10px`, `background: var(--warning-dim)` (`rgba(249,115,22,0.12)`), `border: 1px solid rgba(249,115,22,0.25)`, `margin-bottom: 16px`
+- Text: title in `#f97316`, subtitle in `var(--text-muted)` naming the key address (truncated mono) and time remaining
+- "Renew Key" button: ghost style with `border-color: rgba(249,115,22,0.4)` and `color: #f97316`
+
+#### Card header
+- Left: key SVG icon (muted color) + "Session Keys" `.card-title` + count badge (same rounded pill style as ChannelList — `bg-elevated`, `border`, muted text)
+- Right: "Refresh" ghost button (icon + label) + "Register New" primary button (+ icon + label)
+- Buttons use `.btn .btn-ghost .btn-sm` and `.btn .btn-primary .btn-sm` respectively
+
+#### Table columns
+
+| Column | Header style | Cell content |
+|--------|-------------|--------------|
+| **Address** | Plain `.th-inner` | Key icon SVG (colored by status) + `JetBrains Mono` 12px truncated address + optional "IN USE" chip (accent-dim background, `font-size:10px`, bold) for the currently active key + copy button (`.copy-btn-addr`, appears on row hover) |
+| **Assets** | Plain `.th-inner` | Comma-separated asset symbols in `JetBrains Mono` 12px muted |
+| **Expiration** | `.th-inner.filterable` with chevron | `.ts-toggle` span cycling `relative → date → unix` on click; `data-tip` shows next format name. Expired = "expired" in muted; expiring soon = value in `#f97316` |
+| **Status** | `.th-inner.filterable` with chevron | Pill badge (see below) |
+| **Version** | Plain `.th-inner` | `JetBrains Mono` 12px muted, e.g. "v1", "v3" |
+| **Actions** | Right-aligned plain | Button group flush-right (see below) |
+
+#### Status badges
+All use `.badge` base class (inline-flex, `border-radius: 999px`, `padding: 3px 9px`, `font-size: 11px`, `font-weight: 500`), plus a colored dot prefix:
+
+| Status | Class | Background | Text color |
+|--------|-------|------------|------------|
+| Active | `.badge-active` | `rgba(34,197,94,0.12)` | `#22c55e` |
+| Expiring Soon | `.badge-expiring` | `rgba(249,115,22,0.14)` | `#f97316` |
+| Expired | `.badge-expired` | `rgba(102,102,102,0.14)` | `var(--text-muted)` |
+| Revoked | `.badge-revoked` | `rgba(239,68,68,0.12)` | `var(--error)` |
+| Pending | `.badge-pending` | `rgba(59,130,246,0.12)` | `#3b82f6` |
+
+#### Action buttons per row
+
+| Row status | Left button | Right button |
+|-----------|-------------|--------------|
+| Active | `.btn .btn-ghost .btn-sm` "Update" | `.btn .btn-danger .btn-sm` "Revoke" |
+| Expiring Soon | Styled ghost `border-color:rgba(249,115,22,0.4); color:#f97316` "Renew" | `.btn .btn-danger .btn-sm` "Revoke" |
+| Expired | `.btn .btn-ghost .btn-sm` disabled | `.btn .btn-danger .btn-sm` disabled |
+| Revoked | `.btn .btn-ghost .btn-sm` disabled | `.btn .btn-danger .btn-sm` disabled |
+
+#### Row opacity
+- Active / Expiring Soon: 100%
+- Expired: `opacity: 0.7`
+- Revoked: `opacity: 0.55`
+
+#### Row hover
+- `tbody tr:hover { background: rgba(255,255,255,0.02); }`
+
+---
+
+### 6.2 `mockup-2-register-modal.html` — Register New Key modal
+
+**What it shows**: The register modal open over a blurred Session Keys tab, in "Duration" expiry mode with USDC + ETH selected.
+
+#### Background
+- Session Keys tab is rendered at `filter: blur(1.5px); opacity: 0.35; pointer-events: none` to give context without distraction
+
+#### Overlay
+- `.modal-overlay`: `position: fixed; inset: 0; background: rgba(0,0,0,0.72); backdrop-filter: blur(4px); z-index: 50`
+
+#### Modal card
+- `.modal-card` + custom: `width: 440px; max-width: calc(100vw - 32px); padding: 28px; display: flex; flex-direction: column; gap: 20px`
+- Sections are separated by full-bleed horizontal hairlines: `height: 1px; background: var(--border); margin: 0 -28px`
+
+#### Header section (centered)
+- 48px circle: `background: var(--accent-dim)` + key SVG in `var(--accent)`
+- Title: 17px, `font-weight: 600`, centered
+- Subtitle: 13px, `var(--text-muted)`, centered, 1.5 line-height
+
+#### Assets section
+- Section label: 12px, `font-weight: 500`, `var(--text-muted)`, uppercase, `letter-spacing: 0.05em`
+- "Select all · Clear" right-aligned in 11px muted, cursor pointer
+- Each asset row: flex row, `padding: 10px 14px`, `border-radius: 8px`, `background: var(--bg-elevated)`, `border: 1px solid var(--border)`
+  - **Unchecked**: default style above
+  - **Checked**: `border-color: var(--accent); background: var(--accent-dim)`
+- Checkbox box: 16px × 16px, `border-radius: 4px`, `border: 2px solid var(--border)`; when checked: `background: var(--accent); border-color: var(--accent)` + white checkmark SVG (stroke-width 3.5)
+- Asset icon: 24px circle with brand color background; asset symbol + full name beside it (13px medium + 11px muted)
+
+#### Expiry section
+- Segmented control: outer `background: var(--bg-elevated); border: 1px solid var(--border); border-radius: 8px; padding: 3px; gap: 2px`
+- Each segment button: `border-radius: 6px; font-size: 12px; font-weight: 500; color: var(--text-muted)`; active = `background: var(--bg-surface); border: 1px solid var(--border); color: var(--text-primary)`
+- **Duration mode** (default): number `.input-wrap` (flex, `bg-elevated`, `border`, `border-radius: 8px`) containing plain number input (`JetBrains Mono` 14px) + `<select>` (hours / days) with `border-left: 1px solid var(--border); background: var(--bg-base); padding: 0 12px`
+- Computed timestamp line below: 12px muted "Expires: " + mono inline span for the timestamp value
+- **Date mode**: replaces the duration row with a `datetime-local` input in the same `.input-wrap` style
+- **Unix mode**: replaces with a plain number input + mono human-readable equivalent below
+
+#### Summary box
+- `background: var(--bg-elevated); border: 1px solid var(--border); border-radius: 8px; padding: 12px 14px; font-size: 12px; color: var(--text-muted); line-height: 1.6`
+- Key asset names and expiry duration rendered in `<strong>` (`color: var(--text-primary); font-weight: 500`)
+
+#### Footer
+- Two equal-flex buttons side by side: Cancel (`.btn .btn-ghost`) + "Register & Sign" (`.btn .btn-primary`)
+- During submission: "Register & Sign" shows `.spinner` + "Signing…"
+
+---
+
+### 6.3 `mockup-3-channels-integration.html` — Channels tab, per-channel SK selector
+
+**What it shows**: The Main tab in its normal two-column layout, with a session key selector surfaced inside each opened channel's expanded panel. The mockup renders a dropdown in open state for reference.
+
+> **Design correction**: The mockup renders the SK selector in the Channels card header for illustration of the dropdown anatomy. The actual implementation must place the selector **inside each opened ChannelRow's expanded panel** (the section revealed by clicking the row), not in the card header. Closed channels must not show a selector. This matches the constraint that session key selection applies only to channels where state-update signing is relevant.
+
+#### Main tab layout (unchanged)
+- Two-column grid: `grid-template-columns: 420px 1fr; gap: 20px; align-items: start`
+- Left: `ActionPanel` card (Deposit / Withdraw / Transfer / Faucet sub-tabs)
+- Right: `ChannelList` card
+
+#### ChannelList card header (unchanged from current)
+- Left: "Channels" title + `(N)` count in `.text-text-muted .text-sm .mono`
+- Right: Refresh icon-only button (`.btn .btn-ghost .btn-sm`)
+- No global SK selector in the header
+
+#### SK selector inside ChannelRow expanded panel (new)
+- Rendered in the expanded section (`border-t border-border px-4 py-3`) **only when `channel.status !== ChannelStatus.Closed`**
+- Positioned alongside the existing "Close channel" button (same row or directly above it)
+- Trigger button: same `.chip`-style as other inline controls — shows active key icon (colored dot) + truncated mono address (or "Wallet" if none), + chevron
+- Trigger label variants:
+  - No key selected: gray wallet icon + "Wallet"
+  - Active key: green dot + `0x1a2B…c3dE`
+  - Expiring key: orange dot + `0x9fEd…A1b2`
+
+#### SK dropdown anatomy (open state)
+- Container: `background: var(--bg-elevated); border: 1px solid var(--border); border-radius: 10px; box-shadow: 0 8px 24px rgba(0,0,0,0.55); min-width: 260px; padding: 6px 0`
+- Items use `padding: 9px 14px; font-size: 13px`, hover = `rgba(255,255,255,0.04)`, selected = `var(--accent-dim)`
+- **Wallet option**: wallet icon + "Wallet (no key)" label + right-aligned "MetaMask" muted tag
+- **Separator**: `height: 1px; background: var(--border); margin: 4px 0`
+- **Active key item**: green 6px dot + mono address + right-aligned time-remaining + checkmark SVG for selected item
+- **Expiring key item**: orange 6px dot + mono address + right-aligned time in `#f97316` + `⚠` glyph
+- **Expired key item**: `opacity: 0.45; cursor: not-allowed` — not clickable
+- **Bottom separator + "Manage session keys →"** link item: accent color, navigates to Session Keys tab
+
+#### Per-channel SK badge in collapsed row header (read-only indicator)
+- Small inline badge next to the channel name, always visible (collapsed and expanded)
+- **When SK is active**: `background: rgba(34,197,94,0.1); border: 1px solid rgba(34,197,94,0.25); color: var(--success)` + 9px key SVG + truncated address, e.g. "SK · 0x1a2B…c3dE"
+- **When wallet only**: `background: var(--bg-elevated); border: 1px solid var(--border); color: var(--text-muted)` + wallet SVG + "Wallet"
+- Badge uses `border-radius: 5px; padding: 2px 7px; font-size: 10px; font-weight: 500`
+

--- a/playground/index.html
+++ b/playground/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Nitrolite Playground</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">

--- a/playground/mockups/general/mockup-b.html
+++ b/playground/mockups/general/mockup-b.html
@@ -1,0 +1,946 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Nitrolite Playground</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --bg-base:      #0a0a0a;
+    --bg-surface:   #141414;
+    --bg-elevated:  #1c1c1c;
+    --border:       #242424;
+    --text-primary: #f0f0f0;
+    --text-muted:   #666666;
+    --accent:       #f5a623;
+    --accent-dim:   rgba(245, 166, 35, 0.12);
+    --error:        #ef4444;
+    --success:      #22c55e;
+  }
+
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+  body {
+    font-family: 'Inter', system-ui, sans-serif;
+    background: var(--bg-base);
+    color: var(--text-primary);
+    font-size: 14px;
+    line-height: 1.5;
+    min-height: 100vh;
+  }
+
+  mono { font-family: 'JetBrains Mono', monospace; }
+
+  /* ── Nav ── */
+  .nav {
+    background: var(--bg-surface);
+    border-bottom: 1px solid var(--border);
+    padding: 0 24px;
+    height: 56px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+  }
+
+  .nav-logo {
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--accent);
+    letter-spacing: -0.3px;
+  }
+
+  .nav-center {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13px;
+    color: var(--text-muted);
+  }
+
+  .status-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--success);
+    box-shadow: 0 0 6px var(--success);
+  }
+
+  .nav-right {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .chain-pill {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 5px 10px;
+    font-size: 13px;
+    color: var(--text-primary);
+    cursor: pointer;
+  }
+
+  .chain-pill svg { opacity: 0.5; }
+
+  .wallet-chip {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 5px 10px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 12px;
+    color: var(--text-primary);
+  }
+
+  .icon-btn {
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    padding: 4px;
+    display: flex;
+    align-items: center;
+    border-radius: 4px;
+    transition: color 0.15s;
+  }
+  .icon-btn:hover { color: var(--text-primary); }
+
+  .btn-disconnect {
+    background: none;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 5px 12px;
+    color: var(--text-muted);
+    font-size: 13px;
+    cursor: pointer;
+    transition: border-color 0.15s, color 0.15s;
+  }
+  .btn-disconnect:hover { border-color: var(--error); color: var(--error); }
+
+  /* ── Layout ── */
+  .main {
+    max-width: 940px;
+    margin: 0 auto;
+    padding: 28px 24px;
+    display: grid;
+    grid-template-columns: 340px 1fr;
+    gap: 20px;
+    align-items: start;
+  }
+
+  /* ── Cards ── */
+  .card {
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    overflow: hidden;
+  }
+
+  .card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 18px 20px 14px;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .card-title {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+
+  /* ── ActionPanel ── */
+  .balance-section { padding: 18px 20px; border-bottom: 1px solid var(--border); }
+
+  .asset-selector {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 5px 10px;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--text-primary);
+    cursor: pointer;
+    margin-bottom: 14px;
+  }
+
+  .balance-row { display: flex; justify-content: space-between; align-items: baseline; }
+  .balance-label { font-size: 12px; color: var(--text-muted); }
+  .balance-amount-big {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 28px;
+    font-weight: 500;
+    color: var(--accent);
+    letter-spacing: -0.5px;
+  }
+  .balance-amount-sm {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 16px;
+    color: var(--text-muted);
+  }
+
+  /* ── Tabs ── */
+  .tabs { display: flex; gap: 4px; padding: 14px 20px 0; }
+
+  .tab {
+    padding: 7px 16px;
+    border-radius: 999px;
+    border: none;
+    background: none;
+    font-family: 'Inter', sans-serif;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s;
+  }
+  .tab:hover { background: var(--bg-elevated); color: var(--text-primary); }
+  .tab.active {
+    color: var(--accent);
+    background: var(--accent-dim);
+  }
+
+  /* ── Forms ── */
+  .form-section { padding: 16px 20px 20px; }
+
+  .form-group { margin-bottom: 14px; }
+  .form-label { display: block; font-size: 12px; color: var(--text-muted); margin-bottom: 6px; }
+
+  .input-wrap {
+    display: flex;
+    align-items: center;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    overflow: hidden;
+    transition: border-color 0.15s;
+  }
+  .input-wrap:focus-within { border-color: var(--accent); }
+
+  .input-wrap input {
+    flex: 1;
+    background: none;
+    border: none;
+    outline: none;
+    padding: 10px 12px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 14px;
+    color: var(--text-primary);
+  }
+  .input-wrap input::placeholder { color: var(--text-muted); }
+
+  .input-suffix {
+    padding: 0 12px;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text-muted);
+    border-left: 1px solid var(--border);
+    background: var(--bg-surface);
+    height: 100%;
+    display: flex;
+    align-items: center;
+  }
+
+  .form-error { font-size: 11px; color: var(--error); margin-top: 5px; }
+
+  .btn-primary {
+    width: 100%;
+    background: var(--accent);
+    color: #0a0a0a;
+    border: none;
+    border-radius: 8px;
+    padding: 11px;
+    font-family: 'Inter', sans-serif;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: opacity 0.15s;
+  }
+  .btn-primary:hover { opacity: 0.9; }
+  .btn-primary:disabled { opacity: 0.35; cursor: not-allowed; }
+
+  .form-divider {
+    border: none;
+    border-top: 1px solid var(--border);
+    margin: 4px 0 16px;
+  }
+
+  .transfer-preview-label {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    margin-bottom: 14px;
+    padding: 0 20px;
+  }
+
+  /* ── ChannelList ── */
+  .channels-list { display: flex; flex-direction: column; gap: 10px; padding: 14px 16px; }
+
+  .channel-card {
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    overflow: hidden;
+    transition: border-color 0.15s;
+  }
+  .channel-card:hover { border-color: #333; }
+
+  .channel-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 13px 14px;
+    cursor: pointer;
+  }
+
+  .asset-badge {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 11px;
+    font-weight: 500;
+    background: var(--accent-dim);
+    color: var(--accent);
+    border-radius: 999px;
+    padding: 3px 9px;
+    white-space: nowrap;
+  }
+
+  .channel-meta { flex: 1; min-width: 0; }
+  .channel-network { font-size: 12px; color: var(--text-muted); }
+  .channel-id {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 11px;
+    color: var(--text-muted);
+  }
+
+  .channel-actions-row {
+    display: flex;
+    gap: 6px;
+    padding: 0 14px 12px;
+  }
+
+  .btn-ghost {
+    background: none;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 5px 12px;
+    font-family: 'Inter', sans-serif;
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: border-color 0.15s, color 0.15s;
+  }
+  .btn-ghost:hover { border-color: #444; color: var(--text-primary); }
+  .btn-ghost.danger { color: var(--error); border-color: rgba(239,68,68,0.3); }
+  .btn-ghost.danger:hover { border-color: var(--error); }
+
+  /* ── StateViewer ── */
+  .state-viewer {
+    background: var(--bg-elevated);
+    border-radius: 8px;
+    margin: 0 14px 14px;
+    overflow: hidden;
+  }
+
+  .state-table-header {
+    display: grid;
+    grid-template-columns: 100px 60px 1fr auto;
+    padding: 8px 14px;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .state-col-label {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .state-row {
+    display: grid;
+    grid-template-columns: 100px 60px 1fr auto;
+    padding: 10px 14px;
+    border-bottom: 1px solid var(--border);
+    align-items: center;
+  }
+  .state-row:last-child { border-bottom: none; }
+
+  .state-name {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--text-primary);
+  }
+
+  .tooltip-wrap { position: relative; display: inline-flex; }
+  .tooltip-wrap .tooltip-icon {
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    color: var(--text-muted);
+    font-size: 9px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: default;
+    font-family: 'Inter', sans-serif;
+    font-weight: 600;
+  }
+  .tooltip-wrap::after {
+    content: attr(data-tip);
+    position: absolute;
+    bottom: calc(100% + 6px);
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 5px 10px;
+    font-size: 11px;
+    color: var(--text-primary);
+    white-space: nowrap;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.15s;
+    z-index: 20;
+  }
+  .tooltip-wrap:hover::after { opacity: 1; }
+
+  .state-version {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 12px;
+    color: var(--text-muted);
+  }
+
+  .state-amount {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 13px;
+    color: var(--text-primary);
+  }
+
+  .btn-state-secondary {
+    background: none;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 4px 10px;
+    font-family: 'Inter', sans-serif;
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--text-muted);
+    cursor: pointer;
+    white-space: nowrap;
+    transition: border-color 0.15s, color 0.15s;
+  }
+  .btn-state-secondary:hover { border-color: #444; color: var(--text-primary); }
+
+  .btn-state-accent {
+    background: var(--accent);
+    border: none;
+    border-radius: 6px;
+    padding: 4px 10px;
+    font-family: 'Inter', sans-serif;
+    font-size: 11px;
+    font-weight: 600;
+    color: #0a0a0a;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: opacity 0.15s;
+  }
+  .btn-state-accent:hover { opacity: 0.88; }
+
+  /* ── Warning chip ── */
+  .warn-chip {
+    font-size: 11px;
+    font-weight: 500;
+    background: rgba(245, 166, 35, 0.15);
+    color: var(--accent);
+    border: 1px solid rgba(245, 166, 35, 0.3);
+    border-radius: 6px;
+    padding: 3px 8px;
+    white-space: nowrap;
+  }
+
+  /* ── Closed badge ── */
+  .badge-closed {
+    font-size: 11px;
+    font-weight: 500;
+    background: rgba(102,102,102,0.15);
+    color: var(--text-muted);
+    border-radius: 999px;
+    padding: 3px 9px;
+  }
+
+  /* ── Chevron ── */
+  .chevron {
+    margin-left: auto;
+    color: var(--text-muted);
+    transition: transform 0.2s;
+  }
+  .chevron.open { transform: rotate(180deg); }
+
+  /* ── Modal section ── */
+  .modal-section {
+    max-width: 940px;
+    margin: 0 auto;
+    padding: 0 24px 60px;
+  }
+
+  .modal-section-label {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    border-top: 1px solid var(--border);
+    padding-top: 32px;
+    margin-bottom: 24px;
+  }
+
+  .modal-row {
+    display: flex;
+    gap: 24px;
+    align-items: flex-start;
+  }
+
+  .modal-backdrop {
+    flex: 1;
+    background: rgba(10,10,10,0.7);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 40px 24px;
+    backdrop-filter: blur(4px);
+  }
+
+  .modal-card {
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 28px;
+    width: 100%;
+    max-width: 360px;
+  }
+
+  .modal-icon {
+    width: 42px;
+    height: 42px;
+    background: rgba(245, 166, 35, 0.12);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 16px;
+    font-size: 20px;
+  }
+
+  .modal-title {
+    font-size: 17px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin-bottom: 8px;
+  }
+
+  .modal-body {
+    font-size: 13px;
+    color: var(--text-muted);
+    margin-bottom: 20px;
+    line-height: 1.6;
+  }
+
+  .modal-btn-stack { display: flex; flex-direction: column; gap: 8px; }
+
+  .btn-modal-chain {
+    width: 100%;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 11px 14px;
+    font-family: 'Inter', sans-serif;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--text-primary);
+    cursor: pointer;
+    text-align: left;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    transition: border-color 0.15s, background 0.15s;
+  }
+  .btn-modal-chain:hover { background: #222; border-color: #333; }
+
+  .chain-dot {
+    width: 8px; height: 8px;
+    border-radius: 50%;
+    background: var(--success);
+    flex-shrink: 0;
+  }
+
+  /* ── Radio options ── */
+  .radio-option {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 14px;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    cursor: pointer;
+    margin-bottom: 8px;
+    transition: border-color 0.15s;
+  }
+  .radio-option.selected { border-color: var(--accent); }
+
+  .radio-circle {
+    width: 16px; height: 16px;
+    border-radius: 50%;
+    border: 2px solid var(--border);
+    flex-shrink: 0;
+    display: flex; align-items: center; justify-content: center;
+  }
+  .radio-option.selected .radio-circle {
+    border-color: var(--accent);
+  }
+  .radio-option.selected .radio-circle::after {
+    content: '';
+    width: 7px; height: 7px;
+    border-radius: 50%;
+    background: var(--accent);
+    display: block;
+  }
+
+  .radio-label { font-size: 13px; color: var(--text-primary); }
+  .radio-sublabel { font-size: 11px; color: var(--text-muted); }
+
+  .modal-footer { display: flex; gap: 8px; margin-top: 20px; }
+
+  .btn-cancel {
+    flex: 1;
+    background: none;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 10px;
+    font-family: 'Inter', sans-serif;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: border-color 0.15s, color 0.15s;
+  }
+  .btn-cancel:hover { border-color: #444; color: var(--text-primary); }
+
+  .btn-confirm {
+    flex: 1.5;
+    background: var(--accent);
+    border: none;
+    border-radius: 8px;
+    padding: 10px;
+    font-family: 'Inter', sans-serif;
+    font-size: 13px;
+    font-weight: 600;
+    color: #0a0a0a;
+    cursor: pointer;
+    transition: opacity 0.15s;
+  }
+  .btn-confirm:hover { opacity: 0.88; }
+
+  .muted { color: var(--text-muted); }
+</style>
+</head>
+<body>
+
+<!-- ══════════════════════════════════════
+     NAV / WALLET BAR
+════════════════════════════════════════ -->
+<nav class="nav">
+  <span class="nav-logo">Nitrolite</span>
+
+  <div class="nav-center">
+    <span class="status-dot"></span>
+    <span>Connected &middot; 2s ago</span>
+  </div>
+
+  <div class="nav-right">
+    <div class="chain-pill">
+      Sepolia
+      <svg width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+    </div>
+
+    <div class="wallet-chip">
+      0x742d&hellip;b1c7
+      <button class="icon-btn" title="Copy address">
+        <svg width="13" height="13" viewBox="0 0 14 14" fill="none"><rect x="4" y="4" width="8" height="8" rx="1.5" stroke="currentColor" stroke-width="1.3"/><path d="M2 10V2h8" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg>
+      </button>
+    </div>
+
+    <button class="btn-disconnect">Disconnect</button>
+  </div>
+</nav>
+
+<!-- ══════════════════════════════════════
+     MAIN LAYOUT
+════════════════════════════════════════ -->
+<div class="main">
+
+  <!-- ── LEFT: ActionPanel ── -->
+  <div class="card">
+    <div class="card-header">
+      <span class="card-title">Actions</span>
+    </div>
+
+    <!-- Balance section -->
+    <div class="balance-section">
+      <div class="asset-selector">
+        <span>USDC</span>
+        <svg width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      </div>
+
+      <div class="balance-row" style="margin-bottom:6px;">
+        <span class="balance-label">Channel balance</span>
+        <span class="balance-amount-big">125.00</span>
+      </div>
+      <div class="balance-row">
+        <span class="balance-label">On-chain balance</span>
+        <span class="balance-amount-sm">900.00</span>
+      </div>
+    </div>
+
+    <!-- Tabs -->
+    <div class="tabs">
+      <button class="tab active">Deposit</button>
+      <button class="tab">Withdraw</button>
+      <button class="tab">Transfer</button>
+    </div>
+
+    <!-- Deposit form -->
+    <div class="form-section">
+      <div class="form-group">
+        <label class="form-label">Amount</label>
+        <div class="input-wrap">
+          <input type="text" value="50.00" placeholder="0.00">
+          <span class="input-suffix">USDC</span>
+        </div>
+      </div>
+      <button class="btn-primary">Deposit</button>
+    </div>
+
+    <!-- Transfer preview -->
+    <hr class="form-divider" style="margin: 0 20px 0; border-top:1px solid var(--border);">
+    <p class="transfer-preview-label" style="margin-top:16px;">Transfer tab preview</p>
+    <div class="form-section" style="padding-top:0">
+      <div class="form-group">
+        <label class="form-label">Recipient address</label>
+        <div class="input-wrap" style="border-color:var(--error);">
+          <input type="text" value="0xBadAddr" placeholder="0x...">
+        </div>
+        <p class="form-error">Invalid Ethereum address</p>
+      </div>
+      <div class="form-group">
+        <label class="form-label">Amount</label>
+        <div class="input-wrap">
+          <input type="text" value="" placeholder="0.00">
+          <span class="input-suffix">USDC</span>
+        </div>
+      </div>
+      <button class="btn-primary" disabled>Transfer</button>
+    </div>
+  </div>
+
+  <!-- ── RIGHT: ChannelList ── -->
+  <div class="card">
+    <div class="card-header">
+      <span class="card-title">Channels (3)</span>
+      <button class="icon-btn" title="Refresh">
+        <svg width="15" height="15" viewBox="0 0 15 15" fill="none"><path d="M13 7.5A5.5 5.5 0 1 1 7.5 2a5.5 5.5 0 0 1 4.243 2H9.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><path d="M11.5 4V2h2" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      </button>
+    </div>
+
+    <div class="channels-list">
+
+      <!-- Channel 1 — USDC / Ethereum Mainnet — EXPANDED -->
+      <div class="channel-card" style="border-color:#333;">
+        <div class="channel-header">
+          <span class="asset-badge">USDC</span>
+          <div class="channel-meta">
+            <div style="font-size:13px;font-weight:500;">Ethereum Mainnet</div>
+            <div class="channel-id">0xabc1&hellip;f304
+              <button class="icon-btn" style="display:inline-flex;vertical-align:middle;margin-left:2px;" title="Copy">
+                <svg width="11" height="11" viewBox="0 0 14 14" fill="none"><rect x="4" y="4" width="8" height="8" rx="1.5" stroke="currentColor" stroke-width="1.3"/><path d="M2 10V2h8" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg>
+              </button>
+            </div>
+          </div>
+          <svg class="chevron open" width="14" height="14" viewBox="0 0 12 12" fill="none"><path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </div>
+
+        <div class="channel-actions-row">
+          <button class="btn-ghost">Deposit</button>
+          <button class="btn-ghost">Withdraw</button>
+          <button class="btn-ghost danger">Close</button>
+        </div>
+
+        <!-- StateViewer -->
+        <div class="state-viewer">
+          <div class="state-table-header">
+            <span class="state-col-label">State</span>
+            <span class="state-col-label">Version</span>
+            <span class="state-col-label">Amount</span>
+            <span class="state-col-label">Action</span>
+          </div>
+
+          <div class="state-row">
+            <div class="state-name">
+              Enforced
+              <span class="tooltip-wrap" data-tip="On-chain finalized state. Cannot be reverted.">
+                <span class="tooltip-icon">?</span>
+              </span>
+            </div>
+            <span class="state-version">v12</span>
+            <span class="state-amount">125.00 <span class="muted" style="font-size:11px;">USDC</span></span>
+            <span style="font-size:12px;color:var(--text-muted);">—</span>
+          </div>
+
+          <div class="state-row">
+            <div class="state-name">
+              Signed
+              <span class="tooltip-wrap" data-tip="Both parties signed; ready to checkpoint on-chain.">
+                <span class="tooltip-icon">?</span>
+              </span>
+            </div>
+            <span class="state-version">v14</span>
+            <span class="state-amount">115.00 <span class="muted" style="font-size:11px;">USDC</span></span>
+            <button class="btn-state-secondary">Checkpoint signed</button>
+          </div>
+
+          <div class="state-row">
+            <div class="state-name">
+              Issued
+              <span class="tooltip-wrap" data-tip="Pending acknowledgment from counterparty.">
+                <span class="tooltip-icon">?</span>
+              </span>
+            </div>
+            <span class="state-version">v15</span>
+            <span class="state-amount">105.00 <span class="muted" style="font-size:11px;">USDC</span></span>
+            <button class="btn-state-accent">Acknowledge</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Channel 2 — ETH / Sepolia — COLLAPSED + wrong chain -->
+      <div class="channel-card">
+        <div class="channel-header">
+          <span class="asset-badge">ETH</span>
+          <div class="channel-meta">
+            <div style="font-size:13px;font-weight:500;display:flex;align-items:center;gap:8px;">
+              Sepolia
+              <span class="warn-chip">⚠ Switch to Sepolia</span>
+            </div>
+            <div class="channel-id">0xdef4&hellip;9a21</div>
+          </div>
+          <svg class="chevron" width="14" height="14" viewBox="0 0 12 12" fill="none"><path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </div>
+      </div>
+
+      <!-- Channel 3 — USDC / Sepolia — CLOSED -->
+      <div class="channel-card" style="opacity:0.55;">
+        <div class="channel-header">
+          <span class="asset-badge" style="background:rgba(102,102,102,0.12);color:var(--text-muted);">USDC</span>
+          <div class="channel-meta">
+            <div style="font-size:13px;font-weight:500;display:flex;align-items:center;gap:8px;color:var(--text-muted);">
+              Sepolia
+              <span class="badge-closed">Closed</span>
+            </div>
+            <div class="channel-id">0x8fa2&hellip;c510</div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════
+     MODAL PREVIEWS
+════════════════════════════════════════ -->
+<div class="modal-section">
+  <p class="modal-section-label">Modal Previews</p>
+
+  <div class="modal-row">
+
+    <!-- UnsupportedChainModal -->
+    <div class="modal-backdrop">
+      <div class="modal-card">
+        <div class="modal-icon">⚠</div>
+        <h2 class="modal-title">Unsupported Network</h2>
+        <p class="modal-body">This network is not supported by Nitrolite. Please switch to a supported chain below.</p>
+        <div class="modal-btn-stack">
+          <button class="btn-modal-chain">
+            <span class="chain-dot"></span>
+            Switch to Ethereum Mainnet
+          </button>
+          <button class="btn-modal-chain">
+            <span class="chain-dot" style="background:#818cf8;box-shadow:0 0 6px #818cf8;"></span>
+            Switch to Sepolia
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- SetHomechainModal -->
+    <div class="modal-backdrop">
+      <div class="modal-card">
+        <h2 class="modal-title">Select Home Blockchain</h2>
+        <p class="modal-body" style="margin-bottom:16px;">Choose the home chain for your <strong style="color:var(--text-primary);">USDC</strong> channel.</p>
+
+        <div class="radio-option">
+          <div class="radio-circle"></div>
+          <div>
+            <div class="radio-label">Ethereum Mainnet</div>
+            <div class="radio-sublabel">Higher security, higher fees</div>
+          </div>
+        </div>
+
+        <div class="radio-option selected">
+          <div class="radio-circle"></div>
+          <div>
+            <div class="radio-label">Sepolia</div>
+            <div class="radio-sublabel">Testnet &mdash; fast &amp; free</div>
+          </div>
+        </div>
+
+        <div class="modal-footer">
+          <button class="btn-cancel">Cancel</button>
+          <button class="btn-confirm">Confirm</button>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+</body>
+</html>

--- a/playground/mockups/general/mockup-c.html
+++ b/playground/mockups/general/mockup-c.html
@@ -1,0 +1,805 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Nitrolite Playground</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --bg-base:      #0a0a0a;
+    --bg-surface:   #141414;
+    --bg-elevated:  #1c1c1c;
+    --border:       #242424;
+    --text-primary: #f0f0f0;
+    --text-muted:   #666666;
+    --accent:       #f5a623;
+    --accent-dim:   rgba(245, 166, 35, 0.12);
+    --error:        #ef4444;
+    --success:      #22c55e;
+    --blue:         #3b82f6;
+    --blue-dim:     rgba(59, 130, 246, 0.12);
+  }
+
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+  body {
+    font-family: 'Inter', sans-serif;
+    background: radial-gradient(ellipse at 20% 50%, rgba(245,166,35,0.03) 0%, #0a0a0a 60%);
+    background-color: var(--bg-base);
+    color: var(--text-primary);
+    min-height: 100vh;
+    font-size: 14px;
+    line-height: 1.5;
+  }
+
+  /* ─── NAVBAR ─────────────────────────────────────────── */
+  .navbar {
+    position: sticky; top: 0; z-index: 100;
+    background: rgba(10,10,10,0.85);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border-bottom: 1px solid var(--border);
+    padding: 0 24px;
+    height: 52px;
+    display: flex; align-items: center; justify-content: space-between;
+  }
+  .navbar-brand {
+    display: flex; align-items: center; gap: 10px;
+    font-weight: 700; font-size: 15px; letter-spacing: -0.02em;
+  }
+  .brand-logo {
+    width: 28px; height: 28px; border-radius: 6px;
+    background: linear-gradient(135deg, #f5a623, #e8950f);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 13px; font-weight: 800; color: #0a0a0a;
+    box-shadow: 0 0 12px rgba(245,166,35,0.3);
+  }
+  .navbar-meta { display: flex; align-items: center; gap: 16px; }
+  .chain-pill {
+    background: var(--bg-elevated); border: 1px solid var(--border);
+    padding: 3px 10px; border-radius: 20px;
+    font-size: 12px; font-family: 'JetBrains Mono', monospace;
+    color: var(--text-muted);
+  }
+  .nav-addr {
+    font-family: 'JetBrains Mono', monospace; font-size: 12px; color: var(--text-muted);
+  }
+
+  /* ─── LAYOUT ─────────────────────────────────────────── */
+  .layout {
+    display: grid;
+    grid-template-columns: 220px 400px 1fr;
+    gap: 16px;
+    padding: 20px 24px;
+    max-width: 1280px;
+    align-items: start;
+  }
+
+  /* ─── CARD ───────────────────────────────────────────── */
+  .card {
+    background: rgba(20,20,20,0.75);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    overflow: hidden;
+  }
+  .card-body { padding: 16px; }
+  .card-section { padding: 16px; }
+  .card-divider { height: 1px; background: var(--border); }
+
+  .section-label {
+    font-size: 10px; font-weight: 600; letter-spacing: 0.1em;
+    text-transform: uppercase; color: var(--text-muted);
+    margin-bottom: 12px;
+  }
+
+  /* ─── LEFT COLUMN ────────────────────────────────────── */
+  .wallet-avatar {
+    width: 36px; height: 36px; border-radius: 50%;
+    background: linear-gradient(135deg, #f5a623 0%, #7c3aed 100%);
+    display: flex; align-items: center; justify-content: center;
+    font-weight: 700; font-size: 13px; color: #fff;
+    flex-shrink: 0;
+  }
+  .wallet-info { flex: 1; min-width: 0; }
+  .wallet-addr-row {
+    display: flex; align-items: center; gap: 6px;
+    font-family: 'JetBrains Mono', monospace; font-size: 12px;
+  }
+  .copy-icon {
+    cursor: pointer; color: var(--text-muted); font-size: 11px;
+    opacity: 0.6; transition: opacity 0.15s;
+  }
+  .copy-icon:hover { opacity: 1; color: var(--accent); }
+  .wallet-row { display: flex; align-items: center; gap: 10px; }
+  .pill {
+    display: inline-flex; align-items: center;
+    background: var(--bg-elevated); border: 1px solid var(--border);
+    padding: 2px 8px; border-radius: 20px;
+    font-size: 11px; color: var(--text-muted);
+  }
+  .disconnect { font-size: 11px; color: var(--error); cursor: pointer; opacity: 0.8; }
+  .disconnect:hover { opacity: 1; text-decoration: underline; }
+
+  /* Node status */
+  .node-row { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }
+  .dot-wrap { position: relative; width: 10px; height: 10px; flex-shrink: 0; }
+  .dot {
+    width: 10px; height: 10px; border-radius: 50%;
+    background: var(--success); position: relative; z-index: 1;
+  }
+  .dot-ring {
+    position: absolute; inset: -3px; border-radius: 50%;
+    border: 2px solid var(--success);
+    animation: pulse 2s ease-in-out infinite;
+    opacity: 0.5;
+  }
+  @keyframes pulse { 0%,100% { opacity: 0.5; transform: scale(1); } 50% { opacity: 0; transform: scale(1.5); } }
+  .node-label { font-size: 13px; font-weight: 500; }
+  .node-meta {
+    font-family: 'JetBrains Mono', monospace; font-size: 11px;
+    color: var(--text-muted); line-height: 1.7;
+  }
+  .node-url {
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    max-width: 180px;
+  }
+
+  /* ─── CENTER COLUMN ──────────────────────────────────── */
+  .panel-header {
+    padding: 16px 16px 0;
+    font-size: 13px; font-weight: 600; color: var(--text-muted);
+    letter-spacing: 0.04em; text-transform: uppercase;
+    margin-bottom: 14px;
+  }
+  .asset-select {
+    width: 100%; background: var(--bg-elevated); border: 1px solid var(--border);
+    color: var(--text-primary); font-family: 'Inter', sans-serif;
+    font-size: 14px; font-weight: 600; padding: 10px 12px;
+    border-radius: 8px; appearance: none; cursor: pointer;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23666' stroke-width='2'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
+    background-repeat: no-repeat; background-position: right 12px center;
+    margin-bottom: 16px;
+  }
+  .asset-select:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 2px var(--accent-dim); }
+
+  .balance-big {
+    font-family: 'JetBrains Mono', monospace; font-size: 36px; font-weight: 600;
+    color: var(--accent); letter-spacing: -0.02em; line-height: 1;
+  }
+  .balance-unit { font-size: 16px; font-weight: 400; color: var(--text-muted); margin-left: 6px; }
+  .balance-sub { font-size: 12px; color: var(--text-muted); margin-top: 6px; }
+  .balance-block { margin-bottom: 20px; }
+
+  /* Tabs */
+  .tabs { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 4px; margin-bottom: 16px; }
+  .tab {
+    padding: 8px; text-align: center; border-radius: 7px; cursor: pointer;
+    font-size: 13px; font-weight: 500; border: 1px solid var(--border);
+    color: var(--text-muted); transition: all 0.15s; user-select: none;
+  }
+  .tab.active {
+    background: rgba(245,166,35,0.15); border-color: var(--accent);
+    color: var(--accent);
+    box-shadow: 0 0 12px rgba(245,166,35,0.2);
+  }
+
+  /* Inputs */
+  .input-wrap { position: relative; margin-bottom: 12px; }
+  .input {
+    width: 100%; background: var(--bg-elevated); border: 1px solid var(--border);
+    color: var(--text-primary); font-family: 'JetBrains Mono', monospace;
+    font-size: 14px; padding: 10px 12px; border-radius: 8px; outline: none;
+    transition: border-color 0.15s, box-shadow 0.15s;
+  }
+  .input::placeholder { color: var(--text-muted); }
+  .input:focus, .input.focused { border-color: var(--accent); box-shadow: 0 0 0 2px var(--accent-dim); }
+  .input.error { border-color: var(--error); box-shadow: 0 0 0 2px rgba(239,68,68,0.12); }
+  .input.disabled, .input:disabled { opacity: 0.4; cursor: not-allowed; }
+  .input-max {
+    position: absolute; right: 10px; top: 50%; transform: translateY(-50%);
+    font-size: 11px; font-weight: 600; color: var(--accent); cursor: pointer;
+    font-family: 'Inter', sans-serif; letter-spacing: 0.04em;
+  }
+  .input-error { font-size: 11px; color: var(--error); margin-top: -8px; margin-bottom: 10px; }
+  .input-label { font-size: 11px; color: var(--text-muted); margin-bottom: 5px; }
+
+  /* Buttons */
+  .btn-primary {
+    width: 100%; padding: 12px; border-radius: 8px; border: none; cursor: pointer;
+    background: linear-gradient(135deg, #f5a623, #e8950f);
+    color: #0a0a0a; font-size: 14px; font-weight: 700;
+    font-family: 'Inter', sans-serif;
+    box-shadow: 0 0 20px rgba(245,166,35,0.35), 0 4px 12px rgba(0,0,0,0.4);
+    transition: box-shadow 0.2s, transform 0.1s;
+  }
+  .btn-primary:hover { box-shadow: 0 0 28px rgba(245,166,35,0.5), 0 4px 16px rgba(0,0,0,0.5); transform: translateY(-1px); }
+  .btn-primary:disabled {
+    opacity: 0.35; cursor: not-allowed; transform: none;
+    box-shadow: none; background: var(--bg-elevated); color: var(--text-muted);
+  }
+
+  .btn-sm {
+    padding: 5px 10px; border-radius: 6px; font-size: 11px; font-weight: 600;
+    cursor: pointer; border: 1px solid var(--border); font-family: 'Inter', sans-serif;
+    transition: all 0.15s; white-space: nowrap;
+  }
+  .btn-sm.neutral { background: var(--bg-elevated); color: var(--text-muted); }
+  .btn-sm.neutral:hover { border-color: var(--text-muted); color: var(--text-primary); }
+  .btn-sm.accent { background: var(--accent-dim); border-color: var(--accent); color: var(--accent); }
+  .btn-sm.accent:hover { box-shadow: 0 0 10px rgba(245,166,35,0.3); }
+  .btn-sm.blue { background: var(--blue-dim); border-color: var(--blue); color: var(--blue); }
+  .btn-sm.blue:hover { box-shadow: 0 0 10px rgba(59,130,246,0.25); }
+  .btn-sm.danger { background: rgba(239,68,68,0.08); border-color: var(--error); color: var(--error); }
+
+  /* Transfer form preview */
+  .form-section { border-top: 1px solid var(--border); padding-top: 14px; margin-top: 4px; }
+  .form-section-label {
+    font-size: 10px; font-weight: 600; letter-spacing: 0.08em;
+    text-transform: uppercase; color: var(--text-muted); margin-bottom: 10px;
+  }
+
+  /* ─── RIGHT COLUMN ───────────────────────────────────── */
+  .channels-header {
+    display: flex; align-items: center; justify-content: space-between;
+    margin-bottom: 12px;
+  }
+  .channels-title { font-size: 15px; font-weight: 600; }
+  .count-badge {
+    background: var(--bg-elevated); border: 1px solid var(--border);
+    padding: 1px 8px; border-radius: 20px; font-size: 11px;
+    font-family: 'JetBrains Mono', monospace; color: var(--text-muted);
+  }
+  .channels-list { display: flex; flex-direction: column; gap: 10px; }
+
+  /* Channel cards */
+  .channel-card {
+    background: rgba(20,20,20,0.75);
+    backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px);
+    border: 1px solid var(--border); border-radius: 12px; overflow: hidden;
+  }
+  .channel-card.expanded { border-color: var(--accent); }
+  .channel-card.expanded { border-left: 4px solid var(--accent); }
+  .channel-card.dimmed { opacity: 0.5; }
+
+  .channel-header {
+    padding: 14px 14px 12px; display: flex;
+    align-items: center; gap: 10px; cursor: pointer;
+  }
+  .asset-icon {
+    width: 32px; height: 32px; border-radius: 50%;
+    display: flex; align-items: center; justify-content: center;
+    font-weight: 700; font-size: 11px; flex-shrink: 0;
+  }
+  .asset-icon.amber { background: rgba(245,166,35,0.15); color: var(--accent); border: 1px solid rgba(245,166,35,0.3); }
+  .asset-icon.gray  { background: var(--bg-elevated); color: var(--text-muted); border: 1px solid var(--border); }
+  .channel-meta { flex: 1; min-width: 0; }
+  .channel-name { font-weight: 600; font-size: 13px; }
+  .channel-sub { font-size: 11px; color: var(--text-muted); }
+  .channel-id {
+    font-family: 'JetBrains Mono', monospace; font-size: 10px;
+    color: var(--text-muted); margin-top: 2px;
+  }
+  .channel-right { display: flex; align-items: center; gap: 8px; flex-shrink: 0; }
+  .chevron { font-size: 12px; color: var(--text-muted); transition: transform 0.2s; }
+  .chevron.open { transform: rotate(90deg); }
+  .closed-badge {
+    padding: 2px 8px; border-radius: 20px; border: 1px solid var(--border);
+    font-size: 10px; font-weight: 500; color: var(--text-muted);
+  }
+
+  .channel-actions {
+    padding: 0 14px 12px; display: flex; gap: 6px;
+  }
+
+  /* Warning strip */
+  .warning-strip {
+    margin: 0 14px 12px; padding: 8px 10px; border-radius: 6px;
+    background: var(--accent-dim); border: 1px solid rgba(245,166,35,0.2);
+    font-size: 11px; color: var(--accent); line-height: 1.4;
+  }
+
+  /* State viewer */
+  .state-viewer {
+    margin: 0 14px 14px;
+    background: rgba(10,10,10,0.5);
+    border: 1px solid var(--border); border-radius: 8px;
+    overflow: hidden;
+  }
+  .state-viewer-header {
+    padding: 10px 12px; border-bottom: 1px solid var(--border);
+    font-size: 10px; font-weight: 600; letter-spacing: 0.08em;
+    text-transform: uppercase; color: var(--text-muted);
+    display: grid; grid-template-columns: 1fr 60px 90px 80px; gap: 8px;
+  }
+  .state-row {
+    padding: 10px 12px; display: grid;
+    grid-template-columns: 1fr 60px 90px 80px;
+    gap: 8px; align-items: center; border-bottom: 1px solid rgba(36,36,36,0.5);
+  }
+  .state-row:last-child { border-bottom: none; }
+  .state-name-cell { display: flex; align-items: center; gap: 8px; }
+  .state-dot {
+    width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0;
+    position: relative;
+  }
+  .state-dot.green { background: var(--success); box-shadow: 0 0 6px rgba(34,197,94,0.4); }
+  .state-dot.blue  { background: var(--blue);    box-shadow: 0 0 6px rgba(59,130,246,0.4); }
+  .state-dot.amber { background: var(--accent);  box-shadow: 0 0 6px rgba(245,166,35,0.5); }
+  .state-name-text { font-size: 12px; font-weight: 500; }
+  .tooltip-wrap { position: relative; display: inline-flex; cursor: help; }
+  .tooltip-icon {
+    width: 14px; height: 14px; border-radius: 50%; border: 1px solid var(--border);
+    font-size: 9px; color: var(--text-muted); display: flex;
+    align-items: center; justify-content: center;
+  }
+  .tooltip-wrap::after {
+    content: attr(data-tip);
+    position: absolute; bottom: calc(100% + 6px); left: 50%; transform: translateX(-50%);
+    background: var(--bg-elevated); border: 1px solid var(--border);
+    color: var(--text-primary); font-size: 11px; padding: 6px 10px;
+    border-radius: 6px; white-space: nowrap; pointer-events: none;
+    opacity: 0; transition: opacity 0.15s; z-index: 50;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.4);
+  }
+  .tooltip-wrap:hover::after { opacity: 1; }
+  .state-version {
+    font-family: 'JetBrains Mono', monospace; font-size: 11px;
+    color: var(--text-muted);
+  }
+  .state-amount {
+    font-family: 'JetBrains Mono', monospace; font-size: 12px;
+    font-weight: 500;
+  }
+  .state-amount.green { color: var(--success); }
+  .state-amount.blue  { color: var(--blue); }
+  .state-amount.amber { color: var(--accent); }
+  .state-action { display: flex; justify-content: flex-end; }
+
+  /* ─── MODAL SECTION ──────────────────────────────────── */
+  .modal-section-label {
+    font-size: 11px; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.1em; color: var(--text-muted); margin-bottom: 16px;
+    padding-bottom: 8px; border-bottom: 1px solid var(--border);
+  }
+  .modal-previews {
+    padding: 24px; display: flex; gap: 24px; align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  /* Overlay demo */
+  .overlay-demo {
+    position: relative; border-radius: 12px; overflow: hidden;
+    border: 1px solid var(--border); flex: 1; min-width: 340px;
+  }
+  .overlay-bg {
+    padding: 24px; background: rgba(10,10,10,0.9);
+    filter: blur(1px); pointer-events: none; min-height: 180px;
+    display: flex; gap: 12px;
+  }
+  .overlay-bg-col {
+    flex: 1; border-radius: 8px; background: var(--bg-elevated);
+    border: 1px solid var(--border); height: 130px;
+  }
+  .overlay-scrim {
+    position: absolute; inset: 0;
+    background: rgba(0,0,0,0.65);
+    display: flex; align-items: center; justify-content: center;
+  }
+  .modal-card {
+    background: rgba(20,20,20,0.95);
+    backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px);
+    border: 1px solid rgba(245,166,35,0.35);
+    border-radius: 14px; padding: 28px 24px;
+    box-shadow: 0 0 40px rgba(245,166,35,0.15), 0 20px 60px rgba(0,0,0,0.6);
+    width: 300px;
+  }
+  .modal-icon {
+    width: 44px; height: 44px; border-radius: 50%;
+    background: rgba(245,166,35,0.15); border: 1px solid rgba(245,166,35,0.3);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 20px; margin: 0 auto 14px;
+  }
+  .modal-title { font-size: 17px; font-weight: 700; text-align: center; margin-bottom: 8px; }
+  .modal-body { font-size: 12px; color: var(--text-muted); text-align: center; margin-bottom: 18px; line-height: 1.6; }
+  .chain-btn {
+    width: 100%; padding: 10px 12px; border-radius: 8px;
+    background: var(--bg-elevated); border: 1px solid var(--border);
+    color: var(--text-primary); font-family: 'Inter', sans-serif; font-size: 13px;
+    cursor: pointer; margin-bottom: 6px; text-align: left; display: flex;
+    align-items: center; gap: 8px; transition: all 0.15s;
+  }
+  .chain-btn:hover { border-color: var(--accent); box-shadow: 0 0 10px rgba(245,166,35,0.2); }
+  .chain-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--success); }
+
+  /* Homechain modal */
+  .homechain-card {
+    background: rgba(20,20,20,0.95);
+    backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px);
+    border: 1px solid var(--border); border-radius: 14px; padding: 24px;
+    width: 320px;
+  }
+  .homechain-header { display: flex; align-items: center; gap: 8px; margin-bottom: 18px; }
+  .homechain-title { font-size: 16px; font-weight: 700; }
+  .asset-badge {
+    background: rgba(245,166,35,0.1); border: 1px solid rgba(245,166,35,0.3);
+    color: var(--accent); font-size: 11px; font-weight: 600;
+    padding: 2px 8px; border-radius: 20px;
+  }
+  .radio-card {
+    border: 1px solid var(--border); border-radius: 8px; padding: 12px;
+    cursor: pointer; margin-bottom: 6px; display: flex; align-items: center;
+    gap: 10px; transition: all 0.15s;
+  }
+  .radio-card.selected {
+    border-color: var(--accent); background: var(--accent-dim);
+    box-shadow: 0 0 12px rgba(245,166,35,0.15);
+  }
+  .radio-ring {
+    width: 16px; height: 16px; border-radius: 50%;
+    border: 2px solid var(--border); flex-shrink: 0;
+    display: flex; align-items: center; justify-content: center;
+    transition: border-color 0.15s;
+  }
+  .radio-ring.selected { border-color: var(--accent); }
+  .radio-inner {
+    width: 8px; height: 8px; border-radius: 50%; background: var(--accent);
+    display: none;
+  }
+  .radio-ring.selected .radio-inner { display: block; }
+  .radio-chain-name { font-size: 13px; font-weight: 500; }
+  .radio-chain-sub { font-size: 11px; color: var(--text-muted); }
+  .modal-btn-row { display: flex; gap: 8px; margin-top: 16px; }
+  .btn-ghost {
+    flex: 1; padding: 9px; border-radius: 7px; border: 1px solid var(--border);
+    background: transparent; color: var(--text-muted); font-size: 13px;
+    font-family: 'Inter', sans-serif; cursor: pointer;
+  }
+  .btn-confirm {
+    flex: 2; padding: 9px; border-radius: 7px; border: none;
+    background: linear-gradient(135deg, #f5a623, #e8950f);
+    color: #0a0a0a; font-size: 13px; font-weight: 700;
+    font-family: 'Inter', sans-serif; cursor: pointer;
+    box-shadow: 0 0 14px rgba(245,166,35,0.3);
+  }
+
+  /* section spacer */
+  .spacer { height: 20px; }
+  .full-width { grid-column: 1 / -1; }
+</style>
+</head>
+<body>
+
+<!-- NAVBAR -->
+<nav class="navbar">
+  <div class="navbar-brand">
+    <div class="brand-logo">N</div>
+    Nitrolite Playground
+  </div>
+  <div class="navbar-meta">
+    <span class="chain-pill">⬡ Sepolia</span>
+    <span class="nav-addr">0x742d35Cc...b1c7</span>
+  </div>
+</nav>
+
+<!-- MAIN LAYOUT -->
+<div class="layout">
+
+  <!-- LEFT COLUMN: Wallet & Node -->
+  <div>
+    <div class="card">
+      <!-- Wallet section -->
+      <div class="card-section">
+        <div class="section-label">Wallet</div>
+        <div class="wallet-row" style="margin-bottom:10px;">
+          <div class="wallet-avatar">0x</div>
+          <div class="wallet-info">
+            <div class="wallet-addr-row">
+              0x742d35Cc...b1c7
+              <span class="copy-icon" title="Copy address">⧉</span>
+            </div>
+            <div style="margin-top:4px; display:flex; align-items:center; gap:6px;">
+              <span class="pill">Sepolia</span>
+            </div>
+          </div>
+        </div>
+        <div><span class="disconnect">Disconnect</span></div>
+      </div>
+
+      <div class="card-divider"></div>
+
+      <!-- Node section -->
+      <div class="card-section">
+        <div class="section-label">Nitronode</div>
+        <div class="node-row">
+          <div class="dot-wrap">
+            <div class="dot"></div>
+            <div class="dot-ring"></div>
+          </div>
+          <span class="node-label" style="color: var(--success);">Connected</span>
+        </div>
+        <div class="node-meta">
+          <div>Last seen: <span style="color: var(--text-primary);">2s ago</span></div>
+          <div class="node-url" style="margin-top:4px;" title="wss://nitronode.yellow.org/ws">wss://nitronode.yellow.org/ws</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- CENTER COLUMN: Action Panel -->
+  <div>
+    <div class="card">
+      <div class="panel-header">Balances &amp; Actions</div>
+      <div class="card-body" style="padding-top:0;">
+
+        <select class="asset-select">
+          <option>USDC</option>
+          <option>ETH</option>
+          <option>WBTC</option>
+        </select>
+
+        <div class="balance-block">
+          <div>
+            <span class="balance-big">125.00</span>
+            <span class="balance-unit">USDC</span>
+          </div>
+          <div class="balance-sub">On-chain: 900.00 USDC</div>
+        </div>
+
+        <!-- Tabs -->
+        <div class="tabs">
+          <div class="tab active">Deposit</div>
+          <div class="tab">Withdraw</div>
+          <div class="tab">Transfer</div>
+        </div>
+
+        <!-- Deposit form -->
+        <div class="input-label">Amount</div>
+        <div class="input-wrap">
+          <input class="input focused" type="text" value="50.00" placeholder="0.00">
+          <span class="input-max">MAX</span>
+        </div>
+
+        <button class="btn-primary">Deposit via MetaMask</button>
+
+        <!-- Transfer preview -->
+        <div class="form-section">
+          <div class="form-section-label">Transfer Preview</div>
+
+          <div class="input-label">Recipient Address</div>
+          <div class="input-wrap">
+            <input class="input error" type="text" value="0xZZZ_invalid" placeholder="0x...">
+          </div>
+          <div class="input-error">⚠ Invalid address format</div>
+
+          <div class="input-label">Amount</div>
+          <div class="input-wrap">
+            <input class="input disabled" type="text" disabled placeholder="0.00">
+          </div>
+
+          <button class="btn-primary" disabled>Transfer</button>
+        </div>
+
+      </div>
+    </div>
+  </div>
+
+  <!-- RIGHT COLUMN: Channels -->
+  <div>
+    <div class="channels-header">
+      <span class="channels-title">State Channels</span>
+      <span class="count-badge">3</span>
+    </div>
+
+    <div class="channels-list">
+
+      <!-- Channel 1: EXPANDED -->
+      <div class="channel-card expanded">
+        <div class="channel-header">
+          <div class="asset-icon amber">USDC</div>
+          <div class="channel-meta">
+            <div class="channel-name">USDC</div>
+            <div class="channel-sub">Ethereum Mainnet</div>
+            <div class="channel-id">0xabc1...d4e5</div>
+          </div>
+          <div class="channel-right">
+            <span class="chevron open">▸</span>
+          </div>
+        </div>
+
+        <div class="channel-actions">
+          <button class="btn-sm neutral">Deposit</button>
+          <button class="btn-sm neutral">Withdraw</button>
+          <button class="btn-sm danger">Close</button>
+        </div>
+
+        <!-- State Viewer -->
+        <div class="state-viewer">
+          <div class="state-viewer-header">
+            <span>State</span>
+            <span>Version</span>
+            <span>Balance</span>
+            <span></span>
+          </div>
+
+          <!-- Enforced -->
+          <div class="state-row">
+            <div class="state-name-cell">
+              <div class="state-dot green"></div>
+              <span class="state-name-text">Enforced</span>
+              <div class="tooltip-wrap" data-tip="On-chain finalized state. Cannot be rolled back.">
+                <div class="tooltip-icon">?</div>
+              </div>
+            </div>
+            <div class="state-version">v12</div>
+            <div class="state-amount green">125.00 USDC</div>
+            <div class="state-action"><span style="color:var(--text-muted);font-size:12px;">—</span></div>
+          </div>
+
+          <!-- Signed -->
+          <div class="state-row">
+            <div class="state-name-cell">
+              <div class="state-dot blue"></div>
+              <span class="state-name-text">Signed</span>
+              <div class="tooltip-wrap" data-tip="Mutually signed off-chain state. Can be checkpointed on-chain.">
+                <div class="tooltip-icon">?</div>
+              </div>
+            </div>
+            <div class="state-version">v14</div>
+            <div class="state-amount blue">115.00 USDC</div>
+            <div class="state-action">
+              <button class="btn-sm blue">Checkpoint</button>
+            </div>
+          </div>
+
+          <!-- Issued -->
+          <div class="state-row">
+            <div class="state-name-cell">
+              <div class="state-dot amber"></div>
+              <span class="state-name-text">Issued</span>
+              <div class="tooltip-wrap" data-tip="Pending acknowledgment from counterparty. Not yet signed.">
+                <div class="tooltip-icon">?</div>
+              </div>
+            </div>
+            <div class="state-version">v15</div>
+            <div class="state-amount amber">105.00 USDC</div>
+            <div class="state-action">
+              <button class="btn-sm accent">Acknowledge</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Channel 2: COLLAPSED with warning -->
+      <div class="channel-card">
+        <div class="channel-header">
+          <div class="asset-icon gray">ETH</div>
+          <div class="channel-meta">
+            <div class="channel-name">ETH</div>
+            <div class="channel-sub">Sepolia Testnet</div>
+            <div class="channel-id">0xdef4...9fa2</div>
+          </div>
+          <div class="channel-right">
+            <span class="chevron">▸</span>
+          </div>
+        </div>
+        <div class="warning-strip">
+          ⚠ Wallet is on Ethereum — switch to Sepolia to interact
+        </div>
+      </div>
+
+      <!-- Channel 3: CLOSED -->
+      <div class="channel-card dimmed">
+        <div class="channel-header">
+          <div class="asset-icon gray">USDC</div>
+          <div class="channel-meta">
+            <div class="channel-name">USDC</div>
+            <div class="channel-sub">Sepolia Testnet</div>
+            <div class="channel-id">0x8fe3...c011</div>
+          </div>
+          <div class="channel-right">
+            <span class="closed-badge">Closed</span>
+          </div>
+        </div>
+      </div>
+
+    </div><!-- /channels-list -->
+  </div><!-- /right column -->
+
+</div><!-- /layout -->
+
+<!-- ─── MODAL PREVIEWS ─────────────────────────────────────── -->
+<div style="border-top: 1px solid var(--border); margin: 8px 24px 0;">
+  <div class="modal-previews" style="padding-top:24px;">
+    <div style="color:var(--text-muted); font-size:11px; font-weight:600; letter-spacing:0.08em; text-transform:uppercase; width:100%; margin-bottom:8px;">
+      Modal Previews
+    </div>
+
+    <!-- UnsupportedChainModal -->
+    <div style="flex:1; min-width:300px;">
+      <div style="font-size:10px; color:var(--text-muted); text-transform:uppercase; letter-spacing:0.08em; margin-bottom:8px;">UnsupportedChainModal</div>
+      <div class="overlay-demo">
+        <div class="overlay-bg">
+          <div class="overlay-bg-col"></div>
+          <div class="overlay-bg-col"></div>
+          <div class="overlay-bg-col"></div>
+        </div>
+        <div class="overlay-scrim">
+          <div class="modal-card">
+            <div class="modal-icon">⚠</div>
+            <div class="modal-title">Unsupported Network</div>
+            <div class="modal-body">
+              Your wallet is connected to Ethereum Mainnet. Please switch to a supported network to continue.
+            </div>
+            <button class="chain-btn">
+              <div class="chain-dot"></div>
+              Sepolia Testnet
+            </button>
+            <button class="chain-btn">
+              <div class="chain-dot" style="background: var(--blue);"></div>
+              Arbitrum Sepolia
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- SetHomechainModal -->
+    <div style="flex:1; min-width:300px;">
+      <div style="font-size:10px; color:var(--text-muted); text-transform:uppercase; letter-spacing:0.08em; margin-bottom:8px;">SetHomechainModal</div>
+      <div class="homechain-card">
+        <div class="homechain-header">
+          <span class="homechain-title">Set Home Chain</span>
+          <span class="asset-badge">USDC</span>
+        </div>
+
+        <div style="font-size:11px; color:var(--text-muted); margin-bottom:12px;">
+          Select the chain where your USDC channel will be enforced on-chain.
+        </div>
+
+        <div class="radio-card selected">
+          <div class="radio-ring selected">
+            <div class="radio-inner"></div>
+          </div>
+          <div>
+            <div class="radio-chain-name">Ethereum Mainnet</div>
+            <div class="radio-chain-sub">Chain ID: 1</div>
+          </div>
+        </div>
+
+        <div class="radio-card">
+          <div class="radio-ring">
+            <div class="radio-inner"></div>
+          </div>
+          <div>
+            <div class="radio-chain-name">Arbitrum One</div>
+            <div class="radio-chain-sub">Chain ID: 42161</div>
+          </div>
+        </div>
+
+        <div class="radio-card">
+          <div class="radio-ring">
+            <div class="radio-inner"></div>
+          </div>
+          <div>
+            <div class="radio-chain-name">Sepolia Testnet</div>
+            <div class="radio-chain-sub">Chain ID: 11155111</div>
+          </div>
+        </div>
+
+        <div class="modal-btn-row">
+          <button class="btn-ghost">Cancel</button>
+          <button class="btn-confirm">Confirm</button>
+        </div>
+      </div>
+    </div>
+
+  </div><!-- /modal-previews -->
+</div>
+
+</body>
+</html>

--- a/playground/mockups/history/a-filter-bar.html
+++ b/playground/mockups/history/a-filter-bar.html
@@ -1,0 +1,477 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>History — A: Inline Filter Bar</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      --bg-base:     #0a0a0a;
+      --bg-surface:  #141414;
+      --bg-elevated: #1c1c1c;
+      --border:      #242424;
+      --text-primary:#f0f0f0;
+      --text-muted:  #666666;
+      --accent:      #f5a623;
+      --accent-dim:  rgba(245,166,35,0.12);
+      --error:       #ef4444;
+      --success:     #22c55e;
+    }
+    *, *::before, *::after { box-sizing: border-box; }
+    html, body { height: 100%; margin: 0; }
+    body {
+      font-family: 'Inter', system-ui, sans-serif;
+      background: var(--bg-base);
+      color: var(--text-primary);
+      font-size: 14px;
+      line-height: 1.5;
+      -webkit-font-smoothing: antialiased;
+    }
+    .mono { font-family: 'JetBrains Mono', monospace; }
+
+    /* ── WalletBar ── */
+    nav {
+      position: sticky; top: 0; z-index: 10;
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 0 24px; height: 56px;
+      background: var(--bg-surface);
+      border-bottom: 1px solid var(--border);
+    }
+    .nav-brand { display: flex; align-items: center; gap: 12px; }
+    .brand-name { color: var(--accent); font-weight: 600; letter-spacing: -0.02em; font-size: 15px; }
+    .brand-sub  { color: var(--text-muted); font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; }
+
+    /* ── Chip ── */
+    .chip {
+      display: inline-flex; align-items: center; gap: 6px;
+      background: var(--bg-elevated); border: 1px solid var(--border);
+      border-radius: 8px; padding: 5px 10px;
+      font-size: 12px; color: var(--text-primary);
+    }
+    .chip-sk { border-color: rgba(245,166,35,0.4); color: var(--accent); }
+    .chip select { background: transparent; border: none; outline: none; color: inherit; font-family: inherit; font-size: inherit; cursor: pointer; }
+
+    /* ── Dot ── */
+    .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--success); display: inline-block; flex-shrink: 0; }
+
+    /* ── Buttons ── */
+    .btn {
+      display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+      padding: 8px 14px; border-radius: 8px; border: 1px solid var(--border);
+      background: var(--bg-elevated); color: var(--text-primary);
+      font-size: 13px; font-weight: 500; cursor: pointer;
+      font-family: inherit; transition: background 0.12s;
+    }
+    .btn:hover { background: #1f1f1f; }
+    .btn-ghost { background: transparent; color: var(--text-muted); }
+    .btn-ghost:hover { color: var(--text-primary); border-color: #333; }
+    .btn-sm { padding: 5px 10px; font-size: 12px; }
+
+    /* ── Tabs ── */
+    .tabs { display: flex; gap: 4px; }
+    .tab {
+      padding: 7px 16px; border-radius: 999px; border: none;
+      background: transparent; font-family: 'Inter', sans-serif;
+      font-size: 13px; font-weight: 500; color: var(--text-muted);
+      cursor: pointer; transition: background 0.12s, color 0.12s;
+    }
+    .tab:hover { background: var(--bg-elevated); color: var(--text-primary); }
+    .tab.active { color: var(--accent); background: var(--accent-dim); }
+
+    /* ── Card ── */
+    .card { background: var(--bg-surface); border: 1px solid var(--border); border-radius: 12px; }
+    .card-header {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 16px 20px; border-bottom: 1px solid var(--border);
+    }
+    .card-title { font-size: 15px; font-weight: 600; }
+
+    /* ── Filter bar ── */
+    .filter-bar {
+      display: flex; align-items: center; gap: 8px;
+      padding: 12px 20px;
+      border-bottom: 1px solid var(--border);
+      flex-wrap: wrap;
+    }
+    .filter-select {
+      appearance: none;
+      background: var(--bg-elevated); border: 1px solid var(--border);
+      border-radius: 8px; padding: 6px 28px 6px 10px;
+      font-size: 12px; font-family: 'Inter', sans-serif;
+      color: var(--text-primary); cursor: pointer;
+      outline: none;
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23666' stroke-width='2'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
+      background-repeat: no-repeat;
+      background-position: right 8px center;
+      transition: border-color 0.12s;
+    }
+    .filter-select:hover, .filter-select:focus { border-color: #333; }
+    .filter-select.active { border-color: var(--accent); color: var(--accent); }
+    .filter-input {
+      background: var(--bg-elevated); border: 1px solid var(--border);
+      border-radius: 8px; padding: 6px 10px;
+      font-size: 12px; font-family: 'JetBrains Mono', monospace;
+      color: var(--text-primary); outline: none; width: 148px;
+      transition: border-color 0.12s;
+    }
+    .filter-input::placeholder { color: var(--text-muted); }
+    .filter-input:focus { border-color: var(--accent); }
+    .filter-label { font-size: 11px; color: var(--text-muted); white-space: nowrap; }
+    .filter-group { display: flex; align-items: center; gap: 6px; }
+    .filter-divider { width: 1px; height: 20px; background: var(--border); margin: 0 4px; }
+    .clear-btn {
+      display: inline-flex; align-items: center; gap: 4px;
+      padding: 6px 10px; border-radius: 8px; border: none;
+      background: transparent; color: var(--text-muted);
+      font-size: 12px; cursor: pointer; font-family: inherit;
+      transition: color 0.12s;
+    }
+    .clear-btn:hover { color: var(--error); }
+
+    /* ── Table ── */
+    .table-wrap { overflow-x: auto; }
+    table { width: 100%; border-collapse: collapse; }
+    thead th {
+      padding: 10px 16px; text-align: left;
+      font-size: 11px; font-weight: 500; color: var(--text-muted);
+      text-transform: uppercase; letter-spacing: 0.06em;
+      border-bottom: 1px solid var(--border);
+      white-space: nowrap; background: var(--bg-surface);
+    }
+    tbody td {
+      padding: 11px 16px; font-size: 13px;
+      border-bottom: 1px solid var(--border);
+      white-space: nowrap; color: var(--text-primary);
+    }
+    tbody tr:last-child td { border-bottom: none; }
+    tbody tr:hover td { background: rgba(255,255,255,0.018); }
+
+    /* ── Badges ── */
+    .badge {
+      display: inline-flex; align-items: center;
+      padding: 3px 8px; border-radius: 6px;
+      font-size: 11px; font-weight: 500; white-space: nowrap;
+    }
+    .badge-deposit  { background: rgba(34,197,94,0.1);   color: #22c55e; }
+    .badge-withdraw { background: rgba(239,68,68,0.1);   color: #ef4444; }
+    .badge-transfer { background: rgba(59,130,246,0.1);  color: #3b82f6; }
+    .badge-finalize { background: rgba(168,85,247,0.1);  color: #a855f7; }
+
+    /* ── Amount ── */
+    .amt { font-family: 'JetBrains Mono', monospace; font-size: 13px; }
+    .amt-in  { color: var(--success); }
+    .amt-out { color: var(--error); }
+    .amt-neutral { color: var(--text-primary); }
+
+    /* ── Address ── */
+    .addr { font-family: 'JetBrains Mono', monospace; font-size: 12px; color: var(--text-muted); }
+    .addr-self { color: var(--text-primary); }
+
+    /* ── Hash link ── */
+    .hash-link {
+      font-family: 'JetBrains Mono', monospace; font-size: 12px;
+      color: var(--text-muted); text-decoration: none;
+      display: inline-flex; align-items: center; gap: 4px;
+    }
+    .hash-link:hover { color: var(--accent); }
+    .hash-link svg { opacity: 0.6; }
+
+    /* ── Asset cell ── */
+    .asset-cell { display: flex; align-items: center; gap: 8px; }
+    .asset-icon {
+      width: 24px; height: 24px; border-radius: 50%;
+      display: inline-flex; align-items: center; justify-content: center;
+      font-size: 9px; font-weight: 600; flex-shrink: 0;
+      background: var(--accent-dim); color: var(--accent);
+    }
+    .asset-icon.usdt { background: rgba(38,161,123,0.15); color: #26a17b; }
+    .asset-icon.eth  { background: rgba(98,126,234,0.15); color: #627eea; }
+
+    /* ── Chain pill ── */
+    .chain-pill {
+      font-size: 11px; color: var(--text-muted);
+      background: var(--bg-elevated); border: 1px solid var(--border);
+      border-radius: 6px; padding: 2px 7px; white-space: nowrap;
+    }
+
+    /* ── Pagination ── */
+    .pagination {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 12px 20px; border-top: 1px solid var(--border);
+    }
+    .page-info { font-size: 12px; color: var(--text-muted); }
+    .page-btns { display: flex; gap: 6px; }
+
+    /* ── Status dot ── */
+    .status-confirmed { color: var(--success); font-size: 11px; display: flex; align-items: center; gap: 4px; }
+    .status-confirmed::before { content: ''; width: 6px; height: 6px; border-radius: 50%; background: var(--success); flex-shrink: 0; }
+
+    /* ── Misc ── */
+    .text-muted  { color: var(--text-muted); }
+    .em-dash     { color: var(--text-muted); }
+  </style>
+</head>
+<body>
+
+<!-- ── WalletBar ── -->
+<nav>
+  <div class="nav-brand">
+    <span class="brand-name">Nitrolite</span>
+    <span class="brand-sub">Playground</span>
+  </div>
+  <div style="display:flex;align-items:center;gap:6px;">
+    <span class="dot"></span>
+    <span class="mono text-muted" style="font-size:12px;">3s ago</span>
+  </div>
+  <div style="display:flex;align-items:center;gap:8px;">
+    <span class="chip chip-sk">
+      <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="7" cy="17" r="3"/><path d="M10.5 13.5L21 3"/><path d="M15 9l1.5 1.5"/><path d="M18 6l1.5 1.5"/></svg>
+      SK · 23h
+      <span style="color:var(--text-muted);cursor:pointer;line-height:1;">
+        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
+      </span>
+    </span>
+    <span class="chip mono" style="font-size:11px;cursor:pointer;">
+      Ethereum Sepolia
+      <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg>
+    </span>
+    <span class="chip mono" style="font-size:12px;">
+      0x1234…Cafe
+      <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="color:var(--text-muted);"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+    </span>
+    <button class="btn btn-ghost btn-sm">Disconnect</button>
+  </div>
+</nav>
+
+<!-- ── Main ── -->
+<main style="margin:0 auto;width:100%;max-width:1100px;padding:32px 24px;">
+
+  <!-- Tab switcher -->
+  <div class="tabs" style="margin-bottom:20px;">
+    <button class="tab">Overview</button>
+    <button class="tab active">History</button>
+  </div>
+
+  <!-- History card -->
+  <div class="card">
+
+    <!-- Card header -->
+    <div class="card-header">
+      <span class="card-title">Transaction History</span>
+      <span class="text-muted" style="font-size:12px;">47 transactions</span>
+    </div>
+
+    <!-- ── Filter bar ── -->
+    <div class="filter-bar">
+      <div class="filter-group">
+        <span class="filter-label">Type</span>
+        <select class="filter-select active">
+          <option>All types</option>
+          <option selected>Deposit</option>
+          <option>Withdraw</option>
+          <option>Transfer</option>
+          <option>Finalize</option>
+        </select>
+      </div>
+
+      <div class="filter-divider"></div>
+
+      <div class="filter-group">
+        <span class="filter-label">Asset</span>
+        <select class="filter-select">
+          <option>All assets</option>
+          <option>ETH</option>
+          <option>USDT</option>
+          <option>USDC</option>
+        </select>
+      </div>
+
+      <div class="filter-divider"></div>
+
+      <div class="filter-group">
+        <span class="filter-label">Chain</span>
+        <select class="filter-select">
+          <option>All chains</option>
+          <option>Ethereum Sepolia</option>
+          <option>Base Sepolia</option>
+          <option>Linea Sepolia</option>
+          <option>Polygon Amoy</option>
+        </select>
+      </div>
+
+      <div class="filter-divider"></div>
+
+      <div class="filter-group">
+        <span class="filter-label">From</span>
+        <input class="filter-input" placeholder="0x…" type="text" />
+      </div>
+
+      <div class="filter-group">
+        <span class="filter-label">To</span>
+        <input class="filter-input" placeholder="0x…" type="text" />
+      </div>
+
+      <button class="clear-btn" style="margin-left:auto;">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
+        Clear filters
+      </button>
+    </div>
+
+    <!-- ── Table ── -->
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>Time</th>
+            <th>Type</th>
+            <th>Asset</th>
+            <th>Amount</th>
+            <th>From</th>
+            <th>To</th>
+            <th>Chain</th>
+            <th>Tx Hash</th>
+          </tr>
+        </thead>
+        <tbody>
+
+          <!-- Row 1: Deposit ETH -->
+          <tr>
+            <td>
+              <span style="font-size:12px;color:var(--text-muted);" title="2026-05-27 11:32 UTC">2h ago</span>
+            </td>
+            <td><span class="badge badge-deposit">Deposit</span></td>
+            <td>
+              <div class="asset-cell">
+                <span class="asset-icon eth">ETH</span>
+                <span style="font-weight:500;">ETH</span>
+              </div>
+            </td>
+            <td><span class="amt amt-in">+5.00</span></td>
+            <td><span class="addr addr-self">0x1234…Cafe</span></td>
+            <td><span class="addr">0x9B4F…N0DE</span></td>
+            <td><span class="chain-pill">Eth Sepolia</span></td>
+            <td>
+              <a href="#" class="hash-link">
+                0xabc1…3f4e
+                <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+              </a>
+            </td>
+          </tr>
+
+          <!-- Row 2: Transfer USDT -->
+          <tr>
+            <td>
+              <span style="font-size:12px;color:var(--text-muted);" title="2026-05-27 12:47 UTC">45m ago</span>
+            </td>
+            <td><span class="badge badge-transfer">Transfer</span></td>
+            <td>
+              <div class="asset-cell">
+                <span class="asset-icon usdt">USDT</span>
+                <span style="font-weight:500;">USDT</span>
+              </div>
+            </td>
+            <td><span class="amt amt-neutral">100.00</span></td>
+            <td><span class="addr addr-self">0x1234…Cafe</span></td>
+            <td><span class="addr">0x5678…Feed</span></td>
+            <td><span class="em-dash" style="font-size:13px;">—</span></td>
+            <td><span class="em-dash" style="font-size:12px;font-family:'JetBrains Mono',monospace;">—</span></td>
+          </tr>
+
+          <!-- Row 3: Withdraw ETH -->
+          <tr>
+            <td>
+              <span style="font-size:12px;color:var(--text-muted);" title="2026-05-27 12:32 UTC">1h ago</span>
+            </td>
+            <td><span class="badge badge-withdraw">Withdraw</span></td>
+            <td>
+              <div class="asset-cell">
+                <span class="asset-icon eth">ETH</span>
+                <span style="font-weight:500;">ETH</span>
+              </div>
+            </td>
+            <td><span class="amt amt-out">-2.50</span></td>
+            <td><span class="addr">0x9B4F…N0DE</span></td>
+            <td><span class="addr addr-self">0x1234…Cafe</span></td>
+            <td><span class="chain-pill">Eth Sepolia</span></td>
+            <td>
+              <a href="#" class="hash-link">
+                0xdef2…7a1b
+                <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+              </a>
+            </td>
+          </tr>
+
+          <!-- Row 4: Deposit USDT Base -->
+          <tr>
+            <td>
+              <span style="font-size:12px;color:var(--text-muted);" title="2026-05-27 10:32 UTC">3h ago</span>
+            </td>
+            <td><span class="badge badge-deposit">Deposit</span></td>
+            <td>
+              <div class="asset-cell">
+                <span class="asset-icon usdt">USDT</span>
+                <span style="font-weight:500;">USDT</span>
+              </div>
+            </td>
+            <td><span class="amt amt-in">+500.00</span></td>
+            <td><span class="addr addr-self">0x1234…Cafe</span></td>
+            <td><span class="addr">0x9B4F…N0DE</span></td>
+            <td><span class="chain-pill">Base Sepolia</span></td>
+            <td>
+              <a href="#" class="hash-link">
+                0x789c…2d5f
+                <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+              </a>
+            </td>
+          </tr>
+
+          <!-- Row 5: Finalize ETH -->
+          <tr>
+            <td>
+              <span style="font-size:12px;color:var(--text-muted);" title="2026-05-27 12:37 UTC">55m ago</span>
+            </td>
+            <td><span class="badge badge-finalize">Finalize</span></td>
+            <td>
+              <div class="asset-cell">
+                <span class="asset-icon eth">ETH</span>
+                <span style="font-weight:500;">ETH</span>
+              </div>
+            </td>
+            <td><span class="amt amt-neutral">7.50</span></td>
+            <td><span class="addr addr-self">0x1234…Cafe</span></td>
+            <td><span class="addr addr-self">0x1234…Cafe</span></td>
+            <td><span class="chain-pill">Eth Sepolia</span></td>
+            <td>
+              <a href="#" class="hash-link">
+                0x012d…8e9a
+                <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+              </a>
+            </td>
+          </tr>
+
+        </tbody>
+      </table>
+    </div>
+
+    <!-- ── Pagination ── -->
+    <div class="pagination">
+      <span class="page-info">Showing 1–5 of 47 transactions</span>
+      <div class="page-btns">
+        <button class="btn btn-ghost btn-sm" disabled style="opacity:0.4;cursor:not-allowed;">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M15 18l-6-6 6-6"/></svg>
+          Prev
+        </button>
+        <button class="btn btn-sm">
+          Next
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 18l6-6-6-6"/></svg>
+        </button>
+      </div>
+    </div>
+
+  </div><!-- /card -->
+</main>
+
+</body>
+</html>

--- a/playground/mockups/history/b-sidebar-drawer.html
+++ b/playground/mockups/history/b-sidebar-drawer.html
@@ -1,0 +1,541 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>History — B: Sidebar Drawer Filters</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      --bg-base:     #0a0a0a;
+      --bg-surface:  #141414;
+      --bg-elevated: #1c1c1c;
+      --border:      #242424;
+      --text-primary:#f0f0f0;
+      --text-muted:  #666666;
+      --accent:      #f5a623;
+      --accent-dim:  rgba(245,166,35,0.12);
+      --error:       #ef4444;
+      --success:     #22c55e;
+    }
+    *, *::before, *::after { box-sizing: border-box; }
+    html, body { height: 100%; margin: 0; }
+    body {
+      font-family: 'Inter', system-ui, sans-serif;
+      background: var(--bg-base);
+      color: var(--text-primary);
+      font-size: 14px;
+      line-height: 1.5;
+      -webkit-font-smoothing: antialiased;
+    }
+    .mono { font-family: 'JetBrains Mono', monospace; }
+
+    /* ── WalletBar ── */
+    nav {
+      position: sticky; top: 0; z-index: 10;
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 0 24px; height: 56px;
+      background: var(--bg-surface);
+      border-bottom: 1px solid var(--border);
+    }
+    .nav-brand { display: flex; align-items: center; gap: 12px; }
+    .brand-name { color: var(--accent); font-weight: 600; letter-spacing: -0.02em; font-size: 15px; }
+    .brand-sub  { color: var(--text-muted); font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; }
+
+    /* ── Chip ── */
+    .chip {
+      display: inline-flex; align-items: center; gap: 6px;
+      background: var(--bg-elevated); border: 1px solid var(--border);
+      border-radius: 8px; padding: 5px 10px;
+      font-size: 12px; color: var(--text-primary);
+    }
+    .chip-sk { border-color: rgba(245,166,35,0.4); color: var(--accent); }
+
+    /* ── Dot ── */
+    .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--success); display: inline-block; flex-shrink: 0; }
+
+    /* ── Buttons ── */
+    .btn {
+      display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+      padding: 8px 14px; border-radius: 8px; border: 1px solid var(--border);
+      background: var(--bg-elevated); color: var(--text-primary);
+      font-size: 13px; font-weight: 500; cursor: pointer;
+      font-family: inherit; transition: background 0.12s;
+    }
+    .btn:hover { background: #1f1f1f; }
+    .btn-ghost { background: transparent; color: var(--text-muted); }
+    .btn-ghost:hover { color: var(--text-primary); border-color: #333; }
+    .btn-sm { padding: 5px 10px; font-size: 12px; }
+    .btn-primary {
+      background: var(--accent); color: #0a0a0a;
+      border-color: var(--accent); font-weight: 600;
+    }
+    .btn-primary:hover { background: #e09520; border-color: #e09520; }
+
+    /* ── Tabs ── */
+    .tabs { display: flex; gap: 4px; }
+    .tab {
+      padding: 7px 16px; border-radius: 999px; border: none;
+      background: transparent; font-family: 'Inter', sans-serif;
+      font-size: 13px; font-weight: 500; color: var(--text-muted);
+      cursor: pointer; transition: background 0.12s, color 0.12s;
+    }
+    .tab:hover { background: var(--bg-elevated); color: var(--text-primary); }
+    .tab.active { color: var(--accent); background: var(--accent-dim); }
+
+    /* ── Card ── */
+    .card { background: var(--bg-surface); border: 1px solid var(--border); border-radius: 12px; overflow: hidden; }
+    .card-header {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 16px 20px; border-bottom: 1px solid var(--border);
+    }
+    .card-title { font-size: 15px; font-weight: 600; }
+
+    /* ── Filter button with badge ── */
+    .filter-toggle {
+      display: inline-flex; align-items: center; gap: 6px;
+      padding: 6px 12px; border-radius: 8px; border: 1px solid var(--border);
+      background: var(--bg-elevated); color: var(--text-muted);
+      font-size: 12px; font-weight: 500; cursor: pointer;
+      font-family: inherit; transition: all 0.12s;
+    }
+    .filter-toggle.has-filters {
+      border-color: var(--accent); color: var(--accent);
+      background: var(--accent-dim);
+    }
+    .filter-toggle:hover { border-color: #333; color: var(--text-primary); }
+    .filter-badge {
+      display: inline-flex; align-items: center; justify-content: center;
+      width: 16px; height: 16px; border-radius: 50%;
+      background: var(--accent); color: #0a0a0a;
+      font-size: 10px; font-weight: 700; line-height: 1;
+    }
+
+    /* ── Split layout: table + drawer ── */
+    .history-layout {
+      display: flex;
+      min-height: 0;
+    }
+    .history-table-area {
+      flex: 1;
+      min-width: 0;
+      border-right: 1px solid var(--border);
+    }
+    .history-drawer {
+      width: 252px;
+      flex-shrink: 0;
+      background: var(--bg-base);
+      display: flex;
+      flex-direction: column;
+    }
+    .drawer-header {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 14px 16px 12px;
+      border-bottom: 1px solid var(--border);
+    }
+    .drawer-title { font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-muted); }
+    .drawer-body { flex: 1; padding: 16px; display: flex; flex-direction: column; gap: 16px; overflow-y: auto; }
+    .drawer-footer { padding: 12px 16px; border-top: 1px solid var(--border); display: flex; flex-direction: column; gap: 8px; }
+
+    /* ── Filter controls in drawer ── */
+    .filter-field { display: flex; flex-direction: column; gap: 6px; }
+    .filter-field-label { font-size: 11px; font-weight: 500; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.06em; }
+    .filter-select {
+      appearance: none;
+      background: var(--bg-elevated); border: 1px solid var(--border);
+      border-radius: 8px; padding: 7px 28px 7px 10px;
+      font-size: 12px; font-family: 'Inter', sans-serif;
+      color: var(--text-primary); cursor: pointer; outline: none; width: 100%;
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23666' stroke-width='2'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
+      background-repeat: no-repeat; background-position: right 8px center;
+      transition: border-color 0.12s;
+    }
+    .filter-select:hover, .filter-select:focus { border-color: #333; }
+    .filter-select.active { border-color: rgba(245,166,35,0.5); }
+    .filter-input {
+      background: var(--bg-elevated); border: 1px solid var(--border);
+      border-radius: 8px; padding: 7px 10px;
+      font-size: 12px; font-family: 'JetBrains Mono', monospace;
+      color: var(--text-primary); outline: none; width: 100%;
+      transition: border-color 0.12s;
+    }
+    .filter-input::placeholder { color: var(--text-muted); }
+    .filter-input:focus { border-color: var(--accent); }
+    .filter-input.active { border-color: rgba(245,166,35,0.5); }
+
+    /* ── Checkboxes in drawer ── */
+    .check-list { display: flex; flex-direction: column; gap: 6px; }
+    .check-item { display: flex; align-items: center; gap: 8px; cursor: pointer; }
+    .check-item input[type=checkbox] {
+      appearance: none; width: 14px; height: 14px; border: 1px solid var(--border);
+      border-radius: 4px; background: var(--bg-elevated); cursor: pointer;
+      position: relative; flex-shrink: 0;
+    }
+    .check-item input[type=checkbox]:checked {
+      background: var(--accent); border-color: var(--accent);
+    }
+    .check-item input[type=checkbox]:checked::after {
+      content: ''; position: absolute; top: 2px; left: 4px;
+      width: 4px; height: 7px; border: 2px solid #0a0a0a;
+      border-top: none; border-left: none; transform: rotate(45deg);
+    }
+    .check-label { font-size: 12px; color: var(--text-primary); }
+
+    /* ── Table ── */
+    .table-wrap { overflow-x: auto; }
+    table { width: 100%; border-collapse: collapse; }
+    thead th {
+      padding: 10px 16px; text-align: left;
+      font-size: 11px; font-weight: 500; color: var(--text-muted);
+      text-transform: uppercase; letter-spacing: 0.06em;
+      border-bottom: 1px solid var(--border);
+      white-space: nowrap; background: var(--bg-surface);
+    }
+    tbody td {
+      padding: 11px 16px; font-size: 13px;
+      border-bottom: 1px solid var(--border);
+      white-space: nowrap; color: var(--text-primary);
+    }
+    tbody tr:last-child td { border-bottom: none; }
+    tbody tr:hover td { background: rgba(255,255,255,0.018); }
+
+    /* ── Badges ── */
+    .badge {
+      display: inline-flex; align-items: center;
+      padding: 3px 8px; border-radius: 6px;
+      font-size: 11px; font-weight: 500; white-space: nowrap;
+    }
+    .badge-deposit  { background: rgba(34,197,94,0.1);   color: #22c55e; }
+    .badge-withdraw { background: rgba(239,68,68,0.1);   color: #ef4444; }
+    .badge-transfer { background: rgba(59,130,246,0.1);  color: #3b82f6; }
+    .badge-finalize { background: rgba(168,85,247,0.1);  color: #a855f7; }
+
+    /* ── Amount ── */
+    .amt { font-family: 'JetBrains Mono', monospace; font-size: 13px; }
+    .amt-in  { color: var(--success); }
+    .amt-out { color: var(--error); }
+
+    /* ── Address ── */
+    .addr { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--text-muted); }
+    .addr-self { color: var(--text-primary); }
+
+    /* ── Hash link ── */
+    .hash-link {
+      font-family: 'JetBrains Mono', monospace; font-size: 11px;
+      color: var(--text-muted); text-decoration: none;
+      display: inline-flex; align-items: center; gap: 4px;
+    }
+    .hash-link:hover { color: var(--accent); }
+
+    /* ── Asset cell ── */
+    .asset-cell { display: flex; align-items: center; gap: 7px; }
+    .asset-icon {
+      width: 22px; height: 22px; border-radius: 50%;
+      display: inline-flex; align-items: center; justify-content: center;
+      font-size: 8px; font-weight: 600; flex-shrink: 0;
+    }
+    .asset-icon.eth  { background: rgba(98,126,234,0.15); color: #627eea; }
+    .asset-icon.usdt { background: rgba(38,161,123,0.15); color: #26a17b; }
+
+    /* ── Chain pill ── */
+    .chain-pill {
+      font-size: 11px; color: var(--text-muted);
+      background: var(--bg-elevated); border: 1px solid var(--border);
+      border-radius: 6px; padding: 2px 6px; white-space: nowrap;
+    }
+
+    /* ── Pagination ── */
+    .pagination {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 12px 20px; border-top: 1px solid var(--border);
+    }
+    .page-info { font-size: 12px; color: var(--text-muted); }
+    .page-btns { display: flex; gap: 6px; }
+
+    /* ── Active filter tags ── */
+    .active-filters { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 4px; }
+    .filter-tag {
+      display: inline-flex; align-items: center; gap: 5px;
+      padding: 3px 8px; border-radius: 6px; font-size: 11px;
+      background: var(--accent-dim); color: var(--accent);
+      border: 1px solid rgba(245,166,35,0.25);
+    }
+    .filter-tag-x { cursor: pointer; opacity: 0.6; line-height: 1; }
+    .filter-tag-x:hover { opacity: 1; }
+
+    .text-muted { color: var(--text-muted); }
+    .em-dash { color: var(--text-muted); font-family: 'JetBrains Mono', monospace; font-size: 12px; }
+  </style>
+</head>
+<body>
+
+<!-- ── WalletBar ── -->
+<nav>
+  <div class="nav-brand">
+    <span class="brand-name">Nitrolite</span>
+    <span class="brand-sub">Playground</span>
+  </div>
+  <div style="display:flex;align-items:center;gap:6px;">
+    <span class="dot"></span>
+    <span class="mono text-muted" style="font-size:12px;">3s ago</span>
+  </div>
+  <div style="display:flex;align-items:center;gap:8px;">
+    <span class="chip chip-sk">
+      <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="7" cy="17" r="3"/><path d="M10.5 13.5L21 3"/><path d="M15 9l1.5 1.5"/><path d="M18 6l1.5 1.5"/></svg>
+      SK · 23h
+      <span style="color:var(--text-muted);cursor:pointer;line-height:1;">
+        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
+      </span>
+    </span>
+    <span class="chip mono" style="font-size:11px;cursor:pointer;">
+      Ethereum Sepolia
+      <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg>
+    </span>
+    <span class="chip mono" style="font-size:12px;">
+      0x1234…Cafe
+      <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="color:var(--text-muted);"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+    </span>
+    <button class="btn btn-ghost btn-sm">Disconnect</button>
+  </div>
+</nav>
+
+<!-- ── Main ── -->
+<main style="margin:0 auto;width:100%;max-width:1100px;padding:32px 24px;">
+
+  <!-- Tab switcher -->
+  <div class="tabs" style="margin-bottom:20px;">
+    <button class="tab">Overview</button>
+    <button class="tab active">History</button>
+  </div>
+
+  <!-- History card -->
+  <div class="card">
+
+    <!-- Card header -->
+    <div class="card-header">
+      <div style="display:flex;align-items:center;gap:12px;">
+        <span class="card-title">Transaction History</span>
+        <!-- Active filter tags -->
+        <div class="active-filters">
+          <span class="filter-tag">
+            Type: Deposit
+            <span class="filter-tag-x">
+              <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M18 6L6 18M6 6l12 12"/></svg>
+            </span>
+          </span>
+          <span class="filter-tag">
+            Chain: Eth Sepolia
+            <span class="filter-tag-x">
+              <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M18 6L6 18M6 6l12 12"/></svg>
+            </span>
+          </span>
+        </div>
+      </div>
+      <button class="filter-toggle has-filters">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
+        Filters
+        <span class="filter-badge">2</span>
+      </button>
+    </div>
+
+    <!-- ── Split: table + drawer ── -->
+    <div class="history-layout">
+
+      <!-- Table area -->
+      <div class="history-table-area">
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Time</th>
+                <th>Type</th>
+                <th>Asset</th>
+                <th>Amount</th>
+                <th>From</th>
+                <th>To</th>
+                <th>Chain</th>
+                <th>Tx Hash</th>
+              </tr>
+            </thead>
+            <tbody>
+
+              <!-- Row 1 -->
+              <tr>
+                <td><span style="font-size:12px;color:var(--text-muted);">2h ago</span></td>
+                <td><span class="badge badge-deposit">Deposit</span></td>
+                <td><div class="asset-cell"><span class="asset-icon eth">ETH</span><span style="font-weight:500;">ETH</span></div></td>
+                <td><span class="amt amt-in">+5.00</span></td>
+                <td><span class="addr addr-self">0x1234…Cafe</span></td>
+                <td><span class="addr">0x9B4F…N0DE</span></td>
+                <td><span class="chain-pill">Eth Sepolia</span></td>
+                <td>
+                  <a href="#" class="hash-link">0xabc1…3f4e
+                    <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+                  </a>
+                </td>
+              </tr>
+
+              <!-- Row 2 -->
+              <tr>
+                <td><span style="font-size:12px;color:var(--text-muted);">45m ago</span></td>
+                <td><span class="badge badge-transfer">Transfer</span></td>
+                <td><div class="asset-cell"><span class="asset-icon usdt">USDT</span><span style="font-weight:500;">USDT</span></div></td>
+                <td><span class="amt" style="color:var(--text-primary);">100.00</span></td>
+                <td><span class="addr addr-self">0x1234…Cafe</span></td>
+                <td><span class="addr">0x5678…Feed</span></td>
+                <td><span class="em-dash">—</span></td>
+                <td><span class="em-dash">—</span></td>
+              </tr>
+
+              <!-- Row 3 -->
+              <tr>
+                <td><span style="font-size:12px;color:var(--text-muted);">1h ago</span></td>
+                <td><span class="badge badge-withdraw">Withdraw</span></td>
+                <td><div class="asset-cell"><span class="asset-icon eth">ETH</span><span style="font-weight:500;">ETH</span></div></td>
+                <td><span class="amt amt-out">-2.50</span></td>
+                <td><span class="addr">0x9B4F…N0DE</span></td>
+                <td><span class="addr addr-self">0x1234…Cafe</span></td>
+                <td><span class="chain-pill">Eth Sepolia</span></td>
+                <td>
+                  <a href="#" class="hash-link">0xdef2…7a1b
+                    <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+                  </a>
+                </td>
+              </tr>
+
+              <!-- Row 4 -->
+              <tr>
+                <td><span style="font-size:12px;color:var(--text-muted);">3h ago</span></td>
+                <td><span class="badge badge-deposit">Deposit</span></td>
+                <td><div class="asset-cell"><span class="asset-icon usdt">USDT</span><span style="font-weight:500;">USDT</span></div></td>
+                <td><span class="amt amt-in">+500.00</span></td>
+                <td><span class="addr addr-self">0x1234…Cafe</span></td>
+                <td><span class="addr">0x9B4F…N0DE</span></td>
+                <td><span class="chain-pill">Base Sepolia</span></td>
+                <td>
+                  <a href="#" class="hash-link">0x789c…2d5f
+                    <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+                  </a>
+                </td>
+              </tr>
+
+              <!-- Row 5 -->
+              <tr>
+                <td><span style="font-size:12px;color:var(--text-muted);">55m ago</span></td>
+                <td><span class="badge badge-finalize">Finalize</span></td>
+                <td><div class="asset-cell"><span class="asset-icon eth">ETH</span><span style="font-weight:500;">ETH</span></div></td>
+                <td><span class="amt" style="color:var(--text-primary);">7.50</span></td>
+                <td><span class="addr addr-self">0x1234…Cafe</span></td>
+                <td><span class="addr addr-self">0x1234…Cafe</span></td>
+                <td><span class="chain-pill">Eth Sepolia</span></td>
+                <td>
+                  <a href="#" class="hash-link">0x012d…8e9a
+                    <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+                  </a>
+                </td>
+              </tr>
+
+            </tbody>
+          </table>
+        </div>
+
+        <!-- Pagination -->
+        <div class="pagination">
+          <span class="page-info">Showing 1–5 of 47 transactions</span>
+          <div class="page-btns">
+            <button class="btn btn-ghost btn-sm" style="opacity:0.4;cursor:not-allowed;">
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M15 18l-6-6 6-6"/></svg>
+              Prev
+            </button>
+            <button class="btn btn-sm">
+              Next
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 18l6-6-6-6"/></svg>
+            </button>
+          </div>
+        </div>
+      </div><!-- /table area -->
+
+      <!-- ── Filter drawer ── -->
+      <div class="history-drawer">
+        <div class="drawer-header">
+          <span class="drawer-title">Filters</span>
+          <button style="background:none;border:none;cursor:pointer;color:var(--text-muted);padding:2px;line-height:1;" title="Close filters">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
+          </button>
+        </div>
+
+        <div class="drawer-body">
+
+          <!-- Type checkboxes -->
+          <div class="filter-field">
+            <span class="filter-field-label">Type</span>
+            <div class="check-list">
+              <label class="check-item">
+                <input type="checkbox" checked />
+                <span class="check-label"><span class="badge badge-deposit" style="font-size:10px;padding:2px 6px;">Deposit</span></span>
+              </label>
+              <label class="check-item">
+                <input type="checkbox" />
+                <span class="check-label"><span class="badge badge-withdraw" style="font-size:10px;padding:2px 6px;">Withdraw</span></span>
+              </label>
+              <label class="check-item">
+                <input type="checkbox" />
+                <span class="check-label"><span class="badge badge-transfer" style="font-size:10px;padding:2px 6px;">Transfer</span></span>
+              </label>
+              <label class="check-item">
+                <input type="checkbox" />
+                <span class="check-label"><span class="badge badge-finalize" style="font-size:10px;padding:2px 6px;">Finalize</span></span>
+              </label>
+            </div>
+          </div>
+
+          <!-- Asset -->
+          <div class="filter-field">
+            <span class="filter-field-label">Asset</span>
+            <select class="filter-select">
+              <option>All assets</option>
+              <option>ETH</option>
+              <option>USDT</option>
+              <option>USDC</option>
+            </select>
+          </div>
+
+          <!-- Chain -->
+          <div class="filter-field">
+            <span class="filter-field-label">Chain</span>
+            <select class="filter-select active">
+              <option>Ethereum Sepolia</option>
+              <option>Base Sepolia</option>
+              <option>Linea Sepolia</option>
+              <option>Polygon Amoy</option>
+            </select>
+          </div>
+
+          <!-- From -->
+          <div class="filter-field">
+            <span class="filter-field-label">From address</span>
+            <input class="filter-input" type="text" placeholder="0x…" />
+          </div>
+
+          <!-- To -->
+          <div class="filter-field">
+            <span class="filter-field-label">To address</span>
+            <input class="filter-input" type="text" placeholder="0x…" />
+          </div>
+
+        </div><!-- /drawer-body -->
+
+        <div class="drawer-footer">
+          <button class="btn btn-primary btn-sm" style="width:100%;justify-content:center;">Apply filters</button>
+          <button class="btn btn-ghost btn-sm" style="width:100%;justify-content:center;">Clear all</button>
+        </div>
+      </div><!-- /drawer -->
+
+    </div><!-- /history-layout -->
+
+  </div><!-- /card -->
+</main>
+
+</body>
+</html>

--- a/playground/mockups/history/c-expandable-rows.html
+++ b/playground/mockups/history/c-expandable-rows.html
@@ -1,0 +1,832 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>History — C: Expandable Rows + Column Filters</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      --bg-base:     #0a0a0a;
+      --bg-surface:  #141414;
+      --bg-elevated: #1c1c1c;
+      --border:      #242424;
+      --text-primary:#f0f0f0;
+      --text-muted:  #666666;
+      --accent:      #f5a623;
+      --accent-dim:  rgba(245,166,35,0.12);
+      --error:       #ef4444;
+      --success:     #22c55e;
+    }
+    *, *::before, *::after { box-sizing: border-box; }
+    html, body { height: 100%; margin: 0; }
+    body {
+      font-family: 'Inter', system-ui, sans-serif;
+      background: var(--bg-base);
+      color: var(--text-primary);
+      font-size: 14px;
+      line-height: 1.5;
+      -webkit-font-smoothing: antialiased;
+    }
+    .mono { font-family: 'JetBrains Mono', monospace; }
+
+    /* ── WalletBar ── */
+    nav {
+      position: sticky; top: 0; z-index: 10;
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 0 24px; height: 56px;
+      background: var(--bg-surface);
+      border-bottom: 1px solid var(--border);
+    }
+    .nav-brand { display: flex; align-items: center; gap: 12px; }
+    .brand-name { color: var(--accent); font-weight: 600; letter-spacing: -0.02em; font-size: 15px; }
+    .brand-sub  { color: var(--text-muted); font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; }
+
+    /* ── Chip ── */
+    .chip {
+      display: inline-flex; align-items: center; gap: 6px;
+      background: var(--bg-elevated); border: 1px solid var(--border);
+      border-radius: 8px; padding: 5px 10px;
+      font-size: 12px; color: var(--text-primary);
+    }
+    .chip-sk { border-color: rgba(245,166,35,0.4); color: var(--accent); }
+
+    /* ── Dot ── */
+    .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--success); display: inline-block; flex-shrink: 0; }
+
+    /* ── Buttons ── */
+    .btn {
+      display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+      padding: 8px 14px; border-radius: 8px; border: 1px solid var(--border);
+      background: var(--bg-elevated); color: var(--text-primary);
+      font-size: 13px; font-weight: 500; cursor: pointer;
+      font-family: inherit; transition: background 0.12s;
+    }
+    .btn:hover { background: #1f1f1f; }
+    .btn-ghost { background: transparent; color: var(--text-muted); }
+    .btn-ghost:hover { color: var(--text-primary); border-color: #333; }
+    .btn-sm { padding: 5px 10px; font-size: 12px; }
+
+    /* ── Tabs ── */
+    .tabs { display: flex; gap: 4px; }
+    .tab {
+      padding: 7px 16px; border-radius: 999px; border: none;
+      background: transparent; font-family: 'Inter', sans-serif;
+      font-size: 13px; font-weight: 500; color: var(--text-muted);
+      cursor: pointer; transition: background 0.12s, color 0.12s;
+    }
+    .tab:hover { background: var(--bg-elevated); color: var(--text-primary); }
+    .tab.active { color: var(--accent); background: var(--accent-dim); }
+
+    /* ── Card ── */
+    .card { background: var(--bg-surface); border: 1px solid var(--border); border-radius: 12px; overflow: hidden; }
+    .card-header {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 16px 20px; border-bottom: 1px solid var(--border);
+    }
+    .card-title { font-size: 15px; font-weight: 600; }
+
+    /* ── Table ── */
+    .table-wrap { overflow-x: auto; position: relative; }
+    table { width: 100%; border-collapse: collapse; }
+
+    /* Column headers */
+    thead th {
+      padding: 0;
+      border-bottom: 1px solid var(--border);
+      background: var(--bg-surface);
+      white-space: nowrap;
+    }
+    .th-inner {
+      display: flex; align-items: center; gap: 5px;
+      padding: 10px 16px;
+      font-size: 11px; font-weight: 500; color: var(--text-muted);
+      text-transform: uppercase; letter-spacing: 0.06em;
+      cursor: default; user-select: none;
+    }
+    .th-inner.filterable { cursor: pointer; }
+    .th-inner.filterable:hover .th-filter-icon { opacity: 1; color: var(--text-primary); }
+    .th-inner.filter-active .th-filter-icon { opacity: 1; color: var(--accent); }
+    .th-inner.filter-active { color: var(--accent); }
+    .th-filter-icon { opacity: 0.3; transition: opacity 0.12s, color 0.12s; flex-shrink: 0; }
+
+    /* Column header filter popover */
+    .th-popover-wrap { position: relative; }
+    .th-popover {
+      position: absolute; top: calc(100% + 2px); left: 0; z-index: 200;
+      background: var(--bg-elevated); border: 1px solid var(--border);
+      border-radius: 10px; padding: 10px;
+      min-width: 170px; box-shadow: 0 8px 24px rgba(0,0,0,0.5);
+    }
+    .th-popover-title { font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-muted); margin-bottom: 8px; }
+    .th-popover-opts { display: flex; flex-direction: column; gap: 4px; }
+    .th-opt {
+      display: flex; align-items: center; gap: 8px; padding: 5px 6px;
+      border-radius: 6px; cursor: pointer; font-size: 12px;
+      transition: background 0.1s;
+    }
+    .th-opt:hover { background: rgba(255,255,255,0.04); }
+    .th-opt.selected { background: var(--accent-dim); }
+    .th-opt-check {
+      width: 14px; height: 14px; border-radius: 4px; border: 1px solid var(--border);
+      background: var(--bg-surface); flex-shrink: 0;
+      display: flex; align-items: center; justify-content: center;
+    }
+    .th-opt.selected .th-opt-check { background: var(--accent); border-color: var(--accent); }
+    .th-opt-check-inner { display: none; }
+    .th-opt.selected .th-opt-check-inner {
+      display: block; width: 4px; height: 7px; border: 2px solid #0a0a0a;
+      border-top: none; border-left: none; transform: rotate(45deg) translateY(-1px);
+    }
+    .th-popover-actions { display: flex; gap: 6px; margin-top: 10px; padding-top: 8px; border-top: 1px solid var(--border); }
+    .th-popover-actions button {
+      flex: 1; padding: 5px 8px; border-radius: 6px; border: 1px solid var(--border);
+      background: none; font-family: inherit; font-size: 11px; cursor: pointer; color: var(--text-muted);
+    }
+    .th-popover-actions .apply { background: var(--accent); color: #0a0a0a; border-color: var(--accent); font-weight: 600; }
+
+    /* Text input inside address filter popover */
+    .th-text-input {
+      background: var(--bg-base); border: 1px solid var(--border);
+      border-radius: 6px; padding: 5px 8px;
+      font-size: 11px; font-family: 'JetBrains Mono', monospace;
+      color: var(--text-primary); outline: none;
+    }
+    .th-text-input::placeholder { color: var(--text-muted); }
+    .th-text-input:focus { border-color: var(--accent); }
+
+    /* ── Quick-filter wrapper for cell values ── */
+    .qf {
+      position: relative;
+      display: inline-flex; align-items: center;
+      cursor: pointer;
+      border-radius: 5px;
+      padding: 2px 4px; margin: -2px -4px;
+      transition: background 0.1s;
+    }
+    .qf:hover { background: rgba(255,255,255,0.05); }
+    /* Active = this value is currently filtered */
+    .qf.qf-on { background: var(--accent-dim); }
+    .qf.qf-on:hover { background: rgba(245,166,35,0.2); }
+
+    /* CSS tooltip via ::after */
+    .qf::after {
+      content: attr(data-tip);
+      position: absolute;
+      bottom: calc(100% + 6px);
+      left: 50%; transform: translateX(-50%);
+      background: var(--bg-elevated); border: 1px solid var(--border);
+      border-radius: 6px; padding: 4px 9px;
+      font-size: 11px; font-family: 'Inter', sans-serif; font-weight: 400;
+      color: var(--text-primary); white-space: nowrap;
+      pointer-events: none;
+      opacity: 0; transition: opacity 0.12s;
+      z-index: 300;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.4);
+    }
+    .qf:hover::after { opacity: 1; }
+
+    /* ── Body rows ── */
+    tbody tr.data-row { cursor: pointer; }
+    tbody tr.data-row td {
+      padding: 11px 16px; font-size: 13px;
+      border-bottom: 1px solid var(--border);
+      white-space: nowrap; color: var(--text-primary);
+      transition: background 0.1s;
+    }
+    tbody tr.data-row:hover td { background: rgba(255,255,255,0.018); }
+    tbody tr.data-row.expanded td { background: rgba(255,255,255,0.02); border-bottom: none; }
+    tbody tr.data-row.confirming td { background: rgba(245,166,35,0.03); }
+
+    /* Expand arrow */
+    .expand-cell { width: 40px; }
+    .expand-arrow {
+      display: inline-flex; align-items: center; justify-content: center;
+      width: 20px; height: 20px; color: var(--text-muted);
+      transition: transform 0.15s, color 0.12s;
+    }
+    .expand-arrow.open { transform: rotate(180deg); color: var(--accent); }
+
+    /* ── Expanded detail panel ── */
+    tr.detail-row td { padding: 0; border-bottom: 1px solid var(--border); }
+    .detail-panel {
+      padding: 16px 20px 20px;
+      background: rgba(10,10,10,0.5);
+      display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 16px 28px;
+    }
+    .detail-section { display: flex; flex-direction: column; gap: 5px; }
+    .detail-label {
+      font-size: 10px; font-weight: 600; text-transform: uppercase;
+      letter-spacing: 0.07em; color: var(--text-muted);
+    }
+    .detail-value {
+      font-family: 'JetBrains Mono', monospace; font-size: 11px;
+      color: var(--text-primary); display: flex; align-items: flex-start; gap: 6px;
+      word-break: break-all; white-space: normal;
+    }
+    .detail-value.plain { font-family: 'Inter', sans-serif; font-size: 12px; white-space: nowrap; }
+    .copy-btn-sm {
+      background: none; border: none; cursor: pointer; padding: 1px;
+      color: var(--text-muted); display: inline-flex; line-height: 1; flex-shrink: 0;
+      margin-top: 1px;
+      transition: color 0.12s;
+    }
+    .copy-btn-sm:hover { color: var(--accent); }
+
+    /* Confirmation timeline */
+    .timeline { display: flex; align-items: center; flex-wrap: wrap; gap: 4px; }
+    .tl-step { display: flex; align-items: center; gap: 5px; }
+    .tl-dot {
+      width: 17px; height: 17px; border-radius: 50%; border: 2px solid var(--border);
+      display: flex; align-items: center; justify-content: center; flex-shrink: 0;
+    }
+    .tl-dot.done { background: var(--success); border-color: var(--success); }
+    .tl-dot.done::after { content: '✓'; color: #0a0a0a; font-weight: 700; font-size: 9px; }
+    .tl-label { font-size: 11px; color: var(--text-muted); white-space: nowrap; }
+    .tl-label.done { color: var(--success); }
+    .tl-line { width: 18px; height: 2px; background: var(--border); flex-shrink: 0; }
+    .tl-line.done { background: var(--success); }
+
+    /* ── Badges ── */
+    .badge {
+      display: inline-flex; align-items: center;
+      padding: 3px 8px; border-radius: 6px;
+      font-size: 11px; font-weight: 500; white-space: nowrap;
+    }
+    .badge-deposit  { background: rgba(34,197,94,0.1);   color: #22c55e; }
+    .badge-withdraw { background: rgba(239,68,68,0.1);   color: #ef4444; }
+    .badge-transfer { background: rgba(59,130,246,0.1);  color: #3b82f6; }
+    .badge-finalize { background: rgba(168,85,247,0.1);  color: #a855f7; }
+    .badge-confirming {
+      display: inline-flex; align-items: center; gap: 5px;
+      padding: 3px 8px; border-radius: 6px; font-size: 11px; font-weight: 500;
+      background: var(--accent-dim); color: var(--accent); white-space: nowrap;
+    }
+
+    /* ── Spinner ── */
+    .spinner {
+      display: inline-block; width: 10px; height: 10px;
+      border: 1.5px solid currentColor; border-right-color: transparent;
+      border-radius: 50%; animation: spin 0.6s linear infinite; flex-shrink: 0;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+
+    /* ── Amount ── */
+    .amt { font-family: 'JetBrains Mono', monospace; font-size: 13px; }
+    .amt-in  { color: var(--success); }
+    .amt-out { color: var(--error); }
+
+    /* ── Address cell ── */
+    .addr-cell { display: inline-flex; align-items: center; gap: 5px; }
+    .addr { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--text-muted); }
+    .addr-self { color: var(--text-primary); }
+    .copy-btn-addr {
+      background: none; border: none; cursor: pointer; padding: 1px;
+      color: var(--text-muted); display: inline-flex; line-height: 1; flex-shrink: 0;
+      transition: color 0.12s; opacity: 0;
+    }
+    /* Show copy button when hovering the addr-cell wrapper */
+    .addr-cell:hover .copy-btn-addr { opacity: 1; }
+    .copy-btn-addr:hover { color: var(--accent); opacity: 1 !important; }
+
+    /* ── Hash link ── */
+    .hash-link {
+      font-family: 'JetBrains Mono', monospace; font-size: 11px;
+      color: var(--text-muted); text-decoration: none;
+      display: inline-flex; align-items: center; gap: 4px;
+    }
+    .hash-link:hover { color: var(--accent); }
+
+    /* ── Asset cell ── */
+    .asset-cell { display: flex; align-items: center; gap: 7px; }
+    .asset-icon {
+      width: 22px; height: 22px; border-radius: 50%;
+      display: inline-flex; align-items: center; justify-content: center;
+      font-size: 8px; font-weight: 600; flex-shrink: 0;
+    }
+    .asset-icon.eth  { background: rgba(98,126,234,0.15); color: #627eea; }
+    .asset-icon.usdt { background: rgba(38,161,123,0.15); color: #26a17b; }
+
+    /* ── Chain pill ── */
+    .chain-pill {
+      font-size: 11px; color: var(--text-muted);
+      background: var(--bg-elevated); border: 1px solid var(--border);
+      border-radius: 6px; padding: 2px 6px; white-space: nowrap;
+    }
+
+    /* ── Pagination ── */
+    .pagination {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 12px 20px; border-top: 1px solid var(--border);
+    }
+    .page-info { font-size: 12px; color: var(--text-muted); }
+    .page-btns { display: flex; gap: 6px; }
+
+    .text-muted { color: var(--text-muted); }
+    .em-dash { color: var(--text-muted); font-family: 'JetBrains Mono', monospace; font-size: 12px; }
+
+    /* SVG helpers */
+    .icon-copy { display: inline-block; }
+    .icon-ext  { display: inline-block; }
+  </style>
+</head>
+<body>
+
+<!-- ── WalletBar ── -->
+<nav>
+  <div class="nav-brand">
+    <span class="brand-name">Nitrolite</span>
+    <span class="brand-sub">Playground</span>
+  </div>
+  <div style="display:flex;align-items:center;gap:6px;">
+    <span class="dot"></span>
+    <span class="mono text-muted" style="font-size:12px;">3s ago</span>
+  </div>
+  <div style="display:flex;align-items:center;gap:8px;">
+    <span class="chip chip-sk">
+      <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="7" cy="17" r="3"/><path d="M10.5 13.5L21 3"/><path d="M15 9l1.5 1.5"/><path d="M18 6l1.5 1.5"/></svg>
+      SK · 23h
+      <span style="color:var(--text-muted);cursor:pointer;line-height:1;">
+        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
+      </span>
+    </span>
+    <span class="chip mono" style="font-size:11px;cursor:pointer;">
+      Ethereum Sepolia
+      <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg>
+    </span>
+    <span class="chip mono" style="font-size:12px;">
+      0x1234…Cafe
+      <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="color:var(--text-muted);"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+    </span>
+    <button class="btn btn-ghost btn-sm">Disconnect</button>
+  </div>
+</nav>
+
+<!-- ── Main ── -->
+<main style="margin:0 auto;width:100%;max-width:1100px;padding:32px 24px;">
+
+  <div class="tabs" style="margin-bottom:20px;">
+    <button class="tab">Overview</button>
+    <button class="tab active">History</button>
+  </div>
+
+  <div class="card">
+
+    <div class="card-header">
+      <span class="card-title">Transaction History</span>
+      <span class="text-muted" style="font-size:12px;">47 transactions · 1 active filter</span>
+    </div>
+
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th style="width:40px;"><div class="th-inner"></div></th>
+
+            <!-- Time -->
+            <th><div class="th-inner">Time</div></th>
+
+            <!-- Type — filterable, popover open -->
+            <th>
+              <div class="th-popover-wrap">
+                <div class="th-inner filterable filter-active">
+                  Type
+                  <svg class="th-filter-icon" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
+                </div>
+                <div class="th-popover">
+                  <div class="th-popover-title">Filter by type</div>
+                  <div class="th-popover-opts">
+                    <div class="th-opt selected">
+                      <div class="th-opt-check"><div class="th-opt-check-inner"></div></div>
+                      <span class="badge badge-deposit" style="font-size:10px;padding:2px 6px;">Deposit</span>
+                    </div>
+                    <div class="th-opt">
+                      <div class="th-opt-check"></div>
+                      <span class="badge badge-withdraw" style="font-size:10px;padding:2px 6px;">Withdraw</span>
+                    </div>
+                    <div class="th-opt">
+                      <div class="th-opt-check"></div>
+                      <span class="badge badge-transfer" style="font-size:10px;padding:2px 6px;">Transfer</span>
+                    </div>
+                    <div class="th-opt">
+                      <div class="th-opt-check"></div>
+                      <span class="badge badge-finalize" style="font-size:10px;padding:2px 6px;">Finalize</span>
+                    </div>
+                  </div>
+                  <div class="th-popover-actions">
+                    <button>Clear</button>
+                    <button class="apply">Apply</button>
+                  </div>
+                </div>
+              </div>
+            </th>
+
+            <!-- Asset — filterable -->
+            <th>
+              <div class="th-inner filterable">
+                Asset
+                <svg class="th-filter-icon" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
+              </div>
+            </th>
+
+            <!-- Amount -->
+            <th><div class="th-inner">Amount</div></th>
+
+            <!-- From — filterable, popover with text input (shown open as demo) -->
+            <th>
+              <div class="th-popover-wrap">
+                <div class="th-inner filterable">
+                  From
+                  <svg class="th-filter-icon" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
+                </div>
+                <div class="th-popover" style="min-width:200px;">
+                  <div class="th-popover-title">Filter by from address</div>
+                  <input class="th-text-input" type="text" placeholder="0x…" style="width:100%;margin-bottom:8px;" />
+                  <div class="th-popover-actions">
+                    <button>Clear</button>
+                    <button class="apply">Apply</button>
+                  </div>
+                </div>
+              </div>
+            </th>
+
+            <!-- To — filterable, popover with text input (collapsed) -->
+            <th>
+              <div class="th-popover-wrap">
+                <div class="th-inner filterable">
+                  To
+                  <svg class="th-filter-icon" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
+                </div>
+              </div>
+            </th>
+
+            <!-- Chain — filterable -->
+            <th>
+              <div class="th-inner filterable">
+                Chain
+                <svg class="th-filter-icon" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
+              </div>
+            </th>
+
+            <th><div class="th-inner">Tx Hash</div></th>
+          </tr>
+        </thead>
+        <tbody>
+
+          <!-- ═══════════════════════════════════════════════════
+               Row 1 — just now — Deposit USDT — CONFIRMING
+               ═══════════════════════════════════════════════════ -->
+          <tr class="data-row confirming">
+            <td class="expand-cell">
+              <span class="expand-arrow">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg>
+              </span>
+            </td>
+            <td><span style="font-size:12px;color:var(--text-muted);">just now</span></td>
+            <td>
+              <!-- Deposit = filter is ON → qf-on + "Remove filter" tip -->
+              <span class="qf qf-on" data-tip="Remove filter: Deposit" onclick="event.stopPropagation()">
+                <span class="badge badge-deposit">Deposit</span>
+              </span>
+            </td>
+            <td>
+              <span class="qf" data-tip="Quick filter: USDT" onclick="event.stopPropagation()">
+                <div class="asset-cell">
+                  <span class="asset-icon usdt">USDT</span>
+                  <span style="font-weight:500;">USDT</span>
+                </div>
+              </span>
+            </td>
+            <td><span class="amt amt-in">+500.00</span></td>
+            <td>
+              <div class="addr-cell">
+                <span class="qf" data-tip="Quick filter: 0x1234…Cafe" onclick="event.stopPropagation()">
+                  <span class="addr addr-self">0x1234…Cafe</span>
+                </span>
+                <button class="copy-btn-addr" title="Copy address" onclick="event.stopPropagation()">
+                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+                </button>
+              </div>
+            </td>
+            <td>
+              <div class="addr-cell">
+                <span class="qf" data-tip="Quick filter: 0x9B4F…N0DE" onclick="event.stopPropagation()">
+                  <span class="addr">0x9B4F…N0DE</span>
+                </span>
+                <button class="copy-btn-addr" title="Copy address" onclick="event.stopPropagation()">
+                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+                </button>
+              </div>
+            </td>
+            <td>
+              <span class="qf" data-tip="Quick filter: Base Sepolia" onclick="event.stopPropagation()">
+                <span class="chain-pill">Base Sepolia</span>
+              </span>
+            </td>
+            <td>
+              <div style="display:flex;align-items:center;gap:6px;">
+                <a href="#" class="hash-link" onclick="event.stopPropagation()">
+                  0x789c…2d5f
+                  <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+                </a>
+                <span class="badge-confirming"><span class="spinner"></span>Confirming</span>
+              </div>
+            </td>
+          </tr>
+
+          <!-- ═══════════════════════════════════════════════════
+               Row 2 — 45m ago — Transfer USDT — EXPANDED
+               ═══════════════════════════════════════════════════ -->
+          <tr class="data-row expanded">
+            <td class="expand-cell">
+              <span class="expand-arrow open">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg>
+              </span>
+            </td>
+            <td><span style="font-size:12px;color:var(--text-muted);">45m ago</span></td>
+            <td>
+              <span class="qf" data-tip="Quick filter: Transfer" onclick="event.stopPropagation()">
+                <span class="badge badge-transfer">Transfer</span>
+              </span>
+            </td>
+            <td>
+              <span class="qf" data-tip="Quick filter: USDT" onclick="event.stopPropagation()">
+                <div class="asset-cell">
+                  <span class="asset-icon usdt">USDT</span>
+                  <span style="font-weight:500;">USDT</span>
+                </div>
+              </span>
+            </td>
+            <td><span class="amt" style="color:var(--text-primary);">100.00</span></td>
+            <td>
+              <div class="addr-cell">
+                <span class="qf" data-tip="Quick filter: 0x1234…Cafe" onclick="event.stopPropagation()">
+                  <span class="addr addr-self">0x1234…Cafe</span>
+                </span>
+                <button class="copy-btn-addr" title="Copy address" onclick="event.stopPropagation()">
+                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+                </button>
+              </div>
+            </td>
+            <td>
+              <div class="addr-cell">
+                <span class="qf" data-tip="Quick filter: 0x5678…Feed" onclick="event.stopPropagation()">
+                  <span class="addr">0x5678…Feed</span>
+                </span>
+                <button class="copy-btn-addr" title="Copy address" onclick="event.stopPropagation()">
+                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+                </button>
+              </div>
+            </td>
+            <td><span class="em-dash">—</span></td>
+            <td><span class="em-dash">—</span></td>
+          </tr>
+          <!-- ── Detail panel ── -->
+          <tr class="detail-row">
+            <td colspan="9">
+              <div class="detail-panel">
+
+                <!-- Sender new state ID -->
+                <div class="detail-section">
+                  <span class="detail-label">Sender new state ID</span>
+                  <span class="detail-value">
+                    state_c8f2a4d7e1b39f2a
+                    <button class="copy-btn-sm" title="Copy" onclick="event.stopPropagation()">
+                      <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+                    </button>
+                  </span>
+                </div>
+
+                <!-- Receiver new state ID -->
+                <div class="detail-section">
+                  <span class="detail-label">Receiver new state ID</span>
+                  <span class="detail-value">
+                    state_a1b2c3d4e5f62a8d
+                    <button class="copy-btn-sm" title="Copy" onclick="event.stopPropagation()">
+                      <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+                    </button>
+                  </span>
+                </div>
+
+                <!-- Timestamp -->
+                <div class="detail-section">
+                  <span class="detail-label">Timestamp</span>
+                  <span class="detail-value plain">2026-05-27 12:47:03 UTC</span>
+                </div>
+
+                <!-- Confirmation timeline — spans all 3 cols -->
+                <div class="detail-section" style="grid-column: 1 / -1;">
+                  <span class="detail-label">Confirmation</span>
+                  <div class="timeline" style="margin-top:5px;">
+                    <div class="tl-step">
+                      <div class="tl-dot done"></div>
+                      <span class="tl-label done">Signed</span>
+                    </div>
+                    <div class="tl-line done"></div>
+                    <div class="tl-step">
+                      <div class="tl-dot done"></div>
+                      <span class="tl-label done">Co-signed</span>
+                    </div>
+                  </div>
+                </div>
+
+              </div>
+            </td>
+          </tr>
+
+          <!-- ═══════════════════════════════════════════════════
+               Row 3 — 55m ago — Finalize ETH
+               ═══════════════════════════════════════════════════ -->
+          <tr class="data-row">
+            <td class="expand-cell">
+              <span class="expand-arrow">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg>
+              </span>
+            </td>
+            <td><span style="font-size:12px;color:var(--text-muted);">55m ago</span></td>
+            <td>
+              <span class="qf" data-tip="Quick filter: Finalize" onclick="event.stopPropagation()">
+                <span class="badge badge-finalize">Finalize</span>
+              </span>
+            </td>
+            <td>
+              <span class="qf" data-tip="Quick filter: ETH" onclick="event.stopPropagation()">
+                <div class="asset-cell">
+                  <span class="asset-icon eth">ETH</span>
+                  <span style="font-weight:500;">ETH</span>
+                </div>
+              </span>
+            </td>
+            <td><span class="amt" style="color:var(--text-primary);">7.50</span></td>
+            <td>
+              <div class="addr-cell">
+                <span class="qf" data-tip="Quick filter: 0x1234…Cafe" onclick="event.stopPropagation()">
+                  <span class="addr addr-self">0x1234…Cafe</span>
+                </span>
+                <button class="copy-btn-addr" title="Copy address" onclick="event.stopPropagation()">
+                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+                </button>
+              </div>
+            </td>
+            <td>
+              <div class="addr-cell">
+                <span class="qf" data-tip="Quick filter: 0x1234…Cafe" onclick="event.stopPropagation()">
+                  <span class="addr addr-self">0x1234…Cafe</span>
+                </span>
+                <button class="copy-btn-addr" title="Copy address" onclick="event.stopPropagation()">
+                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+                </button>
+              </div>
+            </td>
+            <td>
+              <span class="qf" data-tip="Quick filter: Eth Sepolia" onclick="event.stopPropagation()">
+                <span class="chain-pill">Eth Sepolia</span>
+              </span>
+            </td>
+            <td>
+              <a href="#" class="hash-link" onclick="event.stopPropagation()">
+                0x012d…8e9a
+                <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+              </a>
+            </td>
+          </tr>
+
+          <!-- ═══════════════════════════════════════════════════
+               Row 4 — 1h ago — Withdraw ETH
+               ═══════════════════════════════════════════════════ -->
+          <tr class="data-row">
+            <td class="expand-cell">
+              <span class="expand-arrow">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg>
+              </span>
+            </td>
+            <td><span style="font-size:12px;color:var(--text-muted);">1h ago</span></td>
+            <td>
+              <span class="qf" data-tip="Quick filter: Withdraw" onclick="event.stopPropagation()">
+                <span class="badge badge-withdraw">Withdraw</span>
+              </span>
+            </td>
+            <td>
+              <span class="qf" data-tip="Quick filter: ETH" onclick="event.stopPropagation()">
+                <div class="asset-cell">
+                  <span class="asset-icon eth">ETH</span>
+                  <span style="font-weight:500;">ETH</span>
+                </div>
+              </span>
+            </td>
+            <td><span class="amt amt-out">-2.50</span></td>
+            <td>
+              <div class="addr-cell">
+                <span class="qf" data-tip="Quick filter: 0x9B4F…N0DE" onclick="event.stopPropagation()">
+                  <span class="addr">0x9B4F…N0DE</span>
+                </span>
+                <button class="copy-btn-addr" title="Copy address" onclick="event.stopPropagation()">
+                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+                </button>
+              </div>
+            </td>
+            <td>
+              <div class="addr-cell">
+                <span class="qf" data-tip="Quick filter: 0x1234…Cafe" onclick="event.stopPropagation()">
+                  <span class="addr addr-self">0x1234…Cafe</span>
+                </span>
+                <button class="copy-btn-addr" title="Copy address" onclick="event.stopPropagation()">
+                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+                </button>
+              </div>
+            </td>
+            <td>
+              <span class="qf" data-tip="Quick filter: Eth Sepolia" onclick="event.stopPropagation()">
+                <span class="chain-pill">Eth Sepolia</span>
+              </span>
+            </td>
+            <td>
+              <a href="#" class="hash-link" onclick="event.stopPropagation()">
+                0xdef2…7a1b
+                <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+              </a>
+            </td>
+          </tr>
+
+          <!-- ═══════════════════════════════════════════════════
+               Row 5 — 2h ago — Deposit ETH
+               ═══════════════════════════════════════════════════ -->
+          <tr class="data-row">
+            <td class="expand-cell">
+              <span class="expand-arrow">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg>
+              </span>
+            </td>
+            <td><span style="font-size:12px;color:var(--text-muted);">2h ago</span></td>
+            <td>
+              <!-- Deposit = filter ON → qf-on -->
+              <span class="qf qf-on" data-tip="Remove filter: Deposit" onclick="event.stopPropagation()">
+                <span class="badge badge-deposit">Deposit</span>
+              </span>
+            </td>
+            <td>
+              <span class="qf" data-tip="Quick filter: ETH" onclick="event.stopPropagation()">
+                <div class="asset-cell">
+                  <span class="asset-icon eth">ETH</span>
+                  <span style="font-weight:500;">ETH</span>
+                </div>
+              </span>
+            </td>
+            <td><span class="amt amt-in">+5.00</span></td>
+            <td>
+              <div class="addr-cell">
+                <span class="qf" data-tip="Quick filter: 0x1234…Cafe" onclick="event.stopPropagation()">
+                  <span class="addr addr-self">0x1234…Cafe</span>
+                </span>
+                <button class="copy-btn-addr" title="Copy address" onclick="event.stopPropagation()">
+                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+                </button>
+              </div>
+            </td>
+            <td>
+              <div class="addr-cell">
+                <span class="qf" data-tip="Quick filter: 0x9B4F…N0DE" onclick="event.stopPropagation()">
+                  <span class="addr">0x9B4F…N0DE</span>
+                </span>
+                <button class="copy-btn-addr" title="Copy address" onclick="event.stopPropagation()">
+                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+                </button>
+              </div>
+            </td>
+            <td>
+              <span class="qf" data-tip="Quick filter: Eth Sepolia" onclick="event.stopPropagation()">
+                <span class="chain-pill">Eth Sepolia</span>
+              </span>
+            </td>
+            <td>
+              <a href="#" class="hash-link" onclick="event.stopPropagation()">
+                0xabc1…3f4e
+                <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+              </a>
+            </td>
+          </tr>
+
+        </tbody>
+      </table>
+    </div>
+
+    <div class="pagination">
+      <span class="page-info">Showing 1–25 of 47 transactions</span>
+      <div class="page-btns">
+        <button class="btn btn-ghost btn-sm" style="opacity:0.4;cursor:not-allowed;">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M15 18l-6-6 6-6"/></svg>
+          Prev
+        </button>
+        <button class="btn btn-sm">
+          Next
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 18l6-6-6-6"/></svg>
+        </button>
+      </div>
+    </div>
+
+  </div>
+</main>
+
+</body>
+</html>

--- a/playground/mockups/history/history-tab.md
+++ b/playground/mockups/history/history-tab.md
@@ -1,0 +1,215 @@
+# History Tab — Design & Data
+
+Mockup file: `c-expandable-rows.html`
+
+---
+
+## Layout
+
+The History tab is a **full-width view** that replaces the two-column (ActionPanel + ChannelList) layout. A tab bar is added at the top of the main content area to switch between **Overview** and **History**. The same WalletBar and outer container are shared with the rest of the app.
+
+---
+
+## Table
+
+### Columns
+
+| Column | Content |
+|--------|---------|
+| *(expand)* | Chevron to expand row detail |
+| Time | Relative timestamp (e.g. "2h ago"); absolute UTC on hover |
+| Type | Colored badge — see types below |
+| Asset | Token icon + symbol |
+| Amount | Mono font; `+` green for deposits, `−` red for withdrawals, neutral for transfers/finalize |
+| From | Shortened address; copy icon on hover; clickable for quick filter |
+| To | Same as From |
+| Chain | Compact chain-name pill; clickable for quick filter; `—` for off-chain txs |
+| Tx Hash | Shortened hash with block-explorer link (↗); `—` for off-chain txs |
+
+### Transaction type badges
+
+| Badge | Color |
+|-------|-------|
+| Deposit | Green |
+| Withdraw | Red |
+| Transfer | Blue |
+| Finalize | Purple |
+| Commit / Release / Rebalance | Muted gray |
+
+### Sort order
+
+Newest first (`createdAt` descending). 25 rows per page. Pagination footer shows "Showing 1–25 of N transactions" with Prev / Next buttons.
+
+### Confirming row (session enrichment)
+
+Rows deposited or withdrawn in the current session may carry a local **Confirming** badge (accent spinner) while `waitForTransactionReceipt` is pending. This state is ephemeral and lost on reload — see Session Enrichment section below.
+
+---
+
+## Filtering
+
+Two complementary mechanisms, both updating the same filter state.
+
+### Column header popovers
+
+Clicking the funnel icon (▾) on a filterable column opens a popover anchored below that header:
+
+| Column | Popover content |
+|--------|----------------|
+| Type | Checkbox list with colored badges (multi-select) |
+| Asset | Checkbox list of available asset symbols |
+| Chain | Checkbox list of available chain names |
+| From | Free-text address input |
+| To | Free-text address input |
+
+Each popover has **Clear** and **Apply** buttons. The column label + icon turn accent-colored when a filter is active on that column.
+
+### Quick filter (per-cell click)
+
+Clicking directly on a cell value — a Type badge, Asset name, shortened address, or Chain pill — immediately applies an exact-value filter for that field. If that filter value is already active, the same click removes it.
+
+Visual feedback:
+- Cursor pointer on hover over any filterable cell value
+- Subtle highlight background on hover
+- Accent-dim background when the filter is active (`.qf-on`)
+- Tooltip on hover: **"Quick filter: X"** or **"Remove filter: X"**
+
+Copy buttons on From / To addresses stop click propagation so they never trigger quick filter.
+
+---
+
+## Expanded Row Detail
+
+Clicking anywhere on a row (except interactive elements) expands it in-place. A detail panel renders below the row with a 3-column grid:
+
+| Section | Content |
+|---------|---------|
+| Sender new state ID | Full state UUID — copy button |
+| Receiver new state ID | Full state UUID — copy button |
+| Timestamp | Absolute UTC timestamp |
+| Confirmation *(spans all 3 cols)* | Step timeline — see below |
+
+### Confirmation timelines
+
+**Off-chain (Transfer):**
+`Signed ──● Co-signed`
+
+**On-chain (Deposit / Withdraw / Finalize):**
+`Signed ──● Broadcasted ──● Confirmed`
+
+Completed steps shown in green; pending steps in border color.
+
+---
+
+## Data Fetching
+
+### Primary source — `client.getTransactions()`
+
+**Location:** `sdk/ts/src/client.ts`
+
+```typescript
+async getTransactions(
+  wallet: Address,
+  options?: {
+    asset?:    string;
+    txType?:   TransactionType;
+    fromTime?: bigint;   // Unix timestamp, seconds
+    toTime?:   bigint;
+    page?:     number;
+    pageSize?: number;
+  }
+): Promise<{
+  transactions: Transaction[];
+  metadata:     PaginationMetadata;
+}>
+```
+
+Underlying RPC method: `user.v1.get_transactions`
+
+### `Transaction` type
+
+```typescript
+interface Transaction {
+  id:                  string;
+  asset:               string;
+  txType:              TransactionType;
+  fromAccount:         Address;
+  toAccount:           Address;
+  senderNewStateId?:   string;
+  receiverNewStateId?: string;
+  amount:              Decimal;
+  createdAt:           Date;
+}
+```
+
+### `TransactionType` enum
+
+```typescript
+enum TransactionType {
+  HomeDeposit    = 10,
+  HomeWithdrawal = 11,
+  EscrowDeposit  = 20,
+  EscrowWithdraw = 21,
+  Transfer       = 30,
+  Commit         = 40,
+  Release        = 41,
+  Rebalance      = 42,
+  Migrate        = 100,
+  EscrowLock     = 110,
+  MutualLock     = 120,
+  Finalize       = 200,
+}
+```
+
+`Migrate`, `EscrowLock`, and `MutualLock` are not exposed through the API's `tx_type` filter.
+
+### `PaginationMetadata` type
+
+```typescript
+interface PaginationMetadata {
+  page:       number;  // 1-indexed
+  perPage:    number;
+  totalCount: number;
+  pageCount:  number;
+}
+```
+
+### Which filters are server-side vs. client-side
+
+| UI filter | Handling | SDK option |
+|-----------|----------|-----------|
+| Type | **Server-side** | `txType` — single value per call; multi-select needs client-side post-filter |
+| Asset | **Server-side** | `asset` |
+| Date range | **Server-side** | `fromTime` / `toTime` |
+| From address | **Client-side** | No API param; filter on `tx.fromAccount` after fetch |
+| To address | **Client-side** | No API param; filter on `tx.toAccount` after fetch |
+| Chain | **Client-side** | No API param; chain inferred from channel records |
+
+For From / To / Chain filtering, either increase `pageSize` to fetch a larger window and filter locally, or fetch all pages (feasible for typical wallet history sizes).
+
+### Session enrichment
+
+The server does not store blockchain tx hashes — those are returned by `client.checkpoint()` and confirmed via `waitForTransactionReceipt`. During the current session, `useChannelOps` can maintain an enrichment map:
+
+```typescript
+// Key: senderNewStateId  Value: { txHash, status }
+type EnrichmentMap = Map<string, { txHash: string; status: 'confirming' | 'confirmed' | 'failed' }>;
+
+// After client.checkpoint(asset) resolves:
+enrichment.set(senderNewStateId, { txHash, status: 'confirming' });
+
+// After waitForTransactionReceipt resolves:
+enrichment.set(senderNewStateId, { txHash, status: 'confirmed' });
+```
+
+When rendering the history table, look up each row's `senderNewStateId` in the map to overlay tx hash and confirmation status. This enrichment is lost on page reload, but the tx hash itself can be used to re-query on-chain status if needed.
+
+### Suggested hook shape
+
+```
+useHistory(client, address, enrichmentMap)
+  state:   { transactions, metadata, filters, page, isLoading }
+  fetch:   client.getTransactions(address, { asset, txType, fromTime, toTime, page, pageSize: 25 })
+  refetch: on address change · filter change · page change · onAfterOp callback
+  render:  merge enrichmentMap by senderNewStateId before passing rows to the table
+```

--- a/playground/mockups/session-keys/mockup-1-key-list.html
+++ b/playground/mockups/session-keys/mockup-1-key-list.html
@@ -1,0 +1,632 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Session Keys — Key List</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --bg-base:      #0a0a0a;
+    --bg-surface:   #141414;
+    --bg-elevated:  #1c1c1c;
+    --border:       #242424;
+    --text-primary: #f0f0f0;
+    --text-muted:   #666666;
+    --accent:       #f5a623;
+    --accent-dim:   rgba(245, 166, 35, 0.12);
+    --error:        #ef4444;
+    --success:      #22c55e;
+    --warning:      #f97316;
+    --warning-dim:  rgba(249, 115, 22, 0.12);
+    --info:         #3b82f6;
+    --info-dim:     rgba(59, 130, 246, 0.12);
+  }
+
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+  body {
+    font-family: 'Inter', system-ui, sans-serif;
+    background: var(--bg-base);
+    color: var(--text-primary);
+    font-size: 14px;
+    line-height: 1.5;
+    min-height: 100vh;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .mono { font-family: 'JetBrains Mono', monospace; }
+
+  /* ── Nav ── */
+  .nav {
+    background: var(--bg-surface);
+    border-bottom: 1px solid var(--border);
+    padding: 0 24px;
+    height: 56px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+  }
+
+  .nav-left { display: flex; align-items: center; gap: 10px; }
+
+  .nav-logo {
+    font-size: 17px;
+    font-weight: 600;
+    color: var(--accent);
+    letter-spacing: -0.3px;
+  }
+
+  .status-dot {
+    width: 7px; height: 7px;
+    border-radius: 50%;
+    background: var(--success);
+    box-shadow: 0 0 5px var(--success);
+    flex-shrink: 0;
+  }
+
+  .nav-center {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    align-items: center;
+    gap: 2px;
+  }
+
+  .nav-right { display: flex; align-items: center; gap: 8px; }
+
+  /* ── Tabs ── */
+  .tab {
+    padding: 7px 16px;
+    border-radius: 999px;
+    border: none;
+    background: transparent;
+    font-family: 'Inter', sans-serif;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--text-muted);
+    cursor: pointer;
+  }
+  .tab.active { color: var(--accent); background: var(--accent-dim); }
+  .tab:hover:not(.active) { background: var(--bg-elevated); color: var(--text-primary); }
+
+  /* ── Chips ── */
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 5px 10px;
+    font-size: 12px;
+    color: var(--text-primary);
+    white-space: nowrap;
+  }
+
+  .chip-sk {
+    border-color: rgba(245,166,35,0.4);
+    background: var(--accent-dim);
+    color: var(--accent);
+    cursor: pointer;
+    font-family: 'JetBrains Mono', monospace;
+  }
+
+  .chip-clear {
+    color: var(--text-muted);
+    font-size: 11px;
+    cursor: pointer;
+    margin-left: 2px;
+  }
+  .chip-clear:hover { color: var(--text-primary); }
+
+  /* ── Buttons ── */
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    padding: 8px 14px;
+    border-radius: 8px;
+    border: 1px solid var(--border);
+    background: var(--bg-elevated);
+    color: var(--text-primary);
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    font-family: 'Inter', sans-serif;
+    transition: background 0.12s;
+  }
+  .btn:hover { background: #1f1f1f; }
+  .btn-primary {
+    background: var(--accent);
+    color: #0a0a0a;
+    border-color: var(--accent);
+    font-weight: 600;
+  }
+  .btn-primary:hover { background: #e09520; border-color: #e09520; }
+  .btn-ghost {
+    background: transparent;
+    border-color: var(--border);
+    color: var(--text-muted);
+  }
+  .btn-ghost:hover { color: var(--text-primary); }
+  .btn-danger {
+    background: transparent;
+    border: none;
+    color: var(--error);
+    padding: 5px 8px;
+  }
+  .btn-danger:hover { background: rgba(239,68,68,0.08); }
+  .btn-sm { padding: 5px 10px; font-size: 12px; }
+  .btn:disabled { opacity: 0.35; cursor: not-allowed; }
+
+  /* ── Card ── */
+  .card {
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+  }
+  .card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px 20px;
+    border-bottom: 1px solid var(--border);
+  }
+  .card-title {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+
+  /* ── Count badge ── */
+  .count-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    min-width: 22px;
+    height: 22px;
+    padding: 0 7px;
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--text-muted);
+  }
+
+  /* ── Dot ── */
+  .dot {
+    width: 7px; height: 7px;
+    border-radius: 50%;
+    background: var(--success);
+    display: inline-block;
+    flex-shrink: 0;
+  }
+  .dot.error { background: var(--error); }
+  .dot.muted { background: var(--text-muted); }
+
+  /* ── Status badges ── */
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    border-radius: 999px;
+    padding: 3px 9px;
+    font-size: 11px;
+    font-weight: 500;
+    white-space: nowrap;
+  }
+  .badge-active   { background: rgba(34,197,94,0.12);  color: #22c55e; }
+  .badge-expiring { background: rgba(249,115,22,0.14); color: #f97316; }
+  .badge-expired  { background: rgba(102,102,102,0.14); color: var(--text-muted); }
+  .badge-revoked  { background: rgba(239,68,68,0.12);  color: var(--error); }
+  .badge-pending  { background: rgba(59,130,246,0.12); color: #3b82f6; }
+
+  /* ── Address cell ── */
+  .addr-cell {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+  }
+  .copy-btn-addr {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 2px;
+    color: var(--text-muted);
+    display: inline-flex;
+    line-height: 1;
+    flex-shrink: 0;
+    opacity: 0;
+    transition: color 0.12s, opacity 0.12s;
+  }
+  .addr-cell:hover .copy-btn-addr { opacity: 1; }
+  .copy-btn-addr:hover { color: var(--accent); }
+
+  /* ── Expiry toggle ── */
+  .ts-toggle {
+    position: relative;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+  }
+  .ts-toggle::after {
+    content: attr(data-tip);
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 4px 9px;
+    font-size: 11px;
+    color: var(--text-primary);
+    white-space: nowrap;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.12s;
+    z-index: 300;
+    font-family: 'Inter', sans-serif;
+  }
+  .ts-toggle:hover::after { opacity: 1; }
+  .ts-toggle:hover span { color: var(--accent); }
+
+  /* ── Table ── */
+  .sk-table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+  .sk-table th {
+    padding: 10px 16px;
+    text-align: left;
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    border-bottom: 1px solid var(--border);
+    white-space: nowrap;
+  }
+  .sk-table th:first-child { padding-left: 20px; }
+  .sk-table th:last-child  { padding-right: 20px; }
+
+  .sk-table td {
+    padding: 13px 16px;
+    font-size: 13px;
+    border-bottom: 1px solid var(--border);
+    vertical-align: middle;
+  }
+  .sk-table td:first-child { padding-left: 20px; }
+  .sk-table td:last-child  { padding-right: 20px; }
+  .sk-table tr:last-child td { border-bottom: none; }
+  .sk-table tbody tr { transition: background 0.1s; }
+  .sk-table tbody tr:hover { background: rgba(255,255,255,0.02); }
+
+  .actions-cell {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    justify-content: flex-end;
+  }
+
+  /* ── Expiring soon banner ── */
+  .warning-banner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 11px 16px;
+    border-radius: 10px;
+    background: var(--warning-dim);
+    border: 1px solid rgba(249,115,22,0.25);
+    margin-bottom: 16px;
+  }
+
+  /* ── Th filter header ── */
+  .th-inner {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    user-select: none;
+  }
+  .th-inner.filterable { cursor: pointer; }
+  .th-inner.filterable:hover { color: var(--text-primary); }
+  .th-inner.filter-active { color: var(--accent); }
+
+  /* ── Main content ── */
+  .main {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 32px 24px;
+  }
+
+  .flex { display: flex; }
+  .items-center { align-items: center; }
+  .gap-2 { gap: 8px; }
+  .gap-3 { gap: 12px; }
+  .text-sm { font-size: 13px; }
+  .text-xs { font-size: 11px; }
+  .text-muted { color: var(--text-muted); }
+  .text-accent { color: var(--accent); }
+  .font-semibold { font-weight: 600; }
+
+  /* ── Spinner ── */
+  .spinner {
+    display: inline-block;
+    width: 12px; height: 12px;
+    border: 2px solid currentColor;
+    border-right-color: transparent;
+    border-radius: 50%;
+    animation: spin 0.6s linear infinite;
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
+</style>
+</head>
+<body>
+
+<!-- ── Navigation Bar ── -->
+<nav class="nav">
+  <div class="nav-left">
+    <span class="nav-logo">nitrolite</span>
+    <div class="flex items-center gap-2 text-sm text-muted">
+      <span class="status-dot"></span>
+      <span>connected · 2s ago</span>
+    </div>
+  </div>
+
+  <div class="nav-center">
+    <button class="tab">Main</button>
+    <button class="tab">History</button>
+    <button class="tab active">Session Keys</button>
+  </div>
+
+  <div class="nav-right">
+    <div class="chip">
+      <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="color:var(--text-muted)">
+        <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>
+      </svg>
+      <span>Base</span>
+    </div>
+    <div class="chip mono" style="font-size:11px">0x1234…abcd</div>
+    <div class="chip chip-sk">
+      <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+        <circle cx="7.5" cy="15.5" r="5.5"/><path d="M21 2l-9.6 9.6"/><path d="M15.5 7.5l3 3L22 7l-3-3"/>
+      </svg>
+      SK · 23h
+      <span class="chip-clear">×</span>
+    </div>
+  </div>
+</nav>
+
+<!-- ── Main Content ── -->
+<main class="main">
+
+  <!-- Expiring Soon Banner -->
+  <div class="warning-banner">
+    <div class="flex items-center gap-3">
+      <div style="width:32px;height:32px;border-radius:50%;background:rgba(249,115,22,0.18);display:flex;align-items:center;justify-content:center;flex-shrink:0">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="7.5" cy="15.5" r="5.5"/><path d="M21 2l-9.6 9.6"/><path d="M15.5 7.5l3 3L22 7l-3-3"/>
+        </svg>
+      </div>
+      <div>
+        <div style="font-size:13px;font-weight:500;color:#f97316">Session key expiring soon</div>
+        <div style="font-size:12px;color:var(--text-muted)">
+          Key <span class="mono" style="font-size:11px">0x9fEd…A1b2</span> expires in 45 minutes. Renew to keep signing without MetaMask prompts.
+        </div>
+      </div>
+    </div>
+    <button class="btn btn-sm" style="border-color:rgba(249,115,22,0.4);color:#f97316;white-space:nowrap;flex-shrink:0">Renew Key</button>
+  </div>
+
+  <!-- Session Keys Card -->
+  <div class="card">
+    <div class="card-header">
+      <div class="flex items-center gap-2">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--text-muted)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="7.5" cy="15.5" r="5.5"/><path d="M21 2l-9.6 9.6"/><path d="M15.5 7.5l3 3L22 7l-3-3"/>
+        </svg>
+        <span class="card-title">Session Keys</span>
+        <span class="count-badge">4</span>
+      </div>
+      <div class="flex items-center gap-2">
+        <button class="btn btn-ghost btn-sm">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/>
+          </svg>
+          Refresh
+        </button>
+        <button class="btn btn-primary btn-sm">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>
+          </svg>
+          Register New
+        </button>
+      </div>
+    </div>
+
+    <!-- Table -->
+    <table class="sk-table">
+      <thead>
+        <tr>
+          <th>
+            <span class="th-inner">Address</span>
+          </th>
+          <th>
+            <span class="th-inner">Assets</span>
+          </th>
+          <th>
+            <span class="th-inner filterable" title="Click to cycle expiry format">
+              Expiration
+              <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+                <polyline points="6 9 12 15 18 9"/>
+              </svg>
+            </span>
+          </th>
+          <th>
+            <span class="th-inner filterable">
+              Status
+              <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+                <polyline points="6 9 12 15 18 9"/>
+              </svg>
+            </span>
+          </th>
+          <th>
+            <span class="th-inner">Version</span>
+          </th>
+          <th style="text-align:right">
+            <span class="th-inner">Actions</span>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+
+        <!-- Row 1: Active key (currently in use) -->
+        <tr>
+          <td>
+            <div class="addr-cell">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="var(--success)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink:0">
+                <circle cx="7.5" cy="15.5" r="5.5"/><path d="M21 2l-9.6 9.6"/><path d="M15.5 7.5l3 3L22 7l-3-3"/>
+              </svg>
+              <span class="mono" style="font-size:12px">0x1a2B…c3dE</span>
+              <div style="display:inline-flex;align-items:center;gap:4px;background:var(--accent-dim);border-radius:4px;padding:1px 6px">
+                <svg width="7" height="7" viewBox="0 0 24 24" fill="none" stroke="var(--accent)" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg>
+                <span style="font-size:10px;font-weight:600;color:var(--accent)">IN USE</span>
+              </div>
+              <button class="copy-btn-addr" title="Copy address">
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+                </svg>
+              </button>
+            </div>
+          </td>
+          <td>
+            <span style="font-size:12px;color:var(--text-muted)" class="mono">USDC, ETH, YUSD</span>
+          </td>
+          <td>
+            <div class="ts-toggle" data-tip="Show as UTC date">
+              <span style="font-size:13px" class="mono">23h 15m</span>
+            </div>
+          </td>
+          <td><span class="badge badge-active">● Active</span></td>
+          <td><span style="font-size:12px;color:var(--text-muted)" class="mono">v1</span></td>
+          <td>
+            <div class="actions-cell">
+              <button class="btn btn-ghost btn-sm">Update</button>
+              <button class="btn btn-danger btn-sm">Revoke</button>
+            </div>
+          </td>
+        </tr>
+
+        <!-- Row 2: Expiring soon -->
+        <tr>
+          <td>
+            <div class="addr-cell">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#f97316" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink:0">
+                <circle cx="7.5" cy="15.5" r="5.5"/><path d="M21 2l-9.6 9.6"/><path d="M15.5 7.5l3 3L22 7l-3-3"/>
+              </svg>
+              <span class="mono" style="font-size:12px">0x9fEd…A1b2</span>
+              <button class="copy-btn-addr" title="Copy address">
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+                </svg>
+              </button>
+            </div>
+          </td>
+          <td>
+            <span style="font-size:12px;color:var(--text-muted)" class="mono">USDC</span>
+          </td>
+          <td>
+            <div class="ts-toggle" data-tip="Show as UTC date">
+              <span style="font-size:13px;color:#f97316" class="mono">45m</span>
+            </div>
+          </td>
+          <td><span class="badge badge-expiring">● Expiring Soon</span></td>
+          <td><span style="font-size:12px;color:var(--text-muted)" class="mono">v3</span></td>
+          <td>
+            <div class="actions-cell">
+              <button class="btn btn-sm" style="border-color:rgba(249,115,22,0.4);color:#f97316">Renew</button>
+              <button class="btn btn-danger btn-sm">Revoke</button>
+            </div>
+          </td>
+        </tr>
+
+        <!-- Row 3: Expired -->
+        <tr style="opacity:0.7">
+          <td>
+            <div class="addr-cell">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="var(--text-muted)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink:0">
+                <circle cx="7.5" cy="15.5" r="5.5"/><path d="M21 2l-9.6 9.6"/><path d="M15.5 7.5l3 3L22 7l-3-3"/>
+              </svg>
+              <span class="mono" style="font-size:12px">0xAbCd…1234</span>
+              <button class="copy-btn-addr" title="Copy address">
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+                </svg>
+              </button>
+            </div>
+          </td>
+          <td>
+            <span style="font-size:12px;color:var(--text-muted)" class="mono">ETH</span>
+          </td>
+          <td>
+            <div class="ts-toggle" data-tip="Show as UTC date">
+              <span style="font-size:13px;color:var(--text-muted)" class="mono">expired</span>
+            </div>
+          </td>
+          <td><span class="badge badge-expired">● Expired</span></td>
+          <td><span style="font-size:12px;color:var(--text-muted)" class="mono">v1</span></td>
+          <td>
+            <div class="actions-cell">
+              <button class="btn btn-ghost btn-sm" disabled>Update</button>
+              <button class="btn btn-danger btn-sm" disabled>Revoke</button>
+            </div>
+          </td>
+        </tr>
+
+        <!-- Row 4: Revoked -->
+        <tr style="opacity:0.55">
+          <td>
+            <div class="addr-cell">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="var(--error)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink:0">
+                <circle cx="7.5" cy="15.5" r="5.5"/><path d="M21 2l-9.6 9.6"/><path d="M15.5 7.5l3 3L22 7l-3-3"/>
+              </svg>
+              <span class="mono" style="font-size:12px">0x7eF1…8Ba4</span>
+              <button class="copy-btn-addr" title="Copy address">
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+                </svg>
+              </button>
+            </div>
+          </td>
+          <td>
+            <span style="font-size:12px;color:var(--text-muted)" class="mono">USDC, ETH</span>
+          </td>
+          <td>
+            <span style="font-size:13px;color:var(--text-muted)" class="mono">—</span>
+          </td>
+          <td><span class="badge badge-revoked">● Revoked</span></td>
+          <td><span style="font-size:12px;color:var(--text-muted)" class="mono">v2</span></td>
+          <td>
+            <div class="actions-cell">
+              <button class="btn btn-ghost btn-sm" disabled>Update</button>
+              <button class="btn btn-danger btn-sm" disabled>Revoke</button>
+            </div>
+          </td>
+        </tr>
+
+      </tbody>
+    </table>
+  </div>
+
+</main>
+</body>
+</html>

--- a/playground/mockups/session-keys/mockup-2-register-modal.html
+++ b/playground/mockups/session-keys/mockup-2-register-modal.html
@@ -1,0 +1,618 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Session Keys — Register Modal</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --bg-base:      #0a0a0a;
+    --bg-surface:   #141414;
+    --bg-elevated:  #1c1c1c;
+    --border:       #242424;
+    --text-primary: #f0f0f0;
+    --text-muted:   #666666;
+    --accent:       #f5a623;
+    --accent-dim:   rgba(245, 166, 35, 0.12);
+    --error:        #ef4444;
+    --success:      #22c55e;
+  }
+
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+  body {
+    font-family: 'Inter', system-ui, sans-serif;
+    background: var(--bg-base);
+    color: var(--text-primary);
+    font-size: 14px;
+    line-height: 1.5;
+    min-height: 100vh;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .mono { font-family: 'JetBrains Mono', monospace; }
+
+  /* ── Nav ── */
+  .nav {
+    background: var(--bg-surface);
+    border-bottom: 1px solid var(--border);
+    padding: 0 24px;
+    height: 56px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+  }
+
+  .nav-left { display: flex; align-items: center; gap: 10px; }
+  .nav-logo { font-size: 17px; font-weight: 600; color: var(--accent); letter-spacing: -0.3px; }
+  .status-dot {
+    width: 7px; height: 7px;
+    border-radius: 50%;
+    background: var(--success);
+    box-shadow: 0 0 5px var(--success);
+  }
+
+  .nav-center {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    align-items: center;
+    gap: 2px;
+  }
+
+  .nav-right { display: flex; align-items: center; gap: 8px; }
+
+  .tab {
+    padding: 7px 16px;
+    border-radius: 999px;
+    border: none;
+    background: transparent;
+    font-family: 'Inter', sans-serif;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--text-muted);
+    cursor: pointer;
+  }
+  .tab.active { color: var(--accent); background: var(--accent-dim); }
+
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 5px 10px;
+    font-size: 12px;
+    color: var(--text-primary);
+  }
+
+  /* ── Buttons ── */
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    padding: 8px 14px;
+    border-radius: 8px;
+    border: 1px solid var(--border);
+    background: var(--bg-elevated);
+    color: var(--text-primary);
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    font-family: 'Inter', sans-serif;
+    transition: background 0.12s;
+    width: 100%;
+    justify-content: center;
+  }
+  .btn-primary {
+    background: var(--accent);
+    color: #0a0a0a;
+    border-color: var(--accent);
+    font-weight: 600;
+  }
+  .btn-primary:hover { background: #e09520; }
+  .btn-ghost {
+    background: transparent;
+    border-color: var(--border);
+    color: var(--text-muted);
+  }
+  .btn-ghost:hover { color: var(--text-primary); }
+  .btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+  /* ── Background card ── */
+  .card {
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+  }
+  .card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px 20px;
+    border-bottom: 1px solid var(--border);
+  }
+  .card-title { font-size: 15px; font-weight: 600; }
+
+  /* ── Main ── */
+  .main {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 32px 24px;
+  }
+
+  /* ── Background table (blurred) ── */
+  .bg-table-placeholder {
+    filter: blur(1.5px);
+    opacity: 0.35;
+    pointer-events: none;
+    user-select: none;
+  }
+
+  .sk-table-bg {
+    width: 100%;
+    border-collapse: collapse;
+  }
+  .sk-table-bg th {
+    padding: 10px 20px;
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    border-bottom: 1px solid var(--border);
+  }
+  .sk-table-bg td {
+    padding: 13px 20px;
+    font-size: 13px;
+    border-bottom: 1px solid var(--border);
+  }
+  .sk-table-bg tr:last-child td { border-bottom: none; }
+
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    border-radius: 999px;
+    padding: 3px 9px;
+    font-size: 11px;
+    font-weight: 500;
+  }
+  .badge-active  { background: rgba(34,197,94,0.12);  color: #22c55e; }
+  .badge-expiring { background: rgba(249,115,22,0.14); color: #f97316; }
+
+  /* ── Modal Overlay ── */
+  .modal-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.72);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 50;
+    backdrop-filter: blur(4px);
+  }
+
+  .modal-card {
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    width: 440px;
+    max-width: calc(100vw - 32px);
+    padding: 28px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+  }
+
+  .modal-header {
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .modal-icon {
+    width: 48px; height: 48px;
+    border-radius: 50%;
+    background: var(--accent-dim);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .modal-title {
+    font-size: 17px;
+    font-weight: 600;
+  }
+
+  /* ── Section ── */
+  .form-section {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .form-label {
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  /* ── Asset checkboxes ── */
+  .asset-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .asset-checkbox {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 14px;
+    border-radius: 8px;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    cursor: pointer;
+    transition: border-color 0.12s;
+  }
+
+  .asset-checkbox.checked {
+    border-color: var(--accent);
+    background: var(--accent-dim);
+  }
+
+  .cb-box {
+    width: 16px; height: 16px;
+    border-radius: 4px;
+    border: 2px solid var(--border);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+  .asset-checkbox.checked .cb-box {
+    background: var(--accent);
+    border-color: var(--accent);
+  }
+
+  .asset-icon {
+    width: 24px; height: 24px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 10px;
+    font-weight: 700;
+    flex-shrink: 0;
+  }
+
+  .asset-info { flex: 1; }
+  .asset-symbol { font-size: 13px; font-weight: 500; }
+  .asset-name { font-size: 11px; color: var(--text-muted); }
+
+  /* ── Expiry segmented control ── */
+  .seg-ctrl {
+    display: flex;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 3px;
+    gap: 2px;
+  }
+
+  .seg-btn {
+    flex: 1;
+    padding: 6px 12px;
+    border-radius: 6px;
+    border: none;
+    background: transparent;
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--text-muted);
+    cursor: pointer;
+    font-family: 'Inter', sans-serif;
+    transition: background 0.12s, color 0.12s;
+  }
+  .seg-btn.active {
+    background: var(--bg-surface);
+    color: var(--text-primary);
+    border: 1px solid var(--border);
+  }
+
+  /* ── Duration input ── */
+  .duration-row {
+    display: flex;
+    gap: 8px;
+    align-items: stretch;
+  }
+
+  .input-wrap {
+    display: flex;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    overflow: hidden;
+    flex: 1;
+  }
+  .input-wrap:focus-within { border-color: var(--accent); }
+
+  .input-wrap input {
+    flex: 1;
+    background: transparent;
+    border: none;
+    outline: none;
+    padding: 10px 12px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 14px;
+    color: var(--text-primary);
+    width: 100%;
+  }
+  .input-wrap input::placeholder { color: var(--text-muted); }
+
+  .unit-select {
+    background: var(--bg-base);
+    border: none;
+    border-left: 1px solid var(--border);
+    padding: 0 12px;
+    font-size: 13px;
+    color: var(--text-muted);
+    font-family: 'Inter', sans-serif;
+    cursor: pointer;
+    outline: none;
+  }
+
+  .computed-expiry {
+    font-size: 12px;
+    color: var(--text-muted);
+    padding: 6px 0 0 2px;
+  }
+  .computed-expiry span { color: var(--text-primary); font-family: 'JetBrains Mono', monospace; }
+
+  /* ── Summary box ── */
+  .summary-box {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 12px 14px;
+    font-size: 12px;
+    color: var(--text-muted);
+    line-height: 1.6;
+  }
+  .summary-box strong { color: var(--text-primary); font-weight: 500; }
+
+  /* ── Footer buttons ── */
+  .modal-footer {
+    display: flex;
+    gap: 8px;
+  }
+  .modal-footer .btn { flex: 1; }
+
+  /* ── Divider ── */
+  .divider {
+    height: 1px;
+    background: var(--border);
+    margin: 0 -28px;
+  }
+
+  /* ── Spinner ── */
+  .spinner {
+    display: inline-block;
+    width: 12px; height: 12px;
+    border: 2px solid currentColor;
+    border-right-color: transparent;
+    border-radius: 50%;
+    animation: spin 0.6s linear infinite;
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
+</style>
+</head>
+<body>
+
+<!-- ── Navigation Bar ── -->
+<nav class="nav">
+  <div class="nav-left">
+    <span class="nav-logo">nitrolite</span>
+    <div style="display:flex;align-items:center;gap:8px;font-size:13px;color:var(--text-muted)">
+      <span class="status-dot"></span>
+      <span>connected · 2s ago</span>
+    </div>
+  </div>
+
+  <div class="nav-center">
+    <button class="tab">Main</button>
+    <button class="tab">History</button>
+    <button class="tab active">Session Keys</button>
+  </div>
+
+  <div class="nav-right">
+    <div class="chip">
+      <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="color:var(--text-muted)">
+        <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>
+      </svg>
+      <span>Base</span>
+    </div>
+    <div class="chip mono" style="font-size:11px">0x1234…abcd</div>
+  </div>
+</nav>
+
+<!-- ── Main Content (blurred background) ── -->
+<main class="main">
+  <div class="bg-table-placeholder">
+    <div class="card">
+      <div class="card-header">
+        <div style="display:flex;align-items:center;gap:8px">
+          <span class="card-title">Session Keys</span>
+          <span style="display:inline-flex;align-items:center;justify-content:center;background:var(--bg-elevated);border:1px solid var(--border);border-radius:999px;min-width:22px;height:22px;padding:0 7px;font-size:12px;color:var(--text-muted)">2</span>
+        </div>
+        <div style="display:flex;gap:8px">
+          <button class="btn" style="padding:5px 10px;font-size:12px;pointer-events:none">Refresh</button>
+          <button class="btn btn-primary" style="padding:5px 10px;font-size:12px;pointer-events:none">+ Register New</button>
+        </div>
+      </div>
+      <table class="sk-table-bg">
+        <thead>
+          <tr>
+            <th style="text-align:left">Address</th>
+            <th style="text-align:left">Assets</th>
+            <th style="text-align:left">Expiration</th>
+            <th style="text-align:left">Status</th>
+            <th style="text-align:left">Version</th>
+            <th style="text-align:right">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><span class="mono" style="font-size:12px">0x1a2B…c3dE</span></td>
+            <td><span class="mono" style="font-size:12px;color:var(--text-muted)">USDC, ETH, YUSD</span></td>
+            <td><span class="mono" style="font-size:12px">23h 15m</span></td>
+            <td><span class="badge badge-active">● Active</span></td>
+            <td><span class="mono" style="font-size:12px;color:var(--text-muted)">v1</span></td>
+            <td style="text-align:right;color:var(--text-muted);font-size:12px">· · ·</td>
+          </tr>
+          <tr>
+            <td><span class="mono" style="font-size:12px">0x9fEd…A1b2</span></td>
+            <td><span class="mono" style="font-size:12px;color:var(--text-muted)">USDC</span></td>
+            <td><span class="mono" style="font-size:12px;color:#f97316">45m</span></td>
+            <td><span class="badge badge-expiring">● Expiring Soon</span></td>
+            <td><span class="mono" style="font-size:12px;color:var(--text-muted)">v3</span></td>
+            <td style="text-align:right;color:var(--text-muted);font-size:12px">· · ·</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</main>
+
+<!-- ── Modal ── -->
+<div class="modal-overlay">
+  <div class="modal-card">
+
+    <!-- Header -->
+    <div class="modal-header">
+      <div class="modal-icon">
+        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="var(--accent)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="7.5" cy="15.5" r="5.5"/><path d="M21 2l-9.6 9.6"/><path d="M15.5 7.5l3 3L22 7l-3-3"/>
+        </svg>
+      </div>
+      <div class="modal-title">Register a new session key</div>
+      <div style="font-size:13px;color:var(--text-muted);text-align:center;line-height:1.5">
+        Authorize a temporary key to sign state updates on your behalf — no MetaMask popup for every action.
+      </div>
+    </div>
+
+    <div class="divider"></div>
+
+    <!-- Assets -->
+    <div class="form-section">
+      <div style="display:flex;align-items:center;justify-content:space-between">
+        <span class="form-label">Authorize Assets</span>
+        <span style="font-size:11px;color:var(--text-muted);cursor:pointer">Select all · Clear</span>
+      </div>
+      <div class="asset-grid">
+
+        <label class="asset-checkbox checked">
+          <div class="cb-box">
+            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="#0a0a0a" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="20 6 9 17 4 12"/>
+            </svg>
+          </div>
+          <div class="asset-icon" style="background:#2775ca">
+            <span style="color:white;font-size:9px">$</span>
+          </div>
+          <div class="asset-info">
+            <div class="asset-symbol">USDC</div>
+            <div class="asset-name">USD Coin</div>
+          </div>
+        </label>
+
+        <label class="asset-checkbox checked">
+          <div class="cb-box">
+            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="#0a0a0a" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="20 6 9 17 4 12"/>
+            </svg>
+          </div>
+          <div class="asset-icon" style="background:#627eea">
+            <span style="color:white;font-size:9px">Ξ</span>
+          </div>
+          <div class="asset-info">
+            <div class="asset-symbol">ETH</div>
+            <div class="asset-name">Ether</div>
+          </div>
+        </label>
+
+        <label class="asset-checkbox">
+          <div class="cb-box"></div>
+          <div class="asset-icon" style="background:#f5a623">
+            <span style="color:#0a0a0a;font-size:8px;font-weight:700">Y</span>
+          </div>
+          <div class="asset-info">
+            <div class="asset-symbol">YUSD</div>
+            <div class="asset-name">Yellow USD</div>
+          </div>
+        </label>
+
+      </div>
+    </div>
+
+    <div class="divider"></div>
+
+    <!-- Expiration -->
+    <div class="form-section">
+      <span class="form-label">Expiration</span>
+
+      <!-- Segmented control -->
+      <div class="seg-ctrl">
+        <button class="seg-btn active">Duration</button>
+        <button class="seg-btn">Date</button>
+        <button class="seg-btn">Unix</button>
+      </div>
+
+      <!-- Duration input -->
+      <div class="duration-row">
+        <div class="input-wrap">
+          <input type="number" value="24" min="1" />
+          <select class="unit-select">
+            <option>hours</option>
+            <option>days</option>
+          </select>
+        </div>
+      </div>
+
+      <div class="computed-expiry">
+        Expires: <span>2026-05-28 11:30:00 UTC</span>
+      </div>
+    </div>
+
+    <div class="divider"></div>
+
+    <!-- Summary -->
+    <div class="summary-box">
+      This key will authorize: <strong>USDC, ETH</strong> and expire in <strong>24 hours</strong>.<br>
+      On-chain transactions (deposit, checkpoint, approve) will still require MetaMask.
+    </div>
+
+    <!-- Buttons -->
+    <div class="modal-footer">
+      <button class="btn btn-ghost">Cancel</button>
+      <button class="btn btn-primary">Register &amp; Sign</button>
+    </div>
+
+  </div>
+</div>
+
+</body>
+</html>

--- a/playground/mockups/session-keys/mockup-3-channels-integration.html
+++ b/playground/mockups/session-keys/mockup-3-channels-integration.html
@@ -1,0 +1,710 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Session Keys — Channels Integration</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --bg-base:      #0a0a0a;
+    --bg-surface:   #141414;
+    --bg-elevated:  #1c1c1c;
+    --border:       #242424;
+    --text-primary: #f0f0f0;
+    --text-muted:   #666666;
+    --accent:       #f5a623;
+    --accent-dim:   rgba(245, 166, 35, 0.12);
+    --error:        #ef4444;
+    --success:      #22c55e;
+  }
+
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+  body {
+    font-family: 'Inter', system-ui, sans-serif;
+    background: var(--bg-base);
+    color: var(--text-primary);
+    font-size: 14px;
+    line-height: 1.5;
+    min-height: 100vh;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .mono { font-family: 'JetBrains Mono', monospace; }
+
+  /* ── Nav ── */
+  .nav {
+    background: var(--bg-surface);
+    border-bottom: 1px solid var(--border);
+    padding: 0 24px;
+    height: 56px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+  }
+
+  .nav-left { display: flex; align-items: center; gap: 10px; }
+  .nav-logo { font-size: 17px; font-weight: 600; color: var(--accent); letter-spacing: -0.3px; }
+  .status-dot {
+    width: 7px; height: 7px;
+    border-radius: 50%;
+    background: var(--success);
+    box-shadow: 0 0 5px var(--success);
+    flex-shrink: 0;
+  }
+  .nav-center {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    align-items: center;
+    gap: 2px;
+  }
+  .nav-right { display: flex; align-items: center; gap: 8px; }
+
+  .tab {
+    padding: 7px 16px;
+    border-radius: 999px;
+    border: none;
+    background: transparent;
+    font-family: 'Inter', sans-serif;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--text-muted);
+    cursor: pointer;
+  }
+  .tab.active { color: var(--accent); background: var(--accent-dim); }
+  .tab:hover:not(.active) { background: var(--bg-elevated); color: var(--text-primary); }
+
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 5px 10px;
+    font-size: 12px;
+    color: var(--text-primary);
+  }
+
+  /* ── Buttons ── */
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    padding: 8px 14px;
+    border-radius: 8px;
+    border: 1px solid var(--border);
+    background: var(--bg-elevated);
+    color: var(--text-primary);
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    font-family: 'Inter', sans-serif;
+    transition: background 0.12s;
+  }
+  .btn:hover { background: #1f1f1f; }
+  .btn-primary { background: var(--accent); color: #0a0a0a; border-color: var(--accent); font-weight: 600; }
+  .btn-primary:hover { background: #e09520; }
+  .btn-ghost { background: transparent; border-color: var(--border); color: var(--text-muted); }
+  .btn-sm { padding: 5px 10px; font-size: 12px; }
+
+  /* ── Card ── */
+  .card {
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+  }
+  .card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px 20px;
+    border-bottom: 1px solid var(--border);
+  }
+  .card-title { font-size: 15px; font-weight: 600; }
+
+  /* ── Layout ── */
+  .main {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 32px 24px;
+  }
+  .grid-layout {
+    display: grid;
+    grid-template-columns: 420px 1fr;
+    gap: 20px;
+    align-items: start;
+  }
+
+  /* ── Action Panel (simplified) ── */
+  .action-panel-tabs {
+    display: flex;
+    gap: 4px;
+    padding: 14px 20px 0;
+    border-bottom: 1px solid var(--border);
+  }
+  .ap-tab {
+    padding: 7px 16px;
+    border-radius: 999px;
+    border: none;
+    background: transparent;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--text-muted);
+    cursor: pointer;
+    font-family: 'Inter', sans-serif;
+  }
+  .ap-tab.active { color: var(--accent); background: var(--accent-dim); }
+
+  .ap-body { padding: 20px; display: flex; flex-direction: column; gap: 14px; }
+
+  .input-wrap {
+    display: flex;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    overflow: hidden;
+  }
+  .input-wrap input {
+    flex: 1;
+    background: transparent;
+    border: none;
+    outline: none;
+    padding: 10px 12px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 14px;
+    color: var(--text-primary);
+    width: 100%;
+  }
+  .input-wrap input::placeholder { color: var(--text-muted); }
+  .input-max {
+    font-family: 'Inter', sans-serif;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    color: var(--accent);
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    padding: 0 12px;
+  }
+
+  .token-selector {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 9px 12px;
+    cursor: pointer;
+    transition: border-color 0.12s;
+  }
+  .token-selector:hover { border-color: #333; }
+
+  .token-icon {
+    width: 22px; height: 22px;
+    border-radius: 50%;
+    background: #2775ca;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 10px;
+    color: white;
+    font-weight: 700;
+    flex-shrink: 0;
+  }
+
+  .balance-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 12px;
+    color: var(--text-muted);
+  }
+
+  /* ── Session Key Selector ── */
+  .sk-selector-wrap {
+    position: relative;
+    display: inline-block;
+  }
+
+  .sk-selector-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 5px 10px;
+    font-size: 12px;
+    color: var(--text-primary);
+    cursor: pointer;
+    font-family: 'Inter', sans-serif;
+    transition: border-color 0.12s;
+  }
+  .sk-selector-btn:hover { border-color: #333; }
+  .sk-selector-btn.open { border-color: var(--accent); }
+
+  .sk-dot-active {
+    width: 6px; height: 6px;
+    border-radius: 50%;
+    background: var(--success);
+    flex-shrink: 0;
+  }
+  .sk-dot-expiring {
+    width: 6px; height: 6px;
+    border-radius: 50%;
+    background: #f97316;
+    flex-shrink: 0;
+  }
+
+  /* ── SK Dropdown ── */
+  .sk-dropdown {
+    position: absolute;
+    top: calc(100% + 6px);
+    left: 0;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    box-shadow: 0 8px 24px rgba(0,0,0,0.55);
+    z-index: 200;
+    min-width: 260px;
+    overflow: hidden;
+    padding: 6px 0;
+  }
+
+  .sk-dropdown-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 9px 14px;
+    font-size: 13px;
+    cursor: pointer;
+    transition: background 0.1s;
+  }
+  .sk-dropdown-item:hover { background: rgba(255,255,255,0.04); }
+  .sk-dropdown-item.selected { background: var(--accent-dim); }
+
+  .sk-dropdown-sep {
+    height: 1px;
+    background: var(--border);
+    margin: 4px 0;
+  }
+
+  .sk-option-address {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 12px;
+    flex: 1;
+  }
+
+  .sk-option-meta {
+    font-size: 11px;
+    color: var(--text-muted);
+    white-space: nowrap;
+  }
+
+  .sk-option-meta.expiring { color: #f97316; }
+  .sk-option-meta.expired  { color: var(--text-muted); opacity: 0.6; }
+
+  .sk-dropdown-item.disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+  .sk-dropdown-item.disabled:hover { background: transparent; }
+
+  /* ── Channel rows ── */
+  .channel-row {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    border-bottom: 1px solid var(--border);
+  }
+  .channel-row:last-child { border-bottom: none; }
+
+  .channel-row-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 14px 20px;
+    gap: 12px;
+  }
+  .channel-row-head:hover { background: rgba(255,255,255,0.02); }
+
+  .channel-info { display: flex; align-items: center; gap: 10px; }
+
+  .channel-avatar {
+    width: 36px; height: 36px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 13px;
+    font-weight: 600;
+    flex-shrink: 0;
+  }
+
+  .channel-peer { font-size: 13px; font-weight: 500; }
+  .channel-id   { font-size: 11px; color: var(--text-muted); font-family: 'JetBrains Mono', monospace; }
+
+  .channel-balance { text-align: right; }
+  .channel-balance-amount {
+    font-size: 14px;
+    font-weight: 600;
+    font-family: 'JetBrains Mono', monospace;
+  }
+  .channel-balance-asset { font-size: 11px; color: var(--text-muted); }
+
+  .channel-sk-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    background: rgba(34,197,94,0.1);
+    border: 1px solid rgba(34,197,94,0.25);
+    border-radius: 5px;
+    padding: 2px 7px;
+    font-size: 10px;
+    font-weight: 500;
+    color: var(--success);
+    white-space: nowrap;
+  }
+  .channel-sk-badge.wallet {
+    background: var(--bg-elevated);
+    border-color: var(--border);
+    color: var(--text-muted);
+  }
+
+  /* ── Annotations / callout boxes ── */
+  .callout {
+    position: absolute;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 10px 14px;
+    font-size: 12px;
+    color: var(--text-muted);
+    line-height: 1.5;
+    max-width: 240px;
+    box-shadow: 0 4px 16px rgba(0,0,0,0.4);
+    pointer-events: none;
+  }
+  .callout strong { color: var(--text-primary); font-weight: 500; }
+  .callout-arrow-left::before {
+    content: '';
+    position: absolute;
+    right: 100%;
+    top: 50%;
+    transform: translateY(-50%);
+    border: 6px solid transparent;
+    border-right-color: var(--border);
+    margin-right: -1px;
+  }
+  .callout-arrow-left::after {
+    content: '';
+    position: absolute;
+    right: 100%;
+    top: 50%;
+    transform: translateY(-50%);
+    border: 5px solid transparent;
+    border-right-color: var(--bg-elevated);
+  }
+
+  .annotations-layer {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+  }
+
+  .layout-wrapper {
+    position: relative;
+  }
+
+  /* ── count badge ── */
+  .count-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    min-width: 22px;
+    height: 22px;
+    padding: 0 7px;
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--text-muted);
+  }
+
+  .check-icon {
+    width: 14px; height: 14px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+</style>
+</head>
+<body>
+
+<!-- ── Navigation Bar ── -->
+<nav class="nav">
+  <div class="nav-left">
+    <span class="nav-logo">nitrolite</span>
+    <div style="display:flex;align-items:center;gap:8px;font-size:13px;color:var(--text-muted)">
+      <span class="status-dot"></span>
+      <span>connected · 2s ago</span>
+    </div>
+  </div>
+
+  <div class="nav-center">
+    <button class="tab active">Main</button>
+    <button class="tab">History</button>
+    <button class="tab">Session Keys</button>
+  </div>
+
+  <div class="nav-right">
+    <div class="chip">
+      <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="color:var(--text-muted)">
+        <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>
+      </svg>
+      <span>Base</span>
+    </div>
+    <div class="chip mono" style="font-size:11px">0x1234…abcd</div>
+    <div class="chip" style="border-color:rgba(245,166,35,0.4);background:var(--accent-dim);color:var(--accent);font-family:'JetBrains Mono',monospace;font-size:11px;cursor:pointer">
+      <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+        <circle cx="7.5" cy="15.5" r="5.5"/><path d="M21 2l-9.6 9.6"/><path d="M15.5 7.5l3 3L22 7l-3-3"/>
+      </svg>
+      SK · 23h
+      <span style="color:var(--text-muted);font-size:11px;cursor:pointer;margin-left:2px">×</span>
+    </div>
+  </div>
+</nav>
+
+<!-- ── Main Content ── -->
+<main class="main">
+  <div class="grid-layout">
+
+    <!-- ── Left: Action Panel (simplified) ── -->
+    <div class="card">
+      <div class="action-panel-tabs">
+        <button class="ap-tab active">Deposit</button>
+        <button class="ap-tab">Withdraw</button>
+        <button class="ap-tab">Transfer</button>
+        <button class="ap-tab">Faucet</button>
+      </div>
+
+      <div class="ap-body">
+        <!-- Token selector -->
+        <div>
+          <div style="font-size:11px;font-weight:500;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.05em;margin-bottom:6px">Asset</div>
+          <div class="token-selector">
+            <div class="token-icon">$</div>
+            <div style="flex:1">
+              <div style="font-size:13px;font-weight:500">USDC</div>
+              <div style="font-size:11px;color:var(--text-muted)">USD Coin</div>
+            </div>
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--text-muted)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="6 9 12 15 18 9"/>
+            </svg>
+          </div>
+        </div>
+
+        <!-- Amount -->
+        <div>
+          <div style="font-size:11px;font-weight:500;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.05em;margin-bottom:6px">Amount</div>
+          <div class="input-wrap">
+            <input type="text" placeholder="0.00" value="100" />
+            <button class="input-max">MAX</button>
+          </div>
+          <div class="balance-row" style="margin-top:6px">
+            <span>On-chain balance</span>
+            <span style="font-family:'JetBrains Mono',monospace;font-size:12px">1,250.00 USDC</span>
+          </div>
+        </div>
+
+        <!-- Channel balance -->
+        <div style="background:var(--bg-elevated);border:1px solid var(--border);border-radius:8px;padding:12px 14px">
+          <div class="balance-row">
+            <span>Channel balance</span>
+            <span style="font-family:'JetBrains Mono',monospace;font-size:12px">320.00 USDC</span>
+          </div>
+        </div>
+
+        <button class="btn btn-primary" style="width:100%">Deposit</button>
+      </div>
+    </div>
+
+    <!-- ── Right: Channels Card ── -->
+    <div style="position:relative">
+      <div class="card" style="position:relative;z-index:1">
+        <div class="card-header">
+          <div style="display:flex;align-items:center;gap:8px">
+            <span class="card-title">Channels</span>
+            <span class="count-badge">2</span>
+            <!-- ── Session Key Selector ── -->
+            <div class="sk-selector-wrap">
+              <button class="sk-selector-btn open">
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--success)">
+                  <circle cx="7.5" cy="15.5" r="5.5"/><path d="M21 2l-9.6 9.6"/><path d="M15.5 7.5l3 3L22 7l-3-3"/>
+                </svg>
+                <span class="mono" style="font-size:11px">0x1a2B…c3dE</span>
+                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="color:var(--text-muted)">
+                  <polyline points="6 9 12 15 18 9"/>
+                </svg>
+              </button>
+
+              <!-- Dropdown (open state) -->
+              <div class="sk-dropdown">
+
+                <!-- Wallet option -->
+                <div class="sk-dropdown-item">
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="var(--text-muted)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <rect x="2" y="5" width="20" height="14" rx="2"/><path d="M2 10h20"/>
+                  </svg>
+                  <span style="font-size:13px;flex:1">Wallet (no key)</span>
+                  <span class="sk-option-meta">MetaMask</span>
+                </div>
+
+                <div class="sk-dropdown-sep"></div>
+
+                <!-- Active key — currently selected -->
+                <div class="sk-dropdown-item selected">
+                  <span class="sk-dot-active"></span>
+                  <span class="sk-option-address">0x1a2B…c3dE</span>
+                  <span class="sk-option-meta">23h 15m</span>
+                  <div class="check-icon" style="margin-left:4px">
+                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="var(--accent)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                      <polyline points="20 6 9 17 4 12"/>
+                    </svg>
+                  </div>
+                </div>
+
+                <!-- Expiring key -->
+                <div class="sk-dropdown-item">
+                  <span class="sk-dot-expiring"></span>
+                  <span class="sk-option-address">0x9fEd…A1b2</span>
+                  <span class="sk-option-meta expiring">45m ⚠</span>
+                </div>
+
+                <div class="sk-dropdown-sep"></div>
+
+                <!-- Expired key (disabled) -->
+                <div class="sk-dropdown-item disabled">
+                  <div style="width:6px;height:6px;border-radius:50%;background:var(--text-muted);flex-shrink:0"></div>
+                  <span class="sk-option-address" style="color:var(--text-muted)">0xAbCd…1234</span>
+                  <span class="sk-option-meta expired">expired</span>
+                </div>
+
+                <div class="sk-dropdown-sep"></div>
+
+                <!-- Manage link -->
+                <div class="sk-dropdown-item" style="color:var(--accent);font-size:12px">
+                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <circle cx="7.5" cy="15.5" r="5.5"/><path d="M21 2l-9.6 9.6"/><path d="M15.5 7.5l3 3L22 7l-3-3"/>
+                  </svg>
+                  <span>Manage session keys →</span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <button class="btn btn-ghost btn-sm">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/>
+            </svg>
+            Refresh
+          </button>
+        </div>
+
+        <!-- Channel Rows -->
+        <div>
+
+          <!-- Channel 1 — signed with SK -->
+          <div class="channel-row">
+            <div class="channel-row-head">
+              <div class="channel-info">
+                <div class="channel-avatar" style="background:rgba(39,117,202,0.18)">
+                  <span style="font-size:13px">🏦</span>
+                </div>
+                <div>
+                  <div style="display:flex;align-items:center;gap:6px">
+                    <span class="channel-peer">Nitronode</span>
+                    <span class="channel-sk-badge">
+                      <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                        <circle cx="7.5" cy="15.5" r="5.5"/><path d="M21 2l-9.6 9.6"/><path d="M15.5 7.5l3 3L22 7l-3-3"/>
+                      </svg>
+                      SK · 0x1a2B…c3dE
+                    </span>
+                  </div>
+                  <div class="channel-id">ch_0xDe4f…2e91</div>
+                </div>
+              </div>
+              <div class="channel-balance">
+                <div class="channel-balance-amount">320.00</div>
+                <div class="channel-balance-asset">USDC</div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Channel 2 — wallet only -->
+          <div class="channel-row">
+            <div class="channel-row-head">
+              <div class="channel-info">
+                <div class="channel-avatar" style="background:rgba(98,126,234,0.18)">
+                  <span style="font-size:13px">⚡</span>
+                </div>
+                <div>
+                  <div style="display:flex;align-items:center;gap:6px">
+                    <span class="channel-peer">App Layer</span>
+                    <span class="channel-sk-badge wallet">
+                      <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <rect x="2" y="5" width="20" height="14" rx="2"/><path d="M2 10h20"/>
+                      </svg>
+                      Wallet
+                    </span>
+                  </div>
+                  <div class="channel-id">ch_0x9bA2…7c03</div>
+                </div>
+              </div>
+              <div class="channel-balance">
+                <div class="channel-balance-amount">0.50</div>
+                <div class="channel-balance-asset">ETH</div>
+              </div>
+            </div>
+          </div>
+
+        </div>
+      </div>
+
+      <!-- ── Annotation callouts ── -->
+
+      <!-- Callout 1: pointing at dropdown -->
+      <div style="position:absolute;top:52px;right:-260px;z-index:10">
+        <div class="callout callout-arrow-left">
+          <strong>Global session key selector</strong><br>
+          Pick which key signs all channel operations. Switching rebuilds the SDK client instantly — no reconnect needed.
+        </div>
+      </div>
+
+      <!-- Callout 2: pointing at SK badge on channel row -->
+      <div style="position:absolute;top:165px;right:-260px;z-index:10">
+        <div class="callout callout-arrow-left">
+          <strong>Per-channel indicator</strong><br>
+          Shows which key (or wallet) is actively signing for this channel. Hover for the full address.
+        </div>
+      </div>
+    </div>
+
+  </div>
+</main>
+
+</body>
+</html>

--- a/playground/public/favicon.svg
+++ b/playground/public/favicon.svg
@@ -1,23 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 32" fill="none">
-  <!-- Italic N: font-size 28 (up from 26), weight 500 (down from 700 → thinner strokes) -->
-  <text
-    x="1" y="27"
-    font-family="'JetBrains Mono', 'Courier New', monospace"
-    font-style="italic"
-    font-weight="500"
-    font-size="28"
-    fill="#f5a623"
-  >N</text>
-
-  <!--
-    FlaskConical — exact Lucide paths (viewBox 0 0 24 24).
-    scale(0.82) down from 0.95 → flask height ~16.4px.
-    N spans y≈6.3–27 (height ~20.7px); flask centered within that range.
-    translate(15.5 7):  flask top ≈ y=8.6, flask bottom ≈ y=25.0
-    Gap: N right edge ≈ x=17.8, flask cap left ≈ x=22.5 → ~5px gap.
-  -->
-  <g transform="translate(18.8 8.5) scale(0.82)"
-     stroke="#f5a623" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <rect width="32" height="32" rx="7" fill="#f5a623"/>
+  <g transform="translate(4.7 4.7) scale(0.943)"
+     stroke="#0a0a0a" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
     <path d="M14 2v6a2 2 0 0 0 .245.96l5.51 10.08A2 2 0 0 1 18 22H6a2 2 0 0 1-1.755-2.96l5.51-10.08A2 2 0 0 0 10 8V2"/>
     <path d="M6.453 15h11.094"/>
     <path d="M8.5 2h7"/>

--- a/playground/public/favicon.svg
+++ b/playground/public/favicon.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 32" fill="none">
+  <!-- Italic N: font-size 28 (up from 26), weight 500 (down from 700 → thinner strokes) -->
+  <text
+    x="1" y="27"
+    font-family="'JetBrains Mono', 'Courier New', monospace"
+    font-style="italic"
+    font-weight="500"
+    font-size="28"
+    fill="#f5a623"
+  >N</text>
+
+  <!--
+    FlaskConical — exact Lucide paths (viewBox 0 0 24 24).
+    scale(0.82) down from 0.95 → flask height ~16.4px.
+    N spans y≈6.3–27 (height ~20.7px); flask centered within that range.
+    translate(15.5 7):  flask top ≈ y=8.6, flask bottom ≈ y=25.0
+    Gap: N right edge ≈ x=17.8, flask cap left ≈ x=22.5 → ~5px gap.
+  -->
+  <g transform="translate(18.8 8.5) scale(0.82)"
+     stroke="#f5a623" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M14 2v6a2 2 0 0 0 .245.96l5.51 10.08A2 2 0 0 1 18 22H6a2 2 0 0 1-1.755-2.96l5.51-10.08A2 2 0 0 0 10 8V2"/>
+    <path d="M6.453 15h11.094"/>
+    <path d="M8.5 2h7"/>
+  </g>
+</svg>

--- a/playground/session-keys-usage.md
+++ b/playground/session-keys-usage.md
@@ -1,0 +1,230 @@
+# Channel Session Keys — Usage Guide
+
+Source of truth: `pkg/core/session_key.go`, `nitronode/api/channel_v1/`, `sdk/ts/src/signers.ts`, `playground/src/sessionKey.ts`.
+
+---
+
+## Overview
+
+A channel session key is a delegated signing key. Once registered, it can sign off-chain channel state transitions on behalf of a wallet — no MetaMask popup per state. On-chain operations (deposit, checkpoint, close) always require the wallet.
+
+---
+
+## 1. Issuance (Registration)
+
+### RPC method
+`channels.v1.submit_session_key_state`
+
+### State object — all fields required at submission
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `user_address` | string | Wallet address authorizing the delegation |
+| `session_key` | string | Address of the session key being registered |
+| `version` | string (uint64) | Must be exactly `latestVersion + 1`; first registration = `"1"` |
+| `assets` | string[] | Asset IDs this key may sign for (e.g. `["usdc", "eth"]`) |
+| `expires_at` | string (unix secs) | Future → active; past/now → immediate revocation |
+| `user_sig` | string | EIP-191 wallet signature (triggers MetaMask once) |
+| `session_key_sig` | string | EIP-191 session key ownership proof (local, no popup) |
+
+### What the signatures sign
+
+Both signatures sign the same packed payload:
+
+```
+keccak256(SESSION_KEY_AUTH_TYPEHASH, session_key, metadataHash)
+```
+
+where:
+
+```
+metadataHash = keccak256(abi.encode(user_address, version, assets, expires_at))
+```
+
+This binds both signatures to the exact `(wallet, session_key, version, assets, expires_at)` tuple — no replay possible across different pairs.
+
+### TypeScript issuance flow
+
+```typescript
+import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
+import { EthereumMsgSigner, type ChannelSessionKeyStateV1 } from '@yellow-org/sdk';
+
+// 1. Generate a fresh throwaway key
+const skPrivateKey = generatePrivateKey();
+const skAccount   = privateKeyToAccount(skPrivateKey);
+const skMsgSigner = new EthereumMsgSigner(skPrivateKey);
+
+// 2. Build state (version = latestVersion + 1; first time = 1)
+const state: ChannelSessionKeyStateV1 = {
+  user_address:    walletAddress,
+  session_key:     skAccount.address,
+  version:         nextVersion.toString(),
+  assets:          ['usdc', 'eth'],
+  expires_at:      (Math.floor(Date.now() / 1000) + 86400).toString(), // 24 h
+  user_sig:        '',
+  session_key_sig: '',
+};
+
+// 3. Wallet signs (one MetaMask popup)
+state.user_sig = await client.signChannelSessionKeyState(state);
+
+// 4. Session key signs locally (no popup)
+state.session_key_sig = await client.signChannelSessionKeyOwnership(state, skMsgSigner);
+
+// 5. Submit
+await client.submitChannelSessionKeyState(state);
+```
+
+### What to persist after registration
+
+You need all of the following to reconstruct the signer in future sessions:
+
+```typescript
+type StoredSessionKey = {
+  privateKey:        Hex;     // session key private key
+  sessionKeyAddress: Address;
+  walletAddress:     Address;
+  version:           string;
+  assets:            string[];
+  expiresAt:         string;  // unix secs
+  userSig:           Hex;     // wallet's auth signature
+};
+```
+
+### Operations: registration / update / revocation
+
+All three use the same RPC method and the same version-increment rule:
+
+| Operation | `expires_at` | Effect |
+|-----------|-------------|--------|
+| Registration | future | Activates the key |
+| Update (rotate assets / extend lifetime) | future | Replaces the active state |
+| Revocation | `<= now` | Retires the key immediately; slot is freed |
+
+---
+
+## 2. Version Rules
+
+### The rule
+Every submit must have `version == latestVersion + 1` — exactly, not "at least". Any other value returns:
+```
+invalid_session_key_state: expected version <N>, got <M>
+```
+
+### Version 0 is invalid
+Version `0` is rejected before any other validation. Internally it is a seed row that reserves ownership of a `(session_key, kind)` slot — never a valid submitted state.
+
+### Version scoping
+Version is scoped per `(user_address, session_key, kind)` triplet. Channel keys (`kind=1`) and app-session keys (`kind=2`) for the same private key have completely independent version sequences.
+
+### How to get the current version before submitting
+
+There is no dedicated version endpoint. Call `getLastChannelKeyStates` and read `state.version`:
+
+```typescript
+const states = await client.getLastChannelKeyStates(walletAddress, sessionKeyAddress);
+
+const nextVersion = states.length === 0
+  ? 1n
+  : BigInt(states[0].version) + 1n;
+```
+
+### Race conditions
+Concurrent submits for the same key are serialized by a row-level lock (`LockSessionKeyState`). The losing transaction re-reads the updated `latestVersion` and receives the "expected version N, got M" error. The client must re-fetch and retry with `latestVersion + 1`.
+
+---
+
+## 3. Using Session Keys for Channel Operations
+
+### Client initialization
+
+Pass a `ChannelSessionKeyStateSigner` as `stateSigner` to `Client.create()`. The `txSigner` (on-chain operations) always uses the wallet — never the session key.
+
+```typescript
+import {
+  Client,
+  ChannelDefaultSigner,
+  ChannelSessionKeyStateSigner,
+  EthereumMsgSigner,
+  getChannelSessionKeyAuthMetadataHashV1,
+} from '@yellow-org/sdk';
+
+function buildSessionKeyStateSigner(sk: StoredSessionKey): StateSigner {
+  const metadataHash = getChannelSessionKeyAuthMetadataHashV1(
+    sk.walletAddress,
+    BigInt(sk.version),
+    sk.assets,
+    BigInt(sk.expiresAt),
+  );
+  return new ChannelSessionKeyStateSigner(
+    sk.privateKey,
+    sk.walletAddress,
+    metadataHash,
+    sk.userSig,   // wallet's auth signature from registration
+  );
+}
+
+// Choose signer based on whether a valid session key exists
+const stateSigner = sessionKey
+  ? buildSessionKeyStateSigner(sessionKey)
+  : new ChannelDefaultSigner(new WalletStateSigner(walletClient));
+
+const client = await Client.create(NODE_URL, stateSigner, txSigner, ...opts);
+```
+
+### Wire format
+
+When the client signs with a session key, it does not produce a bare 65-byte ECDSA signature. It produces:
+
+```
+0x01 || abi.encode(
+  SessionKeyAuthorization { sessionKey, metadataHash, authSignature },
+  sessionKeySig
+)
+```
+
+The `0x01` type byte tells the server to unwrap the authorization bundle. The server then:
+1. Verifies `authSignature` (wallet) over `(SESSION_KEY_AUTH_TYPEHASH, sessionKey, metadataHash)`
+2. Verifies `sessionKeySig` (session key) over the actual state hash
+3. Checks asset permission and expiry
+
+(`sdk/ts/src/signers.ts:224-255`, `pkg/core/channel_signer.go:172-212`)
+
+### What can and cannot be session-key signed
+
+| Operation | Session key OK? |
+|-----------|----------------|
+| Off-chain state transitions (`submitState`, transfers, acks) | Yes |
+| Session key registration (`submitChannelSessionKeyState`) | Partial — `user_sig` must be wallet; `session_key_sig` is the session key |
+| On-chain: `checkpoint`, `deposit`, `withdraw`, `closeChannel` | No — always wallet via `txSigner` |
+
+---
+
+## 4. Constraints
+
+### Asset list
+Enforced **server-side only**. The server joins against `channel_session_key_assets_v1` and checks that the asset being signed for is in the registered list. Submitting a state for an asset not in the list returns:
+```
+session key does not have permission to sign for this data
+```
+
+### Expiry
+Enforced **server-side only** (`expires_at > now`). The same generic error is returned for both expired keys and wrong-asset cases — intentional, to avoid leaking whether a key exists but is expired.
+
+The playground uses a client-side `isExpired()` helper with a renewal buffer as a UX optimization, but the SDK itself does not pre-check expiry.
+
+### `kind` isolation
+The same private key can be registered independently as:
+- `kind = 1` — channel session key (`channels.v1.submit_session_key_state`)
+- `kind = 2` — app-session key (different RPC)
+
+They have separate version histories and asset lists. The SDK selects `kind` automatically based on which RPC method is called — there is no SDK-level `kind` parameter.
+
+### One owner per key per kind
+Once a wallet seeds the ownership row for a `(session_key, kind)` pair it is permanent. No other wallet can register that session key address for the same kind, even after revocation.
+
+### Server-side caps (configurable)
+- Maximum session keys per user: `maxSessionKeysPerUser`
+- Maximum assets per session key: `maxSessionKeyIDs`
+
+Exceeding either cap at registration returns an error before the version check.

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -98,6 +98,7 @@ export default function App() {
                 walletClient={wallet.walletClient}
                 address={wallet.address}
                 sessionKey={sk.sessionKey}
+                allSessionKeys={sk.allKeys}
                 supportedAssets={nitro.supportedAssets.map(a => a.symbol)}
                 onKeyActivated={(newSk) => sk.selectKey(newSk.sessionKeyAddress)}
                 onKeyCleared={sk.clear}
@@ -146,10 +147,6 @@ export default function App() {
                     onSelectAsset={setSelectedAsset}
                     onAfterOp={refreshAll}
                     channelStatesKey={channelStatesKey}
-                    sessionKey={sk.sessionKey}
-                    allSessionKeys={sk.allKeys}
-                    onSelectSessionKey={(addr) => addr ? sk.selectKey(addr) : sk.clear()}
-                    onManageSessionKeys={() => setActiveTab('keys')}
                   />
                 </div>
               </div>

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -10,14 +10,12 @@ import type { AppTab } from './components/WalletBar';
 import ActionPanel from './components/ActionPanel';
 import ChannelList from './components/ChannelList';
 import HistoryTab from './components/HistoryTab';
+import SessionKeysTab from './components/SessionKeysTab';
 import UnsupportedChainModal from './components/UnsupportedChainModal';
 import SetHomechainModal from './components/SetHomechainModal';
-import SessionKeyBanner from './components/SessionKeyBanner';
-import SessionKeySetupModal from './components/SessionKeySetupModal';
 
 export default function App() {
   const wallet = useWallet();
-  const [showSkModal, setShowSkModal] = useState(false);
   const [activeTab, setActiveTab] = useState<AppTab>('main');
 
   const sk = useSessionKey(wallet.address);
@@ -49,20 +47,6 @@ export default function App() {
   }, [wallet.chainId, nitro.supportedChains]);
 
   const showUnsupportedModal = !!wallet.address && !!nitro.isConnected && !isChainSupported;
-  const showSkBanner = !!wallet.address && nitro.isConnected && !sk.sessionKey;
-
-  const onConfirmSk = async () => {
-    if (!nitro.client) return;
-    await sk.register(
-      nitro.client,
-      nitro.supportedAssets.map(a => a.symbol),
-    );
-  };
-
-  // Close modal when registration finishes successfully (sessionKey becomes set).
-  useEffect(() => {
-    if (sk.sessionKey && showSkModal) setShowSkModal(false);
-  }, [sk.sessionKey, showSkModal]);
 
   return (
     <div className="min-h-screen flex flex-col">
@@ -102,13 +86,23 @@ export default function App() {
           <div className="text-text-muted text-sm text-center py-16">Connecting to Nitronode…</div>
         ) : (
           <>
-            {showSkBanner && <SessionKeyBanner onSetup={() => setShowSkModal(true)} />}
-
-            {activeTab === 'history' ? (
+{activeTab === 'history' ? (
               <HistoryTab
                 client={nitro.client}
                 address={wallet.address}
                 chains={nitro.supportedChains}
+              />
+            ) : activeTab === 'keys' ? (
+              <SessionKeysTab
+                client={nitro.client}
+                walletClient={wallet.walletClient}
+                address={wallet.address}
+                sessionKey={sk.sessionKey}
+                supportedAssets={nitro.supportedAssets.map(a => a.symbol)}
+                onKeyActivated={(newSk) => sk.selectKey(newSk.sessionKeyAddress)}
+                onKeyCleared={sk.clear}
+                onSelectKey={sk.selectKey}
+                onRefreshAllKeys={sk.refreshAllKeys}
               />
             ) : (
               <div className="grid grid-cols-1 md:grid-cols-[420px_1fr] gap-5 items-start">
@@ -152,6 +146,10 @@ export default function App() {
                     onSelectAsset={setSelectedAsset}
                     onAfterOp={refreshAll}
                     channelStatesKey={channelStatesKey}
+                    sessionKey={sk.sessionKey}
+                    allSessionKeys={sk.allKeys}
+                    onSelectSessionKey={(addr) => addr ? sk.selectKey(addr) : sk.clear()}
+                    onManageSessionKeys={() => setActiveTab('keys')}
                   />
                 </div>
               </div>
@@ -174,15 +172,6 @@ export default function App() {
         />
       )}
 
-      {showSkModal && (
-        <SessionKeySetupModal
-          assets={nitro.supportedAssets.map(a => a.symbol)}
-          isRegistering={sk.isRegistering}
-          mode={sk.sessionKey ? 'renew' : 'setup'}
-          onConfirm={onConfirmSk}
-          onCancel={() => setShowSkModal(false)}
-        />
-      )}
     </div>
   );
 }

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -133,6 +133,7 @@ export default function App() {
                   onSwitchChain={wallet.switchChain}
                   closingAsset={ops.closingAsset}
                   address={wallet.address}
+                  onRefresh={() => { refreshAll(); bumpChannelStates(); }}
                 />
 
                 <div>

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -6,8 +6,10 @@ import { useChannels } from './hooks/useChannels';
 import { useChannelOps } from './hooks/useChannelOps';
 import { useSessionKey } from './hooks/useSessionKey';
 import WalletBar from './components/WalletBar';
+import type { AppTab } from './components/WalletBar';
 import ActionPanel from './components/ActionPanel';
 import ChannelList from './components/ChannelList';
+import HistoryTab from './components/HistoryTab';
 import UnsupportedChainModal from './components/UnsupportedChainModal';
 import SetHomechainModal from './components/SetHomechainModal';
 import SessionKeyBanner from './components/SessionKeyBanner';
@@ -16,6 +18,7 @@ import SessionKeySetupModal from './components/SessionKeySetupModal';
 export default function App() {
   const wallet = useWallet();
   const [showSkModal, setShowSkModal] = useState(false);
+  const [activeTab, setActiveTab] = useState<AppTab>('main');
 
   const sk = useSessionKey(wallet.address);
   const nitro = useNitrolite(wallet.address, wallet.walletClient, sk.sessionKey, wallet.chainId);
@@ -84,10 +87,12 @@ export default function App() {
         nodeError={nitro.nodeError}
         isConnecting={wallet.isConnecting}
         sessionKey={sk.sessionKey}
+        activeTab={activeTab}
         onConnect={wallet.connect}
         onDisconnect={wallet.disconnect}
         onSwitchChain={wallet.switchChain}
         onClearSessionKey={sk.clear}
+        onTabChange={setActiveTab}
       />
 
       <main className="flex-1 mx-auto w-full max-w-[1100px] px-6 py-8">
@@ -99,48 +104,57 @@ export default function App() {
           <>
             {showSkBanner && <SessionKeyBanner onSetup={() => setShowSkModal(true)} />}
 
-            <div className="grid grid-cols-1 md:grid-cols-[360px_1fr] gap-5 items-start">
-              <ActionPanel
-                assets={nitro.supportedAssets}
-                channels={channels.channels}
-                selectedAsset={selectedAsset}
-                onSelectAsset={setSelectedAsset}
-                balance={nitro.balances[selectedAsset]}
-                onChainBalance={nitro.onChainBalances[selectedAsset]}
-                currentChainId={wallet.chainId}
+            {activeTab === 'history' ? (
+              <HistoryTab
+                client={nitro.client}
+                address={wallet.address}
                 chains={nitro.supportedChains}
-                onDeposit={ops.deposit}
-                onWithdraw={ops.withdraw}
-                onTransfer={ops.transfer}
-                depositPhase={ops.depositPhase}
-                withdrawPhase={ops.withdrawPhase}
-                transferPhase={ops.transferPhase}
-                needsApproval={ops.needsApproval}
-                checkDepositAllowance={ops.checkDepositAllowance}
-                disabled={!nitro.client || showUnsupportedModal}
-                onSwitchChain={wallet.switchChain}
-                closingAsset={ops.closingAsset}
               />
-
-              <div>
-                <ChannelList
+            ) : (
+              <div className="grid grid-cols-1 md:grid-cols-[420px_1fr] gap-5 items-start">
+                <ActionPanel
+                  assets={nitro.supportedAssets}
                   channels={channels.channels}
-                  client={nitro.client}
-                  address={wallet.address}
-                  chains={nitro.supportedChains}
-                  currentChainId={wallet.chainId}
-                  balances={nitro.balances}
-                  isLoading={channels.isLoading}
-                  closingAsset={ops.closingAsset}
-                  onRefresh={refreshAll}
-                  onClose={ops.closeChannel}
-                  onSwitchToHomeChain={wallet.switchChain}
+                  selectedAsset={selectedAsset}
                   onSelectAsset={setSelectedAsset}
-                  onAfterOp={refreshAll}
-                  channelStatesKey={channelStatesKey}
+                  balance={nitro.balances[selectedAsset]}
+                  onChainBalance={nitro.onChainBalances[selectedAsset]}
+                  currentChainId={wallet.chainId}
+                  chains={nitro.supportedChains}
+                  onDeposit={ops.deposit}
+                  onWithdraw={ops.withdraw}
+                  onTransfer={ops.transfer}
+                  depositPhase={ops.depositPhase}
+                  withdrawPhase={ops.withdrawPhase}
+                  transferPhase={ops.transferPhase}
+                  needsApproval={ops.needsApproval}
+                  checkDepositAllowance={ops.checkDepositAllowance}
+                  disabled={!nitro.client || showUnsupportedModal}
+                  onSwitchChain={wallet.switchChain}
+                  closingAsset={ops.closingAsset}
+                  address={wallet.address}
                 />
+
+                <div>
+                  <ChannelList
+                    channels={channels.channels}
+                    client={nitro.client}
+                    address={wallet.address}
+                    chains={nitro.supportedChains}
+                    currentChainId={wallet.chainId}
+                    balances={nitro.balances}
+                    isLoading={channels.isLoading}
+                    closingAsset={ops.closingAsset}
+                    onRefresh={refreshAll}
+                    onClose={ops.closeChannel}
+                    onSwitchToHomeChain={wallet.switchChain}
+                    onSelectAsset={setSelectedAsset}
+                    onAfterOp={refreshAll}
+                    channelStatesKey={channelStatesKey}
+                  />
+                </div>
               </div>
-            </div>
+            )}
           </>
         )}
       </main>

--- a/playground/src/components/ActionPanel.tsx
+++ b/playground/src/components/ActionPanel.tsx
@@ -1,14 +1,18 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useCallback } from 'react';
 import { Decimal } from 'decimal.js';
 import type { Address } from 'viem';
 import type { Asset, Blockchain, Channel } from '@yellow-org/sdk';
 import { ChannelType, ChannelStatus } from '@yellow-org/sdk';
-import { formatBalance, isValidAddress } from '../utils';
+import { formatBalance, isValidAddress, FAUCET_ASSETS } from '../utils';
 import { chainDisplayName } from '../chainMeta';
+import { showErrorToast } from '../toastError';
 import TokenSelector from './TokenSelector';
 import type { DepositPhase, WithdrawPhase, TransferPhase } from '../hooks/useChannelOps';
 
-type Tab = 'deposit' | 'withdraw' | 'transfer';
+type Tab = 'deposit' | 'withdraw' | 'transfer' | 'faucet';
+type FaucetPhase = 'idle' | 'requesting' | 'done' | 'rate-limited';
+
+const FAUCET_URL = 'https://nitronode-sandbox.yellow.org/v1/faucet-app/requestTokens';
 
 interface Props {
   assets: Asset[];
@@ -30,6 +34,8 @@ interface Props {
   disabled: boolean;
   onSwitchChain: (chainId: bigint) => void;
   closingAsset: string | null;
+  address: Address | null;
+  onRefresh: () => void;
 }
 
 export default function ActionPanel({
@@ -52,13 +58,18 @@ export default function ActionPanel({
   disabled,
   onSwitchChain,
   closingAsset,
+  address,
+  onRefresh,
 }: Props) {
   const [tab, setTab] = useState<Tab>('deposit');
   const [amount, setAmount] = useState('');
   const [recipient, setRecipient] = useState('');
   const [recipientError, setRecipientError] = useState<string | null>(null);
+  const [faucetPhase, setFaucetPhase] = useState<FaucetPhase>('idle');
   const wasBusyRef = useRef(false);
   const operatingTabRef = useRef<Tab | null>(null);
+
+  const hasFaucet = FAUCET_ASSETS.has(selectedAsset.toLowerCase());
 
   // Pick the chain for deposit/withdraw: current wallet chain if it's supported, else asset's suggested chain.
   const asset = assets.find(a => a.symbol === selectedAsset);
@@ -153,6 +164,42 @@ export default function ActionPanel({
     wasBusyRef.current = isBusy;
   }, [isBusy]);
 
+  // Switch away from faucet tab if selected asset no longer has a faucet.
+  useEffect(() => {
+    if (tab === 'faucet' && !FAUCET_ASSETS.has(selectedAsset.toLowerCase())) {
+      setTab('deposit');
+    }
+  }, [selectedAsset, tab]);
+
+  const requestDrip = useCallback(async () => {
+    if (!address) return;
+    setFaucetPhase('requesting');
+    try {
+      const res = await fetch(FAUCET_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userAddress: address }),
+      });
+      if (!res.ok) {
+        if (res.status === 429) {
+          setFaucetPhase('rate-limited');
+        } else {
+          const msg =
+            res.status === 503 ? 'Faucet service unavailable — try again later' :
+            'Faucet request failed';
+          showErrorToast(msg);
+          setFaucetPhase('idle');
+        }
+        return;
+      }
+      setFaucetPhase('done');
+      onRefresh();
+    } catch {
+      showErrorToast('Faucet request failed — check your connection');
+      setFaucetPhase('idle');
+    }
+  }, [address, onRefresh]);
+
   // For deposit, also require on-chain balance to be loaded before allowing submit.
   const depositBalanceReady = tab !== 'deposit' || onChainBalance != null;
 
@@ -226,119 +273,144 @@ export default function ActionPanel({
         </div>
       </div>
 
-      {/* Tabs + Form — blurred when cross-chain or channel is closing */}
-      <div className="relative">
-        {/* Tabs */}
-        <div className={`flex gap-1 px-5 pt-4 ${isCrossChain || isChannelClosing ? 'blur-sm pointer-events-none select-none' : ''}`}>
-          <button className={`tab ${tab === 'deposit' ? 'active' : ''}`} onClick={() => setTab('deposit')}>
-            Deposit
+      {/* Tabs */}
+      <div className="flex gap-1 px-5 pt-4">
+        <button className={`tab ${tab === 'deposit' ? 'active' : ''}`} onClick={() => setTab('deposit')}>
+          Deposit
+        </button>
+        <button className={`tab ${tab === 'withdraw' ? 'active' : ''}`} onClick={() => setTab('withdraw')}>
+          Withdraw
+        </button>
+        <button className={`tab ${tab === 'transfer' ? 'active' : ''}`} onClick={() => setTab('transfer')}>
+          Transfer
+        </button>
+        {hasFaucet && (
+          <button className={`tab ${tab === 'faucet' ? 'active' : ''}`} onClick={() => setTab('faucet')}>
+            Faucet
           </button>
-          <button className={`tab ${tab === 'withdraw' ? 'active' : ''}`} onClick={() => setTab('withdraw')}>
-            Withdraw
-          </button>
-          <button className={`tab ${tab === 'transfer' ? 'active' : ''}`} onClick={() => setTab('transfer')}>
-            Transfer
-          </button>
-        </div>
+        )}
+      </div>
 
-        {/* Form */}
-        <div className={`px-5 pt-4 pb-5 ${isCrossChain || isChannelClosing ? 'blur-sm pointer-events-none select-none' : ''}`}>
-          {tab === 'transfer' && (
-            <div className="mb-3">
-              <label className="block text-xs text-text-muted mb-1.5">Recipient address</label>
-              <div className={`input ${recipientError ? 'error' : ''}`}>
-                <input
-                  type="text"
-                  placeholder="0x…"
-                  value={recipient}
-                  disabled={isBusy}
-                  onChange={e => {
-                    setRecipient(e.target.value);
-                    if (recipientError) setRecipientError(null);
-                  }}
-                  onBlur={validateRecipient}
-                />
+      {/* Deposit / Withdraw / Transfer form — blurred when cross-chain or channel is closing */}
+      {tab !== 'faucet' && (
+        <div className="relative">
+          <div className={`px-5 pt-4 pb-5 ${isCrossChain || isChannelClosing ? 'blur-sm pointer-events-none select-none' : ''}`}>
+            {tab === 'transfer' && (
+              <div className="mb-3">
+                <label className="block text-xs text-text-muted mb-1.5">Recipient address</label>
+                <div className={`input ${recipientError ? 'error' : ''}`}>
+                  <input
+                    type="text"
+                    placeholder="0x…"
+                    value={recipient}
+                    disabled={isBusy}
+                    onChange={e => {
+                      setRecipient(e.target.value);
+                      if (recipientError) setRecipientError(null);
+                    }}
+                    onBlur={validateRecipient}
+                  />
+                </div>
+                {recipientError && <p className="text-error text-xs mt-1.5">{recipientError}</p>}
               </div>
-              {recipientError && <p className="text-error text-xs mt-1.5">{recipientError}</p>}
+            )}
+
+            <label className="block text-xs text-text-muted mb-1.5">Amount</label>
+            <div className={`input ${amountInputError ? 'error' : ''}`}>
+              <input
+                type="text"
+                inputMode="decimal"
+                placeholder="0.00"
+                value={amount}
+                disabled={isBusy}
+                onChange={e => setAmount(e.target.value)}
+              />
+              <button type="button" className="input-max" onClick={setMax} disabled={isBusy} title="Use max available">
+                MAX
+              </button>
+              <span className="input-suffix">{selectedAsset.toUpperCase() || '—'}</span>
+            </div>
+
+            {amountExceedsChannel && (
+              <p className="text-error text-xs mt-1.5">Amount exceeds Unified balance</p>
+            )}
+            {amountExceedsOnChain && (
+              <p className="text-error text-xs mt-1.5">Amount exceeds on-chain balance</p>
+            )}
+
+            {operatingChainName && tab === 'deposit' && (
+              <p className="text-text-muted text-xs mt-2">
+                Will deposit on <span className="text-text-primary">"{operatingChainName}"</span>
+              </p>
+            )}
+
+            {operatingChainName && tab === 'withdraw' && (
+              <p className="text-text-muted text-xs mt-2">
+                Will withdraw to <span className="text-text-primary">"{operatingChainName}"</span>
+              </p>
+            )}
+
+            <button
+              className="btn btn-primary w-full mt-4"
+              onClick={fire}
+              disabled={!canSubmit}
+            >
+              {isBusy ? (
+                <>
+                  <span className="spinner" />
+                  {buttonLabel}
+                </>
+              ) : (
+                buttonLabel
+              )}
+            </button>
+          </div>
+
+          {/* Cross-chain overlay */}
+          {isCrossChain && !isChannelClosing && (
+            <div className="absolute inset-0 flex flex-col items-center justify-center px-6 gap-3">
+              <p className="text-text-primary text-sm text-center leading-relaxed">
+                Cross-chain operations are not yet supported. Please select this asset home chain to perform operations.
+              </p>
+              <button
+                className="btn btn-primary text-xs px-4 py-2"
+                onClick={() => homeChainId && onSwitchChain(homeChainId)}
+              >
+                Select "{homeChainName ?? 'home chain'}"
+              </button>
             </div>
           )}
 
-          <label className="block text-xs text-text-muted mb-1.5">Amount</label>
-          <div className={`input ${amountInputError ? 'error' : ''}`}>
-            <input
-              type="text"
-              inputMode="decimal"
-              placeholder="0.00"
-              value={amount}
-              disabled={isBusy}
-              onChange={e => setAmount(e.target.value)}
-            />
-            <button type="button" className="input-max" onClick={setMax} disabled={isBusy} title="Use max available">
-              MAX
-            </button>
-            <span className="input-suffix">{selectedAsset.toUpperCase() || '—'}</span>
-          </div>
-
-          {amountExceedsChannel && (
-            <p className="text-error text-xs mt-1.5">Amount exceeds Unified balance</p>
+          {/* Channel-closing overlay */}
+          {isChannelClosing && (
+            <div className="absolute inset-0 flex flex-col items-center justify-center px-6 gap-3">
+              <span className="spinner" />
+              <p className="text-text-primary text-sm text-center leading-relaxed">
+                Channel is being closed
+              </p>
+            </div>
           )}
-          {amountExceedsOnChain && (
-            <p className="text-error text-xs mt-1.5">Amount exceeds on-chain balance</p>
-          )}
+        </div>
+      )}
 
-          {operatingChainName && tab === 'deposit' && (
-            <p className="text-text-muted text-xs mt-2">
-              Will deposit on <span className="text-text-primary">"{operatingChainName}"</span>
-            </p>
-          )}
-
-          {operatingChainName && tab === 'withdraw' && (
-            <p className="text-text-muted text-xs mt-2">
-              Will withdraw to <span className="text-text-primary">"{operatingChainName}"</span>
-            </p>
-          )}
-
+      {/* Faucet tab content */}
+      {tab === 'faucet' && (
+        <div className="px-5 pt-4 pb-5">
+          <p className="text-text-muted text-sm mb-4">
+            Drips 10 {selectedAsset.toUpperCase()} every 5 minutes to your account.
+          </p>
           <button
-            className="btn btn-primary w-full mt-4"
-            onClick={fire}
-            disabled={!canSubmit}
+            className="btn btn-primary w-full"
+            onClick={requestDrip}
+            disabled={faucetPhase !== 'idle' || disabled || !address}
           >
-            {isBusy ? (
-              <>
-                <span className="spinner" />
-                {buttonLabel}
-              </>
-            ) : (
-              buttonLabel
-            )}
+            {faucetPhase === 'requesting' && <><span className="spinner" />Requesting…</>}
+            {faucetPhase === 'done' && 'Drip sent!'}
+            {faucetPhase === 'rate-limited' && 'Rate limit exceeded'}
+            {faucetPhase === 'idle' && 'Request drip'}
           </button>
         </div>
-
-        {/* Cross-chain overlay */}
-        {isCrossChain && !isChannelClosing && (
-          <div className="absolute inset-0 flex flex-col items-center justify-center px-6 gap-3">
-            <p className="text-text-primary text-sm text-center leading-relaxed">
-              Cross-chain operations are not yet supported. Please select this asset home chain to perform operations.
-            </p>
-            <button
-              className="btn btn-primary text-xs px-4 py-2"
-              onClick={() => homeChainId && onSwitchChain(homeChainId)}
-            >
-              Select "{homeChainName ?? 'home chain'}"
-            </button>
-          </div>
-        )}
-
-        {/* Channel-closing overlay */}
-        {isChannelClosing && (
-          <div className="absolute inset-0 flex flex-col items-center justify-center px-6 gap-3">
-            <span className="spinner" />
-            <p className="text-text-primary text-sm text-center leading-relaxed">
-              Channel is being closed
-            </p>
-          </div>
-        )}
-      </div>
+      )}
     </div>
   );
 }

--- a/playground/src/components/ChannelList.tsx
+++ b/playground/src/components/ChannelList.tsx
@@ -7,6 +7,8 @@ import type { Address } from 'viem';
 import ChannelRow from './ChannelRow';
 import IncomingChannelRow from './IncomingChannelRow';
 
+import type { StoredSessionKey } from '../sessionKey';
+
 interface Props {
   channels: Channel[];
   client: Client | null;
@@ -22,6 +24,10 @@ interface Props {
   onSelectAsset: (asset: string) => void;
   onAfterOp: () => void;
   channelStatesKey?: number;
+  sessionKey: StoredSessionKey | null;
+  allSessionKeys: StoredSessionKey[];
+  onSelectSessionKey: (sessionKeyAddress: Address | null) => void;
+  onManageSessionKeys: () => void;
 }
 
 export default function ChannelList({
@@ -39,6 +45,10 @@ export default function ChannelList({
   onSelectAsset,
   onAfterOp,
   channelStatesKey,
+  sessionKey,
+  allSessionKeys,
+  onSelectSessionKey,
+  onManageSessionKeys,
 }: Props) {
   const [expandedIncoming, setExpandedIncoming] = useState<Set<string>>(new Set());
 
@@ -113,6 +123,10 @@ export default function ChannelList({
                 isClosing={closingAsset?.toLowerCase() === c.asset.toLowerCase()}
                 channelStatesKey={channelStatesKey}
                 defaultExpanded={expandedIncoming.has(c.asset.toLowerCase())}
+                sessionKey={sessionKey}
+                allSessionKeys={allSessionKeys}
+                onSelectSessionKey={onSelectSessionKey}
+                onManageSessionKeys={onManageSessionKeys}
               />
             ))}
           </>

--- a/playground/src/components/ChannelList.tsx
+++ b/playground/src/components/ChannelList.tsx
@@ -7,8 +7,6 @@ import type { Address } from 'viem';
 import ChannelRow from './ChannelRow';
 import IncomingChannelRow from './IncomingChannelRow';
 
-import type { StoredSessionKey } from '../sessionKey';
-
 interface Props {
   channels: Channel[];
   client: Client | null;
@@ -24,10 +22,6 @@ interface Props {
   onSelectAsset: (asset: string) => void;
   onAfterOp: () => void;
   channelStatesKey?: number;
-  sessionKey: StoredSessionKey | null;
-  allSessionKeys: StoredSessionKey[];
-  onSelectSessionKey: (sessionKeyAddress: Address | null) => void;
-  onManageSessionKeys: () => void;
 }
 
 export default function ChannelList({
@@ -45,10 +39,6 @@ export default function ChannelList({
   onSelectAsset,
   onAfterOp,
   channelStatesKey,
-  sessionKey,
-  allSessionKeys,
-  onSelectSessionKey,
-  onManageSessionKeys,
 }: Props) {
   const [expandedIncoming, setExpandedIncoming] = useState<Set<string>>(new Set());
 
@@ -123,10 +113,6 @@ export default function ChannelList({
                 isClosing={closingAsset?.toLowerCase() === c.asset.toLowerCase()}
                 channelStatesKey={channelStatesKey}
                 defaultExpanded={expandedIncoming.has(c.asset.toLowerCase())}
-                sessionKey={sessionKey}
-                allSessionKeys={allSessionKeys}
-                onSelectSessionKey={onSelectSessionKey}
-                onManageSessionKeys={onManageSessionKeys}
               />
             ))}
           </>

--- a/playground/src/components/ChannelRow.tsx
+++ b/playground/src/components/ChannelRow.tsx
@@ -127,8 +127,8 @@ export default function ChannelRow({
   const homeChainName = chainDisplayName(channel.blockchainId, homeChainObj?.name);
   const wrongChain = !closed && currentChainId != null && currentChainId !== channel.blockchainId;
 
-  // Signer selector — shown in header for non-closed channels when keys exist
-  const showSkSelector = !closed && allSessionKeys.length > 0;
+  // Signer selector — shown for all non-closed channels; always useful for the "Manage" link
+  const showSkSelector = !closed;
 
   const skIcon = sessionKey && activeSkSecs > 0
     ? <Key size={11} style={{ color: 'var(--accent)', flexShrink: 0 }} />

--- a/playground/src/components/ChannelRow.tsx
+++ b/playground/src/components/ChannelRow.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { ChevronDown, Search } from 'lucide-react';
+import { useState, useRef, useEffect } from 'react';
+import { ChevronDown, Search, Wallet, Check, Key } from 'lucide-react';
 import type { Client, Channel, Blockchain } from '@yellow-org/sdk';
 import { ChannelStatus } from '@yellow-org/sdk';
 import { Decimal } from 'decimal.js';
@@ -8,6 +8,8 @@ import CopyButton from './CopyButton';
 import StateViewer from './StateViewer';
 import { formatAddress } from '../utils';
 import { chainDisplayName } from '../chainMeta';
+import type { StoredSessionKey } from '../sessionKey';
+import { secondsUntilExpiry } from '../sessionKey';
 
 interface Props {
   channel: Channel;
@@ -23,6 +25,66 @@ interface Props {
   isClosing: boolean;
   channelStatesKey?: number;
   defaultExpanded?: boolean;
+  sessionKey: StoredSessionKey | null;
+  allSessionKeys: StoredSessionKey[];
+  onSelectSessionKey: (sessionKeyAddress: Address | null) => void;
+  onManageSessionKeys: () => void;
+}
+
+function formatSkExpiry(sk: StoredSessionKey): string {
+  const secs = secondsUntilExpiry(sk);
+  if (secs <= 0) return 'expired';
+  if (secs < 60) return `${secs}s`;
+  if (secs < 3600) return `${Math.floor(secs / 60)}m`;
+  return `${Math.floor(secs / 3600)}h`;
+}
+
+// Dropdown item component to handle hover via React state cleanly
+function DropdownItem({
+  onClick,
+  selected,
+  disabled,
+  children,
+}: {
+  onClick?: () => void;
+  selected?: boolean;
+  disabled?: boolean;
+  children: React.ReactNode;
+}) {
+  const [hovered, setHovered] = useState(false);
+  const bg = selected
+    ? 'var(--accent-dim)'
+    : hovered && !disabled
+      ? 'rgba(255,255,255,0.05)'
+      : 'transparent';
+
+  if (disabled) {
+    return (
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 10,
+        padding: '8px 14px', fontSize: 13, opacity: 0.4, cursor: 'not-allowed',
+        background: 'transparent', color: 'var(--text-primary)',
+      }}>
+        {children}
+      </div>
+    );
+  }
+
+  return (
+    <button
+      onClick={onClick}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      style={{
+        display: 'flex', alignItems: 'center', gap: 10, width: '100%',
+        padding: '8px 14px', fontSize: 13, border: 'none', cursor: 'pointer',
+        background: bg, color: 'var(--accent)', textAlign: 'left', fontFamily: 'inherit',
+        transition: 'background 0.1s',
+      }}
+    >
+      {children}
+    </button>
+  );
 }
 
 export default function ChannelRow({
@@ -39,21 +101,53 @@ export default function ChannelRow({
   isClosing,
   channelStatesKey,
   defaultExpanded,
+  sessionKey,
+  allSessionKeys,
+  onSelectSessionKey,
+  onManageSessionKeys,
 }: Props) {
   const [expanded, setExpanded] = useState(defaultExpanded ?? false);
+  const [skOpen, setSkOpen] = useState(false);
+  const skRef = useRef<HTMLDivElement>(null);
   const closed = channel.status === ChannelStatus.Closed;
+
+  useEffect(() => {
+    if (!skOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (skRef.current && !skRef.current.contains(e.target as Node)) setSkOpen(false);
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [skOpen]);
+
+  const validKeys = allSessionKeys.filter(k => secondsUntilExpiry(k) > 0);
+  const expiredKeys = allSessionKeys.filter(k => secondsUntilExpiry(k) <= 0);
+  const activeSkSecs = sessionKey ? secondsUntilExpiry(sessionKey) : -1;
   const homeChainObj = chains.find(c => c.id === channel.blockchainId);
   const homeChainName = chainDisplayName(channel.blockchainId, homeChainObj?.name);
   const wrongChain = !closed && currentChainId != null && currentChainId !== channel.blockchainId;
 
+  // Signer selector — shown in header for non-closed channels when keys exist
+  const showSkSelector = !closed && allSessionKeys.length > 0;
+
+  const skIcon = sessionKey && activeSkSecs > 0
+    ? <Key size={11} style={{ color: 'var(--accent)', flexShrink: 0 }} />
+    : <span style={{ width: 6, height: 6, borderRadius: '50%', flexShrink: 0, background: 'var(--text-muted)' }} />;
+
+  const skLabel = sessionKey && activeSkSecs > 0
+    ? `${sessionKey.sessionKeyAddress.slice(0, 5)}…${sessionKey.sessionKeyAddress.slice(-3)}`
+    : 'Wallet';
+
   return (
     <div className={`border border-border rounded-lg mb-2 ${closed ? 'opacity-60' : ''}`}>
+      {/* ── Row header ── */}
       <div
         className={`flex items-center gap-3 px-4 py-3 cursor-pointer hover:bg-bg-elevated/40 rounded-t-lg ${!expanded ? 'rounded-b-lg' : ''}`}
         onClick={() => setExpanded(e => !e)}
       >
+        {/* Asset icon */}
         <span
-          className="inline-flex items-center justify-center w-9 h-9 rounded-full text-xs font-semibold"
+          className="inline-flex items-center justify-center w-9 h-9 rounded-full text-xs font-semibold flex-shrink-0"
           style={{
             background: closed ? 'rgba(102,102,102,0.12)' : 'var(--accent-dim)',
             color: closed ? 'var(--text-muted)' : 'var(--accent)',
@@ -61,8 +155,10 @@ export default function ChannelRow({
         >
           {channel.asset.slice(0, 4).toUpperCase()}
         </span>
+
+        {/* Name + ID */}
         <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2 text-sm font-medium">
+          <div className="flex items-center gap-2 text-sm font-medium flex-wrap">
             <span>{channel.asset.toUpperCase()}</span>
             <span className="tooltip-wrap">
               <button
@@ -75,11 +171,89 @@ export default function ChannelRow({
               </button>
               <span className="tip">Select asset</span>
             </span>
-            <span
-              className="text-[10px] px-1 rounded-xl border border-border bg-bg-surface text-text-muted font-normal"
-            >
+            {/* Chain pill */}
+            <span className="chip text-[10px] font-normal" style={{ padding: '2px 7px', borderRadius: 6 }}>
               {homeChainName}
             </span>
+            {/* Signer selector — inline after chain pill, non-closed only */}
+            {showSkSelector && (
+              <div
+                ref={skRef}
+                style={{ position: 'relative' }}
+                onClick={e => e.stopPropagation()}
+              >
+                <button
+                  className="chip text-xs"
+                  onClick={() => setSkOpen(o => !o)}
+                  style={{ cursor: 'pointer', gap: 5 }}
+                  title="Select signing key"
+                >
+                  {skIcon}
+                  <span className="mono">{skLabel}</span>
+                  <ChevronDown size={10} style={{ transition: 'transform 0.15s', transform: skOpen ? 'rotate(180deg)' : undefined }} />
+                </button>
+
+                {skOpen && (
+                  <div style={{
+                    position: 'absolute', top: 'calc(100% + 6px)', left: 0, zIndex: 50,
+                    background: 'var(--bg-elevated)', border: '1px solid var(--border)',
+                    borderRadius: 10, boxShadow: '0 8px 24px rgba(0,0,0,0.55)',
+                    minWidth: 250, padding: '6px 0',
+                  }}>
+                    <DropdownItem
+                      selected={!sessionKey || activeSkSecs <= 0}
+                      onClick={() => { onSelectSessionKey(null); setSkOpen(false); }}
+                    >
+                      <Wallet size={13} style={{ color: 'var(--text-muted)', flexShrink: 0 }} />
+                      <span style={{ flex: 1, color: 'var(--text-primary)' }}>Wallet (no key)</span>
+                      {(!sessionKey || activeSkSecs <= 0) && <Check size={13} style={{ color: 'var(--accent)', flexShrink: 0 }} />}
+                      <span style={{ fontSize: 11, color: 'var(--text-muted)' }}>MetaMask</span>
+                    </DropdownItem>
+
+                    {validKeys.length > 0 && (
+                      <>
+                        <div style={{ height: 1, background: 'var(--border)', margin: '4px 0' }} />
+                        {validKeys.map(sk => {
+                          const secs = secondsUntilExpiry(sk);
+                          const expiring = secs < 3600;
+                          const selected = sessionKey?.sessionKeyAddress.toLowerCase() === sk.sessionKeyAddress.toLowerCase();
+                          return (
+                            <DropdownItem
+                              key={sk.sessionKeyAddress}
+                              selected={selected}
+                              onClick={() => { onSelectSessionKey(sk.sessionKeyAddress); setSkOpen(false); }}
+                            >
+                              <Key size={12} style={{ flexShrink: 0, color: 'var(--accent)' }} />
+                              <span className="mono" style={{ flex: 1, fontSize: 12, color: 'var(--text-primary)' }}>
+                                {sk.sessionKeyAddress.slice(0, 5)}…{sk.sessionKeyAddress.slice(-3)}
+                              </span>
+                              {selected && <Check size={13} style={{ color: 'var(--accent)', flexShrink: 0 }} />}
+                              <span style={{ fontSize: 11, color: expiring ? '#f97316' : 'var(--text-muted)' }}>
+                                {formatSkExpiry(sk)}
+                              </span>
+                            </DropdownItem>
+                          );
+                        })}
+                      </>
+                    )}
+
+                    {expiredKeys.length > 0 && (
+                      <>
+                        <div style={{ height: 1, background: 'var(--border)', margin: '4px 0' }} />
+                        <div style={{ padding: '6px 14px', fontSize: 11, color: 'var(--text-muted)', fontStyle: 'italic' }}>
+                          And {expiredKeys.length} more expired session {expiredKeys.length === 1 ? 'key' : 'keys'}
+                        </div>
+                      </>
+                    )}
+
+                    <div style={{ height: 1, background: 'var(--border)', margin: '4px 0' }} />
+                    <DropdownItem onClick={() => { onManageSessionKeys(); setSkOpen(false); }}>
+                      Manage session keys →
+                    </DropdownItem>
+                  </div>
+                )}
+              </div>
+            )}
             {wrongChain && (
               <span className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded border border-accent/40 text-accent">
                 wrong chain
@@ -96,12 +270,14 @@ export default function ChannelRow({
             <CopyButton value={channel.channelId} size={11} />
           </div>
         </div>
+
         <ChevronDown
           size={16}
-          className={`text-text-muted transition-transform ${expanded ? 'rotate-180' : ''}`}
+          className={`text-text-muted transition-transform flex-shrink-0 ${expanded ? 'rotate-180' : ''}`}
         />
       </div>
 
+      {/* ── Expanded panel ── */}
       {expanded && (
         <div className="border-t border-border px-4 py-3 space-y-3 bg-bg-base/30 rounded-b-lg">
           {wrongChain && (
@@ -121,7 +297,11 @@ export default function ChannelRow({
 
           {!closed && (
             <div className="flex gap-2">
-              <button className="btn btn-danger btn-sm" onClick={() => onClose(channel.asset, channel.blockchainId)} disabled={isClosing || wrongChain}>
+              <button
+                className="btn btn-danger btn-sm"
+                onClick={() => onClose(channel.asset, channel.blockchainId)}
+                disabled={isClosing || wrongChain}
+              >
                 {isClosing ? <span className="spinner" /> : 'Close channel'}
               </button>
             </div>

--- a/playground/src/components/ChannelRow.tsx
+++ b/playground/src/components/ChannelRow.tsx
@@ -1,5 +1,5 @@
-import { useState, useRef, useEffect } from 'react';
-import { ChevronDown, Search, Wallet, Check, Key } from 'lucide-react';
+import { useState } from 'react';
+import { ChevronDown, Search } from 'lucide-react';
 import type { Client, Channel, Blockchain } from '@yellow-org/sdk';
 import { ChannelStatus } from '@yellow-org/sdk';
 import { Decimal } from 'decimal.js';
@@ -8,8 +8,6 @@ import CopyButton from './CopyButton';
 import StateViewer from './StateViewer';
 import { formatAddress } from '../utils';
 import { chainDisplayName } from '../chainMeta';
-import type { StoredSessionKey } from '../sessionKey';
-import { secondsUntilExpiry } from '../sessionKey';
 
 interface Props {
   channel: Channel;
@@ -25,66 +23,6 @@ interface Props {
   isClosing: boolean;
   channelStatesKey?: number;
   defaultExpanded?: boolean;
-  sessionKey: StoredSessionKey | null;
-  allSessionKeys: StoredSessionKey[];
-  onSelectSessionKey: (sessionKeyAddress: Address | null) => void;
-  onManageSessionKeys: () => void;
-}
-
-function formatSkExpiry(sk: StoredSessionKey): string {
-  const secs = secondsUntilExpiry(sk);
-  if (secs <= 0) return 'expired';
-  if (secs < 60) return `${secs}s`;
-  if (secs < 3600) return `${Math.floor(secs / 60)}m`;
-  return `${Math.floor(secs / 3600)}h`;
-}
-
-// Dropdown item component to handle hover via React state cleanly
-function DropdownItem({
-  onClick,
-  selected,
-  disabled,
-  children,
-}: {
-  onClick?: () => void;
-  selected?: boolean;
-  disabled?: boolean;
-  children: React.ReactNode;
-}) {
-  const [hovered, setHovered] = useState(false);
-  const bg = selected
-    ? 'var(--accent-dim)'
-    : hovered && !disabled
-      ? 'rgba(255,255,255,0.05)'
-      : 'transparent';
-
-  if (disabled) {
-    return (
-      <div style={{
-        display: 'flex', alignItems: 'center', gap: 10,
-        padding: '8px 14px', fontSize: 13, opacity: 0.4, cursor: 'not-allowed',
-        background: 'transparent', color: 'var(--text-primary)',
-      }}>
-        {children}
-      </div>
-    );
-  }
-
-  return (
-    <button
-      onClick={onClick}
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
-      style={{
-        display: 'flex', alignItems: 'center', gap: 10, width: '100%',
-        padding: '8px 14px', fontSize: 13, border: 'none', cursor: 'pointer',
-        background: bg, color: 'var(--accent)', textAlign: 'left', fontFamily: 'inherit',
-        transition: 'background 0.1s',
-      }}
-    >
-      {children}
-    </button>
-  );
 }
 
 export default function ChannelRow({
@@ -101,42 +39,13 @@ export default function ChannelRow({
   isClosing,
   channelStatesKey,
   defaultExpanded,
-  sessionKey,
-  allSessionKeys,
-  onSelectSessionKey,
-  onManageSessionKeys,
 }: Props) {
   const [expanded, setExpanded] = useState(defaultExpanded ?? false);
-  const [skOpen, setSkOpen] = useState(false);
-  const skRef = useRef<HTMLDivElement>(null);
   const closed = channel.status === ChannelStatus.Closed;
 
-  useEffect(() => {
-    if (!skOpen) return;
-    const handler = (e: MouseEvent) => {
-      if (skRef.current && !skRef.current.contains(e.target as Node)) setSkOpen(false);
-    };
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
-  }, [skOpen]);
-
-  const validKeys = allSessionKeys.filter(k => secondsUntilExpiry(k) > 0);
-  const expiredKeys = allSessionKeys.filter(k => secondsUntilExpiry(k) <= 0);
-  const activeSkSecs = sessionKey ? secondsUntilExpiry(sessionKey) : -1;
   const homeChainObj = chains.find(c => c.id === channel.blockchainId);
   const homeChainName = chainDisplayName(channel.blockchainId, homeChainObj?.name);
   const wrongChain = !closed && currentChainId != null && currentChainId !== channel.blockchainId;
-
-  // Signer selector — shown for all non-closed channels; always useful for the "Manage" link
-  const showSkSelector = !closed;
-
-  const skIcon = sessionKey && activeSkSecs > 0
-    ? <Key size={11} style={{ color: 'var(--accent)', flexShrink: 0 }} />
-    : <span style={{ width: 6, height: 6, borderRadius: '50%', flexShrink: 0, background: 'var(--text-muted)' }} />;
-
-  const skLabel = sessionKey && activeSkSecs > 0
-    ? `${sessionKey.sessionKeyAddress.slice(0, 5)}…${sessionKey.sessionKeyAddress.slice(-3)}`
-    : 'Wallet';
 
   return (
     <div className={`border border-border rounded-lg mb-2 ${closed ? 'opacity-60' : ''}`}>
@@ -175,85 +84,6 @@ export default function ChannelRow({
             <span className="chip text-[10px] font-normal" style={{ padding: '2px 7px', borderRadius: 6 }}>
               {homeChainName}
             </span>
-            {/* Signer selector — inline after chain pill, non-closed only */}
-            {showSkSelector && (
-              <div
-                ref={skRef}
-                style={{ position: 'relative' }}
-                onClick={e => e.stopPropagation()}
-              >
-                <button
-                  className="chip text-xs"
-                  onClick={() => setSkOpen(o => !o)}
-                  style={{ cursor: 'pointer', gap: 5 }}
-                  title="Select signing key"
-                >
-                  {skIcon}
-                  <span className="mono">{skLabel}</span>
-                  <ChevronDown size={10} style={{ transition: 'transform 0.15s', transform: skOpen ? 'rotate(180deg)' : undefined }} />
-                </button>
-
-                {skOpen && (
-                  <div style={{
-                    position: 'absolute', top: 'calc(100% + 6px)', left: 0, zIndex: 50,
-                    background: 'var(--bg-elevated)', border: '1px solid var(--border)',
-                    borderRadius: 10, boxShadow: '0 8px 24px rgba(0,0,0,0.55)',
-                    minWidth: 250, padding: '6px 0',
-                  }}>
-                    <DropdownItem
-                      selected={!sessionKey || activeSkSecs <= 0}
-                      onClick={() => { onSelectSessionKey(null); setSkOpen(false); }}
-                    >
-                      <Wallet size={13} style={{ color: 'var(--text-muted)', flexShrink: 0 }} />
-                      <span style={{ flex: 1, color: 'var(--text-primary)' }}>Wallet (no key)</span>
-                      {(!sessionKey || activeSkSecs <= 0) && <Check size={13} style={{ color: 'var(--accent)', flexShrink: 0 }} />}
-                      <span style={{ fontSize: 11, color: 'var(--text-muted)' }}>MetaMask</span>
-                    </DropdownItem>
-
-                    {validKeys.length > 0 && (
-                      <>
-                        <div style={{ height: 1, background: 'var(--border)', margin: '4px 0' }} />
-                        {validKeys.map(sk => {
-                          const secs = secondsUntilExpiry(sk);
-                          const expiring = secs < 3600;
-                          const selected = sessionKey?.sessionKeyAddress.toLowerCase() === sk.sessionKeyAddress.toLowerCase();
-                          return (
-                            <DropdownItem
-                              key={sk.sessionKeyAddress}
-                              selected={selected}
-                              onClick={() => { onSelectSessionKey(sk.sessionKeyAddress); setSkOpen(false); }}
-                            >
-                              <Key size={12} style={{ flexShrink: 0, color: 'var(--accent)' }} />
-                              <span className="mono" style={{ flex: 1, fontSize: 12, color: 'var(--text-primary)' }}>
-                                {sk.sessionKeyAddress.slice(0, 5)}…{sk.sessionKeyAddress.slice(-3)}
-                              </span>
-                              {selected && <Check size={13} style={{ color: 'var(--accent)', flexShrink: 0 }} />}
-                              <span style={{ fontSize: 11, color: expiring ? '#f97316' : 'var(--text-muted)' }}>
-                                {formatSkExpiry(sk)}
-                              </span>
-                            </DropdownItem>
-                          );
-                        })}
-                      </>
-                    )}
-
-                    {expiredKeys.length > 0 && (
-                      <>
-                        <div style={{ height: 1, background: 'var(--border)', margin: '4px 0' }} />
-                        <div style={{ padding: '6px 14px', fontSize: 11, color: 'var(--text-muted)', fontStyle: 'italic' }}>
-                          And {expiredKeys.length} more expired session {expiredKeys.length === 1 ? 'key' : 'keys'}
-                        </div>
-                      </>
-                    )}
-
-                    <div style={{ height: 1, background: 'var(--border)', margin: '4px 0' }} />
-                    <DropdownItem onClick={() => { onManageSessionKeys(); setSkOpen(false); }}>
-                      Manage session keys →
-                    </DropdownItem>
-                  </div>
-                )}
-              </div>
-            )}
             {wrongChain && (
               <span className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded border border-accent/40 text-accent">
                 wrong chain

--- a/playground/src/components/HistoryTab.tsx
+++ b/playground/src/components/HistoryTab.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { RefreshCw, ChevronRight, ChevronDown, Filter, X, Copy, Check } from 'lucide-react';
 import { TransactionType } from '@yellow-org/sdk';
-import type { Client, Transaction, Blockchain } from '@yellow-org/sdk';
+import type { Client, Transaction, Blockchain, State } from '@yellow-org/sdk';
 import type { Address } from 'viem';
 import { tokenIconUrl } from '../icons';
 import { formatAddress, timeAgo } from '../utils';
@@ -94,6 +94,30 @@ function isOnChainTx(type: TransactionType): boolean {
     type === TransactionType.EscrowDeposit ||
     type === TransactionType.EscrowWithdraw ||
     type === TransactionType.Finalize;
+}
+
+type ConfirmStatus = 'cosigned' | 'pending';
+
+function getConfirmStatus(
+  tx: Transaction,
+  address: Address | null,
+  latestStates: Record<string, State | null>,
+): ConfirmStatus {
+  // On-chain txs have their own confirmation model; off-chain senders are co-signed synchronously.
+  if (isOnChainTx(tx.txType)) return 'cosigned';
+  if (!address || tx.toAccount.toLowerCase() !== address.toLowerCase()) return 'cosigned';
+
+  const state = latestStates[tx.asset];
+  if (!state || !tx.receiverNewStateId) return 'cosigned';
+
+  // Pending = latest state IS this receiver state AND the user hasn't signed it yet.
+  if (
+    state.id.toLowerCase() === tx.receiverNewStateId.toLowerCase() &&
+    state.nodeSig &&
+    !state.userSig
+  ) return 'pending';
+
+  return 'cosigned';
 }
 
 // ── Sub-components ────────────────────────────────────────────────────────────
@@ -215,10 +239,11 @@ function FilterIcon({ active }: { active: boolean }) {
 
 type TsFormat = 'date' | 'unix';
 
-function DetailPanel({ tx, tsFormat, onToggleTsFormat }: {
+function DetailPanel({ tx, tsFormat, onToggleTsFormat, confirmStatus }: {
   tx: Transaction;
   tsFormat: TsFormat;
   onToggleTsFormat: () => void;
+  confirmStatus: ConfirmStatus;
 }) {
   const onChain = isOnChainTx(tx.txType);
   const tsDate = tx.createdAt.toISOString().replace('T', ' ').slice(0, 19) + ' UTC';
@@ -277,7 +302,7 @@ function DetailPanel({ tx, tsFormat, onToggleTsFormat }: {
         <span style={{ fontSize: '11px', color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.05em', display: 'block', marginBottom: '8px' }}>
           Confirmation
         </span>
-        <ConfirmTimeline onChain={onChain} />
+        <ConfirmTimeline onChain={onChain} status={confirmStatus} />
       </div>
     </div>
   );
@@ -319,24 +344,33 @@ function DetailField({ label, value, displayValue, mono = true, onCopy }: {
   );
 }
 
-function ConfirmTimeline({ onChain }: { onChain: boolean }) {
-  const steps = onChain
-    ? ['Signed', 'Broadcasted', 'Confirmed']
-    : ['Signed', 'Co-signed'];
+function ConfirmTimeline({ onChain, status }: { onChain: boolean; status: ConfirmStatus }) {
+  type Step = { label: string; done: boolean };
+  const steps: Step[] = onChain
+    ? [
+        { label: 'Signed', done: true },
+        { label: 'Broadcasted', done: true },
+        { label: 'Confirmed', done: true },
+      ]
+    : [
+        { label: 'Signed', done: true },
+        { label: 'Co-signed', done: status === 'cosigned' },
+      ];
 
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: 0 }}>
-      {steps.map((step, i) => (
-        <span key={step} style={{ display: 'inline-flex', alignItems: 'center' }}>
+      {steps.map(({ label, done }, i) => (
+        <span key={label} style={{ display: 'inline-flex', alignItems: 'center' }}>
           <span style={{
             fontSize: '12px',
-            color: 'var(--text-primary)',
-            background: 'rgba(34,197,94,0.12)',
-            border: '1px solid rgba(34,197,94,0.3)',
             borderRadius: '4px',
             padding: '2px 8px',
+            ...(done
+              ? { color: 'var(--text-primary)', background: 'rgba(34,197,94,0.12)', border: '1px solid rgba(34,197,94,0.3)' }
+              : { color: 'var(--text-muted)', background: 'rgba(255,255,255,0.04)', border: '1px solid var(--border)' }
+            ),
           }}>
-            {step}
+            {label}{!done ? '…' : ''}
           </span>
           {i < steps.length - 1 && (
             <span style={{ width: '28px', height: '1px', background: 'var(--border)', display: 'inline-block', margin: '0 2px' }} />
@@ -416,6 +450,8 @@ export default function HistoryTab({ client, address }: Props) {
   const [pendingFrom, setPendingFrom] = useState('');
   const [pendingTo, setPendingTo] = useState('');
 
+  const [latestStates, setLatestStates] = useState<Record<string, State | null>>({});
+
   const [openPopover, setOpenPopover] = useState<'type' | 'asset' | 'from' | 'to' | null>(null);
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [page, setPage] = useState(1);
@@ -448,6 +484,24 @@ export default function HistoryTab({ client, address }: Props) {
     setPage(1);
     fetchTxs();
   }, [fetchTxs]);
+
+  // After transactions load, fetch the latest state for each asset where the user is receiver.
+  useEffect(() => {
+    if (!client || !address || allTxs.length === 0) return;
+    const assets = [...new Set(
+      allTxs
+        .filter(tx => !isOnChainTx(tx.txType) && tx.toAccount.toLowerCase() === address.toLowerCase())
+        .map(tx => tx.asset)
+    )];
+    if (assets.length === 0) return;
+    Promise.all(
+      assets.map(asset =>
+        client.getLatestState(address, asset, false)
+          .then(state => [asset, state] as const)
+          .catch(() => [asset, null] as const)
+      )
+    ).then(entries => setLatestStates(Object.fromEntries(entries)));
+  }, [client, address, allTxs]);
 
   // Close popover on outside click
   useEffect(() => {
@@ -785,6 +839,7 @@ export default function HistoryTab({ client, address }: Props) {
                   const variant = txVariant(tx.txType);
                   const { color: amtColor } = VARIANT_STYLE[variant];
                   const prefix = amountPrefix(tx.txType, tx.toAccount, address);
+                  const confirmStatus = getConfirmStatus(tx, address, latestStates);
 
                   return (
                     <>
@@ -873,6 +928,7 @@ export default function HistoryTab({ client, address }: Props) {
                               tx={tx}
                               tsFormat={tsFormat}
                               onToggleTsFormat={() => setTsFormat(f => f === 'date' ? 'unix' : 'date')}
+                              confirmStatus={confirmStatus}
                             />
                           </td>
                         </tr>

--- a/playground/src/components/HistoryTab.tsx
+++ b/playground/src/components/HistoryTab.tsx
@@ -1,0 +1,922 @@
+import { useState, useEffect, useCallback } from 'react';
+import { RefreshCw, ChevronRight, ChevronDown, Filter, X, Copy, Check } from 'lucide-react';
+import { TransactionType } from '@yellow-org/sdk';
+import type { Client, Transaction, Blockchain } from '@yellow-org/sdk';
+import type { Address } from 'viem';
+import { tokenIconUrl } from '../icons';
+import { formatAddress, timeAgo } from '../utils';
+
+function formatStateId(id: string): string {
+  if (id.length <= 14) return id;
+  return `${id.slice(0, 6)}…${id.slice(-6)}`;
+}
+
+const PAGE_SIZE = 25;
+const FETCH_LIMIT = 200;
+
+type TxVariant = 'deposit' | 'withdraw' | 'transfer' | 'finalize' | 'muted';
+
+interface HistoryFilters {
+  types: TransactionType[];
+  assets: string[];
+  fromAddress: string;
+  toAddress: string;
+}
+
+interface Props {
+  client: Client | null;
+  address: Address | null;
+  chains: Blockchain[];
+}
+
+const EMPTY_FILTERS: HistoryFilters = { types: [], assets: [], fromAddress: '', toAddress: '' };
+
+const TX_LABELS: Partial<Record<TransactionType, string>> = {
+  [TransactionType.HomeDeposit]:    'Home Deposit',
+  [TransactionType.HomeWithdrawal]: 'Home Withdrawal',
+  [TransactionType.EscrowDeposit]:  'Escrow Deposit',
+  [TransactionType.EscrowWithdraw]: 'Escrow Withdraw',
+  [TransactionType.Transfer]:       'Transfer',
+  [TransactionType.Commit]:         'Commit',
+  [TransactionType.Release]:        'Release',
+  [TransactionType.Rebalance]:      'Rebalance',
+  [TransactionType.Migrate]:        'Migrate',
+  [TransactionType.EscrowLock]:     'Escrow Lock',
+  [TransactionType.MutualLock]:     'Mutual Lock',
+  [TransactionType.Finalize]:       'Finalize',
+};
+
+const ALL_TX_TYPES = [
+  TransactionType.HomeDeposit,
+  TransactionType.HomeWithdrawal,
+  TransactionType.EscrowDeposit,
+  TransactionType.EscrowWithdraw,
+  TransactionType.Transfer,
+  TransactionType.Commit,
+  TransactionType.Release,
+  TransactionType.Rebalance,
+  TransactionType.Migrate,
+  TransactionType.EscrowLock,
+  TransactionType.MutualLock,
+  TransactionType.Finalize,
+];
+
+function txVariant(type: TransactionType): TxVariant {
+  if (type === TransactionType.HomeDeposit || type === TransactionType.EscrowDeposit) return 'deposit';
+  if (type === TransactionType.HomeWithdrawal || type === TransactionType.EscrowWithdraw) return 'withdraw';
+  if (type === TransactionType.Transfer) return 'transfer';
+  if (type === TransactionType.Finalize) return 'finalize';
+  return 'muted';
+}
+
+const VARIANT_STYLE: Record<TxVariant, { color: string; bg: string }> = {
+  deposit:  { color: 'var(--success)',    bg: 'rgba(34,197,94,0.12)'   },
+  withdraw: { color: 'var(--error)',      bg: 'rgba(239,68,68,0.12)'   },
+  transfer: { color: '#60a5fa',           bg: 'rgba(96,165,250,0.12)'  },
+  finalize: { color: '#a78bfa',           bg: 'rgba(167,139,250,0.12)' },
+  muted:    { color: 'var(--text-muted)', bg: 'rgba(255,255,255,0.06)' },
+};
+
+function amountPrefix(type: TransactionType): string {
+  const v = txVariant(type);
+  if (v === 'deposit') return '+';
+  if (v === 'withdraw' || v === 'transfer') return '−';
+  return '';
+}
+
+function isOnChainTx(type: TransactionType): boolean {
+  return type === TransactionType.HomeDeposit ||
+    type === TransactionType.HomeWithdrawal ||
+    type === TransactionType.EscrowDeposit ||
+    type === TransactionType.EscrowWithdraw ||
+    type === TransactionType.Finalize;
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function TypeBadge({ type, isActive, onClick }: {
+  type: TransactionType;
+  isActive: boolean;
+  onClick?: (e: React.MouseEvent) => void;
+}) {
+  const label = TX_LABELS[type] ?? `Type ${type}`;
+  const { color, bg } = VARIANT_STYLE[txVariant(type)];
+  return (
+    <span
+      className={`qf${isActive ? ' qf-on' : ''}`}
+      data-tip={isActive ? `Remove filter: ${label}` : `Quick filter: ${label}`}
+      onClick={onClick}
+    >
+      <span style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        fontSize: '11px',
+        fontWeight: 500,
+        padding: '2px 7px',
+        borderRadius: '4px',
+        background: bg,
+        color,
+        whiteSpace: 'nowrap',
+      }}>
+        {label}
+      </span>
+    </span>
+  );
+}
+
+function AddrCell({ value, isActive, onClick }: {
+  value: string;
+  isActive: boolean;
+  onClick: (e: React.MouseEvent) => void;
+}) {
+  const [copied, setCopied] = useState(false);
+  const display = formatAddress(value);
+
+  const onCopy = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch { /* clipboard denied */ }
+  };
+
+  return (
+    <div className="addr-cell">
+      <span
+        className={`qf${isActive ? ' qf-on' : ''}`}
+        data-tip={isActive ? `Remove filter: ${display}` : `Quick filter: ${display}`}
+        onClick={onClick}
+      >
+        <span className="mono" style={{ fontSize: '12px', color: 'var(--text-muted)' }}>{display}</span>
+      </span>
+      <button className="copy-btn-addr" onClick={onCopy} title={copied ? 'Copied' : 'Copy address'}>
+        {copied
+          ? <Check size={11} style={{ color: 'var(--success)' }} />
+          : <Copy size={11} />}
+      </button>
+    </div>
+  );
+}
+
+function AssetCell({ asset, isActive, onClick }: {
+  asset: string;
+  isActive: boolean;
+  onClick: (e: React.MouseEvent) => void;
+}) {
+  const iconUrl = tokenIconUrl(asset);
+  const [imgErr, setImgErr] = useState(false);
+  return (
+    <span
+      className={`qf${isActive ? ' qf-on' : ''}`}
+      data-tip={isActive ? `Remove filter: ${asset}` : `Quick filter: ${asset}`}
+      onClick={onClick}
+      style={{ display: 'inline-flex', alignItems: 'center', gap: '6px' }}
+    >
+      {iconUrl && !imgErr ? (
+        <img
+          src={iconUrl}
+          alt={asset}
+          width={16}
+          height={16}
+          style={{ borderRadius: '50%', flexShrink: 0 }}
+          onError={() => setImgErr(true)}
+        />
+      ) : (
+        <span style={{
+          width: 16, height: 16, borderRadius: '50%', background: 'var(--border)',
+          display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+          fontSize: '9px', fontWeight: 700, color: 'var(--text-muted)', flexShrink: 0,
+        }}>
+          {asset.slice(0, 1).toUpperCase()}
+        </span>
+      )}
+      <span style={{ fontWeight: 500, fontSize: '13px' }}>{asset.toUpperCase()}</span>
+    </span>
+  );
+}
+
+// ── Filter popover ────────────────────────────────────────────────────────────
+
+function FilterIcon({ active }: { active: boolean }) {
+  return (
+    <Filter
+      size={11}
+      style={{ color: active ? 'var(--accent)' : 'var(--text-muted)', flexShrink: 0 }}
+    />
+  );
+}
+
+// ── Detail panel ─────────────────────────────────────────────────────────────
+
+type TsFormat = 'date' | 'unix';
+
+function DetailPanel({ tx, tsFormat, onToggleTsFormat }: {
+  tx: Transaction;
+  tsFormat: TsFormat;
+  onToggleTsFormat: () => void;
+}) {
+  const onChain = isOnChainTx(tx.txType);
+  const tsDate = tx.createdAt.toISOString().replace('T', ' ').slice(0, 19) + ' UTC';
+  const tsUnix = Math.floor(tx.createdAt.getTime() / 1000).toString();
+  const tsValue = tsFormat === 'date' ? tsDate : tsUnix;
+  const tsTip = tsFormat === 'date' ? 'Display as Unix seconds' : 'Display as UTC date';
+
+  const copyInline = (value: string) => {
+    navigator.clipboard.writeText(value).catch(() => {});
+  };
+
+  return (
+    <div style={{
+      width: '100%',
+      padding: '16px 20px',
+      borderTop: '1px solid var(--border)',
+      background: 'rgba(10,10,10,0.3)',
+      display: 'grid',
+      gridTemplateColumns: 'minmax(0,1fr) minmax(0,1fr) minmax(0,1fr)',
+      gap: '16px 12px',
+      boxSizing: 'border-box',
+    }}>
+      <DetailField
+        label="Sender new state ID"
+        value={tx.senderNewStateId}
+        displayValue={tx.senderNewStateId ? formatStateId(tx.senderNewStateId) : undefined}
+        onCopy={copyInline}
+      />
+      <DetailField
+        label="Receiver new state ID"
+        value={tx.receiverNewStateId}
+        displayValue={tx.receiverNewStateId ? formatStateId(tx.receiverNewStateId) : undefined}
+        onCopy={copyInline}
+      />
+      {/* Timestamp — rendered inline so the value itself is the interactive target */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '4px', minWidth: 0 }}>
+        <span style={{ fontSize: '11px', color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+          Timestamp
+        </span>
+        <span
+          className="ts-toggle"
+          data-tip={tsTip}
+          onClick={e => { e.stopPropagation(); onToggleTsFormat(); }}
+        >
+          <span
+            className={tsFormat === 'unix' ? 'mono' : undefined}
+            style={{ fontSize: '12px', color: 'var(--text-primary)' }}
+          >
+            {tsValue}
+          </span>
+        </span>
+      </div>
+
+      {/* Confirmation timeline — spans all 3 columns */}
+      <div style={{ gridColumn: '1 / -1' }}>
+        <span style={{ fontSize: '11px', color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.05em', display: 'block', marginBottom: '8px' }}>
+          Confirmation
+        </span>
+        <ConfirmTimeline onChain={onChain} />
+      </div>
+    </div>
+  );
+}
+
+function DetailField({ label, value, displayValue, mono = true, onCopy }: {
+  label: string;
+  value?: string;
+  displayValue?: string;
+  mono?: boolean;
+  onCopy?: (v: string) => void;
+}) {
+  const shown = displayValue ?? value;
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '4px', minWidth: 0 }}>
+      <span style={{ fontSize: '11px', color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>{label}</span>
+      {shown ? (
+        <span style={{ display: 'inline-flex', alignItems: 'center', gap: '6px', minWidth: 0 }}>
+          <span
+            className={mono ? 'mono' : undefined}
+            style={{ fontSize: '12px', color: 'var(--text-primary)', wordBreak: 'break-all', minWidth: 0 }}
+          >
+            {shown}
+          </span>
+          {onCopy && value && (
+            <button
+              onClick={e => { e.stopPropagation(); onCopy(value); }}
+              style={{ background: 'none', border: 'none', cursor: 'pointer', padding: '1px', color: 'var(--text-muted)', display: 'inline-flex', flexShrink: 0 }}
+              title="Copy"
+            >
+              <Copy size={11} />
+            </button>
+          )}
+        </span>
+      ) : (
+        <span style={{ fontSize: '12px', color: 'var(--text-muted)' }}>—</span>
+      )}
+    </div>
+  );
+}
+
+function ConfirmTimeline({ onChain }: { onChain: boolean }) {
+  const steps = onChain
+    ? ['Signed', 'Broadcasted', 'Confirmed']
+    : ['Signed', 'Co-signed'];
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 0 }}>
+      {steps.map((step, i) => (
+        <span key={step} style={{ display: 'inline-flex', alignItems: 'center' }}>
+          <span style={{
+            fontSize: '12px',
+            color: 'var(--text-primary)',
+            background: 'rgba(34,197,94,0.12)',
+            border: '1px solid rgba(34,197,94,0.3)',
+            borderRadius: '4px',
+            padding: '2px 8px',
+          }}>
+            {step}
+          </span>
+          {i < steps.length - 1 && (
+            <span style={{ width: '28px', height: '1px', background: 'var(--border)', display: 'inline-block', margin: '0 2px' }} />
+          )}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+// ── Table header with filter popover ─────────────────────────────────────────
+
+function TxIdCell({ id }: { id: string }) {
+  const [copied, setCopied] = useState(false);
+  const display = formatAddress(id);
+
+  const onCopy = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    try {
+      await navigator.clipboard.writeText(id);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch { /* clipboard denied */ }
+  };
+
+  return (
+    <div className="addr-cell">
+      <span className="mono" style={{ fontSize: '12px', color: 'var(--text-muted)' }}>{display}</span>
+      <button className="copy-btn-addr" onClick={onCopy} title={copied ? 'Copied' : 'Copy ID'}>
+        {copied
+          ? <Check size={11} style={{ color: 'var(--success)' }} />
+          : <Copy size={11} />}
+      </button>
+    </div>
+  );
+}
+
+function ThFilter({ label, isActive, isOpen, onToggle, width, children }: {
+  label: string;
+  isActive: boolean;
+  isOpen: boolean;
+  onToggle: (e: React.MouseEvent) => void;
+  width?: string;
+  children?: React.ReactNode;
+}) {
+  return (
+    <th style={{ padding: '10px 12px', textAlign: 'left', fontWeight: 500, fontSize: '12px', color: 'var(--text-muted)', whiteSpace: 'nowrap', ...(width ? { width } : {}) }}>
+      <div className="th-popover-wrap">
+        <div
+          className={`th-inner filterable${isActive ? ' filter-active' : ''}`}
+          onClick={onToggle}
+        >
+          {label}
+          <FilterIcon active={isActive} />
+        </div>
+        {isOpen && (
+          <div className="th-popover" onClick={e => e.stopPropagation()}>
+            {children}
+          </div>
+        )}
+      </div>
+    </th>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+export default function HistoryTab({ client, address }: Props) {
+  const [allTxs, setAllTxs] = useState<Transaction[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [filters, setFilters] = useState<HistoryFilters>(EMPTY_FILTERS);
+  // pending filter edits inside popovers before Apply
+  const [pendingTypes, setPendingTypes] = useState<TransactionType[]>([]);
+  const [pendingAssets, setPendingAssets] = useState<string[]>([]);
+  const [pendingFrom, setPendingFrom] = useState('');
+  const [pendingTo, setPendingTo] = useState('');
+
+  const [openPopover, setOpenPopover] = useState<'type' | 'asset' | 'from' | 'to' | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [page, setPage] = useState(1);
+  const [tsFormat, setTsFormat] = useState<TsFormat>('date');
+  const [, setTick] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(() => setTick(t => t + 1), 30000);
+    return () => clearInterval(id);
+  }, []);
+
+  const fetchTxs = useCallback(async () => {
+    if (!client || !address) return;
+    setIsLoading(true);
+    setError(null);
+    try {
+      const { transactions } = await client.getTransactions(address, {
+        pageSize: FETCH_LIMIT,
+        page: 1,
+      });
+      setAllTxs(transactions.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime()));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load transactions');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [client, address]);
+
+  useEffect(() => {
+    setPage(1);
+    fetchTxs();
+  }, [fetchTxs]);
+
+  // Close popover on outside click
+  useEffect(() => {
+    if (!openPopover) return;
+    const handler = (e: MouseEvent) => {
+      if (!(e.target as Element).closest('.th-popover-wrap')) {
+        setOpenPopover(null);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [openPopover]);
+
+  // Client-side filter
+  const filteredTxs = allTxs.filter(tx => {
+    if (filters.types.length && !filters.types.includes(tx.txType)) return false;
+    if (filters.assets.length && !filters.assets.includes(tx.asset)) return false;
+    if (filters.fromAddress && !tx.fromAccount.toLowerCase().includes(filters.fromAddress.toLowerCase())) return false;
+    if (filters.toAddress && !tx.toAccount.toLowerCase().includes(filters.toAddress.toLowerCase())) return false;
+    return true;
+  });
+
+  const totalCount = filteredTxs.length;
+  const pageCount = Math.max(1, Math.ceil(totalCount / PAGE_SIZE));
+  const pageTxs = filteredTxs.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+
+  const availableAssets = [...new Set(allTxs.map(t => t.asset))].sort();
+
+  // Active filter count for the badge
+  const activeFilterCount =
+    (filters.types.length ? 1 : 0) +
+    (filters.assets.length ? 1 : 0) +
+    (filters.fromAddress ? 1 : 0) +
+    (filters.toAddress ? 1 : 0);
+
+  // ── Quick filter handlers ──────────────────────────────────────────────────
+
+  const toggleType = (type: TransactionType, e: React.MouseEvent) => {
+    e.stopPropagation();
+    setFilters(f => ({
+      ...f,
+      types: f.types.includes(type) ? f.types.filter(t => t !== type) : [...f.types, type],
+    }));
+    setPage(1);
+  };
+
+  const toggleAsset = (asset: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    setFilters(f => ({
+      ...f,
+      assets: f.assets.includes(asset) ? f.assets.filter(a => a !== asset) : [...f.assets, asset],
+    }));
+    setPage(1);
+  };
+
+  const toggleFrom = (addr: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    setFilters(f => ({ ...f, fromAddress: f.fromAddress === addr ? '' : addr }));
+    setPage(1);
+  };
+
+  const toggleTo = (addr: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    setFilters(f => ({ ...f, toAddress: f.toAddress === addr ? '' : addr }));
+    setPage(1);
+  };
+
+  // ── Popover open/close helpers ─────────────────────────────────────────────
+
+  const openFilter = (col: typeof openPopover, e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (openPopover === col) {
+      setOpenPopover(null);
+      return;
+    }
+    // Sync pending state with current filters
+    setPendingTypes(filters.types);
+    setPendingAssets(filters.assets);
+    setPendingFrom(filters.fromAddress);
+    setPendingTo(filters.toAddress);
+    setOpenPopover(col);
+  };
+
+  const applyTypeFilter = () => {
+    setFilters(f => ({ ...f, types: pendingTypes }));
+    setOpenPopover(null);
+    setPage(1);
+  };
+
+  const applyAssetFilter = () => {
+    setFilters(f => ({ ...f, assets: pendingAssets }));
+    setOpenPopover(null);
+    setPage(1);
+  };
+
+  const applyFromFilter = () => {
+    setFilters(f => ({ ...f, fromAddress: pendingFrom }));
+    setOpenPopover(null);
+    setPage(1);
+  };
+
+  const applyToFilter = () => {
+    setFilters(f => ({ ...f, toAddress: pendingTo }));
+    setOpenPopover(null);
+    setPage(1);
+  };
+
+  const clearFilter = (col: keyof HistoryFilters) => {
+    setFilters(f => ({
+      ...f,
+      ...(col === 'types' ? { types: [] } : {}),
+      ...(col === 'assets' ? { assets: [] } : {}),
+      ...(col === 'fromAddress' ? { fromAddress: '' } : {}),
+      ...(col === 'toAddress' ? { toAddress: '' } : {}),
+    }));
+    setOpenPopover(null);
+    setPage(1);
+  };
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+
+  const thBase: React.CSSProperties = {
+    padding: '10px 12px',
+    textAlign: 'left',
+    fontWeight: 500,
+    fontSize: '12px',
+    color: 'var(--text-muted)',
+    whiteSpace: 'nowrap',
+    borderBottom: '1px solid var(--border)',
+    background: 'var(--bg-elevated)',
+  };
+
+  const tdBase: React.CSSProperties = {
+    padding: '10px 12px',
+    verticalAlign: 'middle',
+    borderBottom: '1px solid var(--border)',
+  };
+
+  return (
+    <div className="card">
+      {/* Card header */}
+      <div className="card-header">
+        <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+          <span className="card-title">Transaction History</span>
+          {activeFilterCount > 0 && (
+            <span style={{
+              fontSize: '11px',
+              color: 'var(--accent)',
+              background: 'var(--accent-dim)',
+              borderRadius: '999px',
+              padding: '2px 8px',
+            }}>
+              {activeFilterCount} filter{activeFilterCount !== 1 ? 's' : ''}
+            </span>
+          )}
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          {activeFilterCount > 0 && (
+            <button
+              className="btn btn-ghost btn-sm"
+              onClick={() => { setFilters(EMPTY_FILTERS); setPage(1); }}
+            >
+              <X size={11} />
+              Clear filters
+            </button>
+          )}
+          <button
+            className="btn btn-ghost btn-sm"
+            onClick={fetchTxs}
+            disabled={isLoading}
+          >
+            <RefreshCw size={12} className={isLoading ? 'animate-spin' : ''} />
+            {isLoading ? 'Loading…' : 'Refresh'}
+          </button>
+        </div>
+      </div>
+
+      {/* Error state */}
+      {error && (
+        <div style={{ padding: '16px 20px', color: 'var(--error)', fontSize: '13px' }}>
+          {error}
+        </div>
+      )}
+
+      {/* Empty / loading state */}
+      {!error && !isLoading && allTxs.length === 0 && (
+        <div style={{ padding: '40px 20px', textAlign: 'center', color: 'var(--text-muted)', fontSize: '13px' }}>
+          {client && address ? 'No transactions found.' : 'Connect wallet to view history.'}
+        </div>
+      )}
+
+      {/* Table */}
+      {(allTxs.length > 0 || isLoading) && (
+        <div style={{ overflowX: 'auto' }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '13px', tableLayout: 'fixed' }}>
+            <thead>
+              <tr>
+                {/* expand chevron */}
+                <th style={{ ...thBase, width: '36px', padding: '10px 8px 10px 16px' }} />
+
+                {/* Time */}
+                <th style={{ ...thBase, width: '80px' }}>Time</th>
+
+                {/* Type with filter popover */}
+                <ThFilter
+                  label="Type"
+                  isActive={filters.types.length > 0}
+                  isOpen={openPopover === 'type'}
+                  onToggle={e => openFilter('type', e)}
+                >
+                  <div className="th-popover-title">Filter by type</div>
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: '6px', maxHeight: '220px', overflowY: 'auto' }}>
+                    {ALL_TX_TYPES.map(t => (
+                      <label key={t} style={{ display: 'flex', alignItems: 'center', gap: '8px', cursor: 'pointer', fontSize: '12px' }}>
+                        <input
+                          type="checkbox"
+                          checked={pendingTypes.includes(t)}
+                          onChange={() => setPendingTypes(prev =>
+                            prev.includes(t) ? prev.filter(x => x !== t) : [...prev, t]
+                          )}
+                          style={{ accentColor: 'var(--accent)' }}
+                        />
+                        <TypeBadge type={t} isActive={false} />
+                      </label>
+                    ))}
+                  </div>
+                  <div className="th-popover-actions">
+                    <button className="btn btn-ghost btn-sm" onClick={() => clearFilter('types')}>Clear</button>
+                    <button className="btn btn-primary btn-sm" onClick={applyTypeFilter}>Apply</button>
+                  </div>
+                </ThFilter>
+
+                {/* Asset with filter popover */}
+                <ThFilter
+                  label="Asset"
+                  isActive={filters.assets.length > 0}
+                  isOpen={openPopover === 'asset'}
+                  onToggle={e => openFilter('asset', e)}
+                  width="15%"
+                >
+                  <div className="th-popover-title">Filter by asset</div>
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+                    {availableAssets.map(a => (
+                      <label key={a} style={{ display: 'flex', alignItems: 'center', gap: '8px', cursor: 'pointer', fontSize: '12px' }}>
+                        <input
+                          type="checkbox"
+                          checked={pendingAssets.includes(a)}
+                          onChange={() => setPendingAssets(prev =>
+                            prev.includes(a) ? prev.filter(x => x !== a) : [...prev, a]
+                          )}
+                          style={{ accentColor: 'var(--accent)' }}
+                        />
+                        <AssetCell asset={a} isActive={false} onClick={e => e.stopPropagation()} />
+                      </label>
+                    ))}
+                  </div>
+                  <div className="th-popover-actions">
+                    <button className="btn btn-ghost btn-sm" onClick={() => clearFilter('assets')}>Clear</button>
+                    <button className="btn btn-primary btn-sm" onClick={applyAssetFilter}>Apply</button>
+                  </div>
+                </ThFilter>
+
+                {/* Amount */}
+                <th style={{ ...thBase, width: '110px', textAlign: 'right' }}>Amount</th>
+
+                {/* From with filter popover */}
+                <ThFilter
+                  label="From"
+                  isActive={!!filters.fromAddress}
+                  isOpen={openPopover === 'from'}
+                  onToggle={e => openFilter('from', e)}
+                  width="15%"
+                >
+                  <div className="th-popover-title">Filter by from address</div>
+                  <input
+                    className="th-text-input"
+                    type="text"
+                    placeholder="0x…"
+                    value={pendingFrom}
+                    onChange={e => setPendingFrom(e.target.value)}
+                    onKeyDown={e => e.key === 'Enter' && applyFromFilter()}
+                    autoFocus
+                  />
+                  <div className="th-popover-actions">
+                    <button className="btn btn-ghost btn-sm" onClick={() => clearFilter('fromAddress')}>Clear</button>
+                    <button className="btn btn-primary btn-sm" onClick={applyFromFilter}>Apply</button>
+                  </div>
+                </ThFilter>
+
+                {/* To with filter popover */}
+                <ThFilter
+                  label="To"
+                  isActive={!!filters.toAddress}
+                  isOpen={openPopover === 'to'}
+                  onToggle={e => openFilter('to', e)}
+                  width="15%"
+                >
+                  <div className="th-popover-title">Filter by to address</div>
+                  <input
+                    className="th-text-input"
+                    type="text"
+                    placeholder="0x…"
+                    value={pendingTo}
+                    onChange={e => setPendingTo(e.target.value)}
+                    onKeyDown={e => e.key === 'Enter' && applyToFilter()}
+                    autoFocus
+                  />
+                  <div className="th-popover-actions">
+                    <button className="btn btn-ghost btn-sm" onClick={() => clearFilter('toAddress')}>Clear</button>
+                    <button className="btn btn-primary btn-sm" onClick={applyToFilter}>Apply</button>
+                  </div>
+                </ThFilter>
+
+                {/* Tx ID */}
+                <th style={{ ...thBase, width: '15%' }}>Tx ID</th>
+              </tr>
+            </thead>
+            <tbody>
+              {isLoading && allTxs.length === 0 ? (
+                <tr>
+                  <td colSpan={8} style={{ padding: '32px', textAlign: 'center', color: 'var(--text-muted)' }}>
+                    <span className="spinner" style={{ marginRight: '8px' }} />
+                    Loading transactions…
+                  </td>
+                </tr>
+              ) : pageTxs.length === 0 ? (
+                <tr>
+                  <td colSpan={8} style={{ padding: '32px', textAlign: 'center', color: 'var(--text-muted)', fontSize: '13px' }}>
+                    No transactions match the current filters.
+                  </td>
+                </tr>
+              ) : (
+                pageTxs.map(tx => {
+                  const isExpanded = expandedId === tx.id;
+                  const variant = txVariant(tx.txType);
+                  const { color: amtColor } = VARIANT_STYLE[variant];
+                  const prefix = amountPrefix(tx.txType);
+
+                  return (
+                    <>
+                      <tr
+                        key={tx.id}
+                        onClick={() => setExpandedId(isExpanded ? null : tx.id)}
+                        style={{
+                          cursor: 'pointer',
+                          background: isExpanded ? 'rgba(255,255,255,0.02)' : undefined,
+                          transition: 'background 0.1s',
+                        }}
+                        onMouseEnter={e => { if (!isExpanded) (e.currentTarget as HTMLElement).style.background = 'rgba(255,255,255,0.02)'; }}
+                        onMouseLeave={e => { if (!isExpanded) (e.currentTarget as HTMLElement).style.background = ''; }}
+                      >
+                        {/* Expand chevron */}
+                        <td style={{ ...tdBase, padding: '10px 8px 10px 16px', width: '32px' }}>
+                          {isExpanded
+                            ? <ChevronDown size={14} style={{ color: 'var(--text-muted)' }} />
+                            : <ChevronRight size={14} style={{ color: 'var(--text-muted)' }} />}
+                        </td>
+
+                        {/* Time */}
+                        <td style={{ ...tdBase, color: 'var(--text-muted)', fontSize: '12px', whiteSpace: 'nowrap' }}>
+                          <span
+                            className="tooltip-wrap"
+                            title={tx.createdAt.toISOString().replace('T', ' ').slice(0, 19) + ' UTC'}
+                          >
+                            {timeAgo(tx.createdAt)}
+                          </span>
+                        </td>
+
+                        {/* Type */}
+                        <td style={tdBase}>
+                          <TypeBadge
+                            type={tx.txType}
+                            isActive={filters.types.includes(tx.txType)}
+                            onClick={e => toggleType(tx.txType, e)}
+                          />
+                        </td>
+
+                        {/* Asset */}
+                        <td style={tdBase}>
+                          <AssetCell
+                            asset={tx.asset}
+                            isActive={filters.assets.includes(tx.asset)}
+                            onClick={e => toggleAsset(tx.asset, e)}
+                          />
+                        </td>
+
+                        {/* Amount */}
+                        <td style={{ ...tdBase, textAlign: 'right' }}>
+                          <span className="mono" style={{ color: amtColor, fontSize: '13px', whiteSpace: 'nowrap' }}>
+                            {prefix}{tx.amount.toString()}
+                          </span>
+                        </td>
+
+                        {/* From */}
+                        <td style={tdBase}>
+                          <AddrCell
+                            value={tx.fromAccount}
+                            isActive={filters.fromAddress === tx.fromAccount}
+                            onClick={e => toggleFrom(tx.fromAccount, e)}
+                          />
+                        </td>
+
+                        {/* To */}
+                        <td style={tdBase}>
+                          <AddrCell
+                            value={tx.toAccount}
+                            isActive={filters.toAddress === tx.toAccount}
+                            onClick={e => toggleTo(tx.toAccount, e)}
+                          />
+                        </td>
+
+                        {/* Tx ID */}
+                        <td style={{ ...tdBase, color: 'var(--text-muted)', fontSize: '12px' }}>
+                          {tx.id ? <TxIdCell id={tx.id} /> : <span>—</span>}
+                        </td>
+                      </tr>
+
+                      {/* Expanded detail */}
+                      {isExpanded && (
+                        <tr key={`${tx.id}-detail`}>
+                          <td colSpan={8} style={{ padding: 0 }}>
+                            <DetailPanel
+                              tx={tx}
+                              tsFormat={tsFormat}
+                              onToggleTsFormat={() => setTsFormat(f => f === 'date' ? 'unix' : 'date')}
+                            />
+                          </td>
+                        </tr>
+                      )}
+                    </>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Pagination footer */}
+      {totalCount > 0 && (
+        <div style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '12px 20px',
+          borderTop: '1px solid var(--border)',
+          fontSize: '12px',
+          color: 'var(--text-muted)',
+        }}>
+          <span>
+            Showing {Math.min((page - 1) * PAGE_SIZE + 1, totalCount)}–{Math.min(page * PAGE_SIZE, totalCount)} of {totalCount} transaction{totalCount !== 1 ? 's' : ''}
+          </span>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+            <button
+              className="btn btn-ghost btn-sm"
+              onClick={() => setPage(p => Math.max(1, p - 1))}
+              disabled={page === 1}
+            >
+              ← Prev
+            </button>
+            <span style={{ minWidth: '60px', textAlign: 'center' }}>
+              {page} / {pageCount}
+            </span>
+            <button
+              className="btn btn-ghost btn-sm"
+              onClick={() => setPage(p => Math.min(pageCount, p + 1))}
+              disabled={page === pageCount}
+            >
+              Next →
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/playground/src/components/HistoryTab.tsx
+++ b/playground/src/components/HistoryTab.tsx
@@ -77,10 +77,14 @@ const VARIANT_STYLE: Record<TxVariant, { color: string; bg: string }> = {
   muted:    { color: 'var(--text-muted)', bg: 'rgba(255,255,255,0.06)' },
 };
 
-function amountPrefix(type: TransactionType): string {
+function amountPrefix(type: TransactionType, toAccount?: string, address?: Address | null): string {
   const v = txVariant(type);
   if (v === 'deposit') return '+';
-  if (v === 'withdraw' || v === 'transfer') return '−';
+  if (v === 'withdraw') return '−';
+  if (v === 'transfer') {
+    if (address && toAccount && toAccount.toLowerCase() === address.toLowerCase()) return '+';
+    return '−';
+  }
   return '';
 }
 
@@ -780,7 +784,7 @@ export default function HistoryTab({ client, address }: Props) {
                   const isExpanded = expandedId === tx.id;
                   const variant = txVariant(tx.txType);
                   const { color: amtColor } = VARIANT_STYLE[variant];
-                  const prefix = amountPrefix(tx.txType);
+                  const prefix = amountPrefix(tx.txType, tx.toAccount, address);
 
                   return (
                     <>

--- a/playground/src/components/SessionKeyRegisterForm.tsx
+++ b/playground/src/components/SessionKeyRegisterForm.tsx
@@ -1,0 +1,371 @@
+import { useState, useEffect, useMemo } from 'react';
+import { Key } from 'lucide-react';
+
+interface SessionKeyRegisterFormProps {
+  mode: 'register' | 'update';
+  initialAssets?: string[];
+  initialExpiryUnix?: bigint;
+  supportedAssets: string[];
+  isSubmitting: boolean;
+  onSubmit: (assets: string[], expiresAt: bigint) => Promise<void>;
+  onCancel: () => void;
+}
+
+type ExpiryMode = 'duration' | 'date' | 'unix';
+
+export default function SessionKeyRegisterForm({
+  mode,
+  initialAssets,
+  initialExpiryUnix,
+  supportedAssets,
+  isSubmitting,
+  onSubmit,
+  onCancel,
+}: SessionKeyRegisterFormProps) {
+  const [selectedAssets, setSelectedAssets] = useState<string[]>(
+    initialAssets ?? [...supportedAssets]
+  );
+
+  const [expiryMode, setExpiryMode] = useState<ExpiryMode>('duration');
+
+  const [durationValue, setDurationValue] = useState('24');
+  const [durationUnit, setDurationUnit] = useState<'minutes' | 'hours' | 'days'>('hours');
+
+  const [dateValue, setDateValue] = useState('');
+
+  const [unixValue, setUnixValue] = useState('');
+
+  useEffect(() => {
+    if (initialExpiryUnix) {
+      const expDate = new Date(Number(initialExpiryUnix) * 1000);
+      setDateValue(expDate.toISOString().slice(0, 16));
+      setUnixValue(initialExpiryUnix.toString());
+      const secsFromNow = Number(initialExpiryUnix) - Math.floor(Date.now() / 1000);
+      if (secsFromNow > 0) {
+        const hoursFromNow = Math.ceil(secsFromNow / 3600);
+        setDurationValue(String(hoursFromNow));
+      }
+    }
+  }, [initialExpiryUnix]);
+
+  const computedExpiresAt: bigint | null = useMemo(() => {
+    const now = Math.floor(Date.now() / 1000);
+    try {
+      if (expiryMode === 'duration') {
+        const val = parseInt(durationValue, 10);
+        if (!val || val <= 0) return null;
+        const seconds = durationUnit === 'minutes' ? val * 60 : durationUnit === 'hours' ? val * 3600 : val * 86400;
+        return BigInt(now + seconds);
+      }
+      if (expiryMode === 'date') {
+        if (!dateValue) return null;
+        const ts = Math.floor(new Date(dateValue).getTime() / 1000);
+        if (ts <= now + 60) return null;
+        return BigInt(ts);
+      }
+      if (expiryMode === 'unix') {
+        const ts = parseInt(unixValue, 10);
+        if (!ts || ts <= now + 60) return null;
+        return BigInt(ts);
+      }
+    } catch {
+      return null;
+    }
+    return null;
+  }, [expiryMode, durationValue, durationUnit, dateValue, unixValue]);
+
+  const computedExpiryDisplay = computedExpiresAt
+    ? new Date(Number(computedExpiresAt) * 1000).toISOString().replace('T', ' ').slice(0, 19) + ' UTC'
+    : '—';
+
+  const isValid = selectedAssets.length > 0 && computedExpiresAt !== null;
+
+  const handleSubmit = async () => {
+    if (!isValid || !computedExpiresAt) return;
+    await onSubmit(selectedAssets, computedExpiresAt);
+  };
+
+  const toggleAsset = (asset: string) => {
+    setSelectedAssets(prev =>
+      prev.includes(asset) ? prev.filter(a => a !== asset) : [...prev, asset]
+    );
+  };
+
+  return (
+    <div className="modal-overlay">
+      <div
+        className="modal-card"
+        style={{
+          width: 520,
+          maxWidth: 'calc(100vw - 32px)',
+          padding: 28,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 20,
+        }}
+      >
+        {/* Header */}
+        <div style={{ textAlign: 'center' }}>
+          <div
+            style={{
+              width: 48,
+              height: 48,
+              borderRadius: '50%',
+              background: 'var(--accent-dim)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              margin: '0 auto 14px',
+            }}
+          >
+            <Key size={20} color="var(--accent)" />
+          </div>
+          <h2 style={{ fontSize: 17, fontWeight: 600, margin: '0 0 6px' }}>
+            {mode === 'update' ? 'Update session key' : 'Register a new session key'}
+          </h2>
+          <p style={{ fontSize: 13, color: 'var(--text-muted)', margin: 0, lineHeight: 1.5 }}>
+            {mode === 'update'
+              ? 'Modify the assets or extend the expiry. A new version will be signed.'
+              : 'A session key signs state updates on your behalf — no MetaMask for every operation.'}
+          </p>
+        </div>
+
+        {/* Divider */}
+        <div style={{ height: 1, background: 'var(--border)', margin: '0 -28px' }} />
+
+        {/* Assets + Expiry side by side */}
+        <div style={{ display: 'flex', gap: 16, alignItems: 'flex-start' }}>
+
+          {/* Assets column */}
+          <div style={{ flex: '0 0 180px' }}>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 }}>
+              <span style={{ fontSize: 12, fontWeight: 500, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+                Assets
+              </span>
+              <span style={{ display: 'flex', gap: 6, fontSize: 11, color: 'var(--text-muted)' }}>
+                <button
+                  type="button"
+                  style={{ background: 'none', border: 'none', color: 'var(--text-muted)', cursor: 'pointer', padding: 0, fontSize: 11 }}
+                  onClick={() => setSelectedAssets([...supportedAssets])}
+                >
+                  All
+                </button>
+                <span>·</span>
+                <button
+                  type="button"
+                  style={{ background: 'none', border: 'none', color: 'var(--text-muted)', cursor: 'pointer', padding: 0, fontSize: 11 }}
+                  onClick={() => setSelectedAssets([])}
+                >
+                  None
+                </button>
+              </span>
+            </div>
+            {/* Scrollable asset list — shows ~3 items before scrolling */}
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 6, maxHeight: 138, overflowY: 'auto' }}>
+              {supportedAssets.map(asset => {
+                const checked = selectedAssets.includes(asset);
+                return (
+                  <div
+                    key={asset}
+                    onClick={() => toggleAsset(asset)}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 10,
+                      padding: '8px 12px',
+                      borderRadius: 8,
+                      cursor: 'pointer',
+                      background: checked ? 'var(--accent-dim)' : 'var(--bg-elevated)',
+                      border: `1px solid ${checked ? 'var(--accent)' : 'var(--border)'}`,
+                      transition: 'border-color 0.15s, background 0.15s',
+                      flexShrink: 0,
+                    }}
+                  >
+                    <div
+                      style={{
+                        width: 15,
+                        height: 15,
+                        borderRadius: 4,
+                        flexShrink: 0,
+                        border: `2px solid ${checked ? 'var(--accent)' : 'var(--border)'}`,
+                        background: checked ? 'var(--accent)' : 'transparent',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        transition: 'background 0.15s, border-color 0.15s',
+                      }}
+                    >
+                      {checked && (
+                        <svg width="9" height="7" viewBox="0 0 10 8" fill="none">
+                          <path d="M1 4l3 3 5-6" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                        </svg>
+                      )}
+                    </div>
+                    <span style={{ fontSize: 13, fontWeight: 500 }}>{asset}</span>
+                  </div>
+                );
+              })}
+            </div>
+            {selectedAssets.length === 0 && (
+              <p style={{ fontSize: 11, color: 'var(--error)', marginTop: 5 }}>Select at least one.</p>
+            )}
+          </div>
+
+          {/* Vertical separator */}
+          <div style={{ width: 1, background: 'var(--border)', alignSelf: 'stretch' }} />
+
+          {/* Expiry column */}
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ fontSize: 12, fontWeight: 500, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: 10 }}>
+              Expiration
+            </div>
+
+            {/* Segmented control */}
+            <div style={{ display: 'flex', gap: 2, background: 'var(--bg-elevated)', border: '1px solid var(--border)', borderRadius: 8, padding: 3, marginBottom: 12 }}>
+              {(['duration', 'date', 'unix'] as ExpiryMode[]).map(m => (
+                <button
+                  key={m}
+                  type="button"
+                  onClick={() => setExpiryMode(m)}
+                  style={{
+                    flex: 1,
+                    padding: '5px 0',
+                    borderRadius: 6,
+                    fontSize: 11,
+                    fontWeight: 500,
+                    cursor: 'pointer',
+                    border: expiryMode === m ? '1px solid var(--border)' : '1px solid transparent',
+                    background: expiryMode === m ? 'var(--bg-surface)' : 'transparent',
+                    color: expiryMode === m ? 'var(--text-primary)' : 'var(--text-muted)',
+                    transition: 'background 0.15s, color 0.15s',
+                    textTransform: 'capitalize',
+                    fontFamily: 'inherit',
+                  }}
+                >
+                  {m}
+                </button>
+              ))}
+            </div>
+
+            {expiryMode === 'duration' && (
+              <div className="input" style={{ display: 'flex', alignItems: 'center' }}>
+                <input
+                  type="number"
+                  min="1"
+                  value={durationValue}
+                  onChange={e => setDurationValue(e.target.value)}
+                  style={{ flex: 1, background: 'transparent', border: 'none', outline: 'none', padding: '7px 10px', fontFamily: 'JetBrains Mono, monospace', fontSize: 13, color: 'var(--text-primary)', minWidth: 0 }}
+                  placeholder="24"
+                />
+                <select
+                  value={durationUnit}
+                  onChange={e => setDurationUnit(e.target.value as 'minutes' | 'hours' | 'days')}
+                  style={{ background: 'var(--bg-base)', border: 'none', borderLeft: '1px solid var(--border)', padding: '7px 8px', fontSize: 12, color: 'var(--text-primary)', cursor: 'pointer', outline: 'none', fontFamily: 'inherit' }}
+                >
+                  <option value="minutes">minutes</option>
+                  <option value="hours">hours</option>
+                  <option value="days">days</option>
+                </select>
+              </div>
+            )}
+
+            {expiryMode === 'date' && (
+              <div className="input">
+                <input
+                  type="datetime-local"
+                  value={dateValue}
+                  onChange={e => setDateValue(e.target.value)}
+                  style={{ flex: 1, background: 'transparent', border: 'none', outline: 'none', padding: '7px 10px', fontSize: 12, color: 'var(--text-primary)', width: '100%', fontFamily: 'inherit' }}
+                />
+              </div>
+            )}
+
+            {expiryMode === 'unix' && (
+              <div className="input">
+                <input
+                  type="number"
+                  value={unixValue}
+                  onChange={e => setUnixValue(e.target.value)}
+                  placeholder="1748424600"
+                  style={{ flex: 1, background: 'transparent', border: 'none', outline: 'none', padding: '7px 10px', fontFamily: 'JetBrains Mono, monospace', fontSize: 13, color: 'var(--text-primary)', width: '100%' }}
+                />
+              </div>
+            )}
+
+            <div style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 8 }}>
+              Expires:{' '}
+              <span className="mono" style={{ color: computedExpiresAt ? 'var(--text-primary)' : 'var(--error)' }}>
+                {computedExpiryDisplay}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        {/* Divider */}
+        <div style={{ height: 1, background: 'var(--border)', margin: '0 -28px' }} />
+
+        {/* Summary box */}
+        <div
+          style={{
+            background: 'var(--bg-elevated)',
+            border: '1px solid var(--border)',
+            borderRadius: 8,
+            padding: '12px 14px',
+            fontSize: 12,
+            color: 'var(--text-muted)',
+            lineHeight: 1.6,
+          }}
+        >
+          This key will authorize:{' '}
+          <strong style={{ color: 'var(--text-primary)', fontWeight: 500 }}>
+            {selectedAssets.length > 0 ? selectedAssets.join(', ') : 'no assets selected'}
+          </strong>{' '}
+          and expire in{' '}
+          <strong style={{ color: 'var(--text-primary)', fontWeight: 500 }}>
+            {computedExpiresAt
+              ? expiryMode === 'duration'
+                ? `${durationValue} ${durationUnit === 'minutes' ? 'min' : durationUnit}`
+                : computedExpiryDisplay
+              : '—'}
+          </strong>
+          .<br />
+          On-chain operations (deposit, checkpoint, approve) will still require MetaMask.
+          {mode === 'update' && (
+            <>
+              <br />
+              Version will be incremented from the current one.
+            </>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div style={{ display: 'flex', gap: 10 }}>
+          <button
+            className="btn btn-ghost"
+            style={{ flex: 1 }}
+            onClick={onCancel}
+            disabled={isSubmitting}
+          >
+            Cancel
+          </button>
+          <button
+            className="btn btn-primary"
+            style={{ flex: 1 }}
+            onClick={handleSubmit}
+            disabled={!isValid || isSubmitting}
+          >
+            {isSubmitting ? (
+              <>
+                <span className="spinner" /> Signing…
+              </>
+            ) : mode === 'update' ? (
+              'Update & Sign'
+            ) : (
+              'Register & Sign'
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/playground/src/components/SessionKeyRevokeModal.tsx
+++ b/playground/src/components/SessionKeyRevokeModal.tsx
@@ -1,0 +1,93 @@
+import type { Address } from 'viem';
+import { AlertTriangle } from 'lucide-react';
+
+interface SessionKeyRevokeModalProps {
+  sessionKeyAddress: Address;
+  isSubmitting: boolean;
+  onConfirm: () => Promise<void>;
+  onCancel: () => void;
+}
+
+export default function SessionKeyRevokeModal({
+  sessionKeyAddress,
+  isSubmitting,
+  onConfirm,
+  onCancel,
+}: SessionKeyRevokeModalProps) {
+  return (
+    <div className="modal-overlay">
+      <div
+        className="modal-card"
+        style={{ width: 400, maxWidth: 'calc(100vw - 32px)', padding: 28 }}
+      >
+        {/* Header */}
+        <div style={{ textAlign: 'center', marginBottom: 20 }}>
+          <div
+            style={{
+              width: 48,
+              height: 48,
+              borderRadius: '50%',
+              background: 'rgba(239,68,68,0.12)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              margin: '0 auto 14px',
+            }}
+          >
+            <AlertTriangle size={20} color="var(--error)" />
+          </div>
+          <h2 style={{ fontSize: 17, fontWeight: 600, margin: '0 0 8px' }}>Revoke session key</h2>
+          <p style={{ fontSize: 13, color: 'var(--text-muted)', margin: 0, lineHeight: 1.5 }}>
+            This key will no longer authorize any operations. This action requires a MetaMask
+            signature.
+          </p>
+        </div>
+
+        {/* Key address box */}
+        <div
+          style={{
+            background: 'var(--bg-elevated)',
+            border: '1px solid var(--border)',
+            borderRadius: 8,
+            padding: '10px 14px',
+            marginBottom: 20,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+          }}
+        >
+          <span style={{ fontSize: 12, color: 'var(--text-muted)' }}>Key:</span>
+          <span className="mono" style={{ fontSize: 12 }}>
+            {sessionKeyAddress.slice(0, 10)}…{sessionKeyAddress.slice(-8)}
+          </span>
+        </div>
+
+        {/* Footer */}
+        <div style={{ display: 'flex', gap: 10 }}>
+          <button
+            className="btn btn-ghost"
+            style={{ flex: 1 }}
+            onClick={onCancel}
+            disabled={isSubmitting}
+          >
+            Cancel
+          </button>
+          <button
+            className="btn btn-danger"
+            style={{ flex: 1 }}
+            onClick={onConfirm}
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? (
+              <>
+                <span className="spinner" /> Revoking…
+              </>
+            ) : (
+              'Revoke & Sign'
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/playground/src/components/SessionKeysTab.tsx
+++ b/playground/src/components/SessionKeysTab.tsx
@@ -74,6 +74,7 @@ interface Props {
   walletClient: WalletClient | null;
   address: Address | null;
   sessionKey: StoredSessionKey | null;
+  allSessionKeys: StoredSessionKey[];
   supportedAssets: string[];
   onKeyActivated: (sk: StoredSessionKey) => void;
   onKeyCleared: () => void;
@@ -88,6 +89,7 @@ export default function SessionKeysTab({
   walletClient,
   address,
   sessionKey,
+  allSessionKeys,
   supportedAssets,
   onKeyActivated,
   onKeyCleared,
@@ -238,7 +240,10 @@ export default function SessionKeysTab({
               <tbody>
                 {displayKeys.map(key => {
                   const status = getKeyStatus(key);
-                  const isDisabled = status === 'expired' || status === 'revoked';
+                  const isTerminal = status === 'expired' || status === 'revoked';
+                  const hasLocalKey = allSessionKeys.some(
+                    lk => lk.sessionKeyAddress.toLowerCase() === key.session_key.toLowerCase(),
+                  );
                   const isCurrentKey = sessionKey?.sessionKeyAddress.toLowerCase() === key.session_key.toLowerCase();
                   const rowOpacity = status === 'revoked' ? 0.55 : status === 'expired' ? 0.7 : 1;
 
@@ -252,7 +257,7 @@ export default function SessionKeysTab({
                         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
                           <Key
                             size={12}
-                            color={isDisabled ? 'var(--text-muted)' : status === 'expiring' ? '#f97316' : '#22c55e'}
+                            color={isTerminal ? 'var(--text-muted)' : status === 'expiring' ? '#f97316' : '#22c55e'}
                           />
                           <span className="mono" style={{ fontSize: 12 }}>
                             {key.session_key.slice(0, 6)}…{key.session_key.slice(-4)}
@@ -308,7 +313,7 @@ export default function SessionKeysTab({
                       {/* Actions */}
                       <td style={{ padding: '12px 16px', textAlign: 'right' }}>
                         <div style={{ display: 'flex', gap: 6, justifyContent: 'flex-end' }}>
-                          {status === 'expiring' ? (
+                          {status === 'expiring' && (
                             <button
                               className="btn btn-ghost btn-sm"
                               style={{ borderColor: 'rgba(249,115,22,0.4)', color: '#f97316' }}
@@ -316,23 +321,33 @@ export default function SessionKeysTab({
                             >
                               Renew
                             </button>
-                          ) : (
+                          )}
+                          {status === 'active' && (
                             <button
                               className="btn btn-ghost btn-sm"
-                              disabled={isDisabled}
                               onClick={() => setKeyForUpdate(key)}
                             >
                               Update
                             </button>
                           )}
-                          <button
-                            className="btn btn-danger btn-sm"
-                            disabled={isDisabled}
-                            onClick={() => setKeyForRevoke(key)}
-                          >
-                            Revoke
-                          </button>
-                          {!isDisabled && !isCurrentKey && (
+                          {isTerminal && hasLocalKey && (
+                            <button
+                              className="btn btn-ghost btn-sm"
+                              onClick={() => setKeyForUpdate(key)}
+                              title="Re-register with future expiry to reactivate"
+                            >
+                              Reactivate
+                            </button>
+                          )}
+                          {!isTerminal && (
+                            <button
+                              className="btn btn-danger btn-sm"
+                              onClick={() => setKeyForRevoke(key)}
+                            >
+                              Revoke
+                            </button>
+                          )}
+                          {!isTerminal && !isCurrentKey && (
                             <button
                               className="btn btn-ghost btn-sm"
                               onClick={() => onSelectKey(key.session_key as Address)}

--- a/playground/src/components/SessionKeysTab.tsx
+++ b/playground/src/components/SessionKeysTab.tsx
@@ -37,9 +37,10 @@ type KeyStatus = 'active' | 'expiring' | 'expired' | 'revoked';
 function getKeyStatus(key: ChannelSessionKeyStateV1): KeyStatus {
   const now = Math.floor(Date.now() / 1000);
   const expiresAt = Number(key.expires_at);
-  if (expiresAt <= now) return 'expired';
-  // Revoked = registered with expiresAt well in the past (via revoke flow)
+  // Revoked = registered with expiresAt well in the past (via revoke flow).
+  // Check before 'expired' so the more specific branch wins.
   if (expiresAt < now - 60) return 'revoked';
+  if (expiresAt <= now) return 'expired';
   if (expiresAt - now < 3600) return 'expiring'; // < 1 hour
   return 'active';
 }

--- a/playground/src/components/SessionKeysTab.tsx
+++ b/playground/src/components/SessionKeysTab.tsx
@@ -1,0 +1,397 @@
+import { useState, useEffect } from 'react';
+import { Key, RefreshCw, Plus, Copy, Check, Eye, EyeOff } from 'lucide-react';
+import type { Address, WalletClient } from 'viem';
+import type { Client, ChannelSessionKeyStateV1 } from '@yellow-org/sdk';
+import type { StoredSessionKey } from '../sessionKey';
+import { useSessionKeyManagement } from '../hooks/useSessionKeyManagement';
+import SessionKeyRegisterForm from './SessionKeyRegisterForm';
+import SessionKeyRevokeModal from './SessionKeyRevokeModal';
+
+// ── Expiry format cycling ─────────────────────────────────────────────────────
+
+type ExpFormat = 'relative' | 'date' | 'unix';
+
+const NEXT_FMT: Record<ExpFormat, ExpFormat> = { relative: 'date', date: 'unix', unix: 'relative' };
+const FMT_HINT: Record<ExpFormat, string> = {
+  relative: 'Show as UTC date',
+  date: 'Show as Unix timestamp',
+  unix: 'Show as relative time',
+};
+
+function formatExpiry(expiresAtStr: string, fmt: ExpFormat): string {
+  const expiresAt = Number(expiresAtStr);
+  const now = Math.floor(Date.now() / 1000);
+  if (fmt === 'unix') return expiresAtStr;
+  if (fmt === 'date') return new Date(expiresAt * 1000).toISOString().replace('T', ' ').slice(0, 19) + ' UTC';
+  const diff = expiresAt - now;
+  if (diff <= 0) return 'expired';
+  const h = Math.floor(diff / 3600);
+  const m = Math.floor((diff % 3600) / 60);
+  return h > 0 ? `${h}h ${m}m` : `${m}m`;
+}
+
+// ── Status derivation ─────────────────────────────────────────────────────────
+
+type KeyStatus = 'active' | 'expiring' | 'expired' | 'revoked';
+
+function getKeyStatus(key: ChannelSessionKeyStateV1): KeyStatus {
+  const now = Math.floor(Date.now() / 1000);
+  const expiresAt = Number(key.expires_at);
+  if (expiresAt <= now) return 'expired';
+  // Revoked = registered with expiresAt well in the past (via revoke flow)
+  if (expiresAt < now - 60) return 'revoked';
+  if (expiresAt - now < 3600) return 'expiring'; // < 1 hour
+  return 'active';
+}
+
+// ── Status badge ──────────────────────────────────────────────────────────────
+
+const STATUS_STYLE: Record<KeyStatus, { bg: string; color: string; label: string }> = {
+  active:   { bg: 'rgba(34,197,94,0.12)',   color: '#22c55e',            label: 'Active' },
+  expiring: { bg: 'rgba(249,115,22,0.14)',  color: '#f97316',            label: 'Expiring Soon' },
+  expired:  { bg: 'rgba(102,102,102,0.14)', color: 'var(--text-muted)',  label: 'Expired' },
+  revoked:  { bg: 'rgba(239,68,68,0.12)',   color: 'var(--error)',       label: 'Revoked' },
+};
+
+function StatusBadge({ status }: { status: KeyStatus }) {
+  const s = STATUS_STYLE[status];
+  return (
+    <span style={{
+      display: 'inline-flex', alignItems: 'center', gap: 5,
+      borderRadius: 999, padding: '3px 9px', fontSize: 11, fontWeight: 500,
+      background: s.bg, color: s.color,
+    }}>
+      <span style={{ width: 6, height: 6, borderRadius: '50%', background: s.color, flexShrink: 0 }} />
+      {s.label}
+    </span>
+  );
+}
+
+// ── Props ─────────────────────────────────────────────────────────────────────
+
+interface Props {
+  client: Client | null;
+  walletClient: WalletClient | null;
+  address: Address | null;
+  sessionKey: StoredSessionKey | null;
+  supportedAssets: string[];
+  onKeyActivated: (sk: StoredSessionKey) => void;
+  onKeyCleared: () => void;
+  onSelectKey: (sessionKeyAddress: Address) => void;
+  onRefreshAllKeys: () => void;
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+export default function SessionKeysTab({
+  client,
+  walletClient,
+  address,
+  sessionKey,
+  supportedAssets,
+  onKeyActivated,
+  onKeyCleared,
+  onSelectKey,
+  onRefreshAllKeys,
+}: Props) {
+  const [expFmt, setExpFmt] = useState<ExpFormat>('relative');
+  const [showExpired, setShowExpired] = useState(true);
+  const [showRegisterModal, setShowRegisterModal] = useState(false);
+  const [keyForUpdate, setKeyForUpdate] = useState<ChannelSessionKeyStateV1 | null>(null);
+  const [keyForRevoke, setKeyForRevoke] = useState<ChannelSessionKeyStateV1 | null>(null);
+  const [copiedAddress, setCopiedAddress] = useState<string | null>(null);
+
+  const mgmt = useSessionKeyManagement(client, address, walletClient);
+
+  // Fetch on mount
+  useEffect(() => { mgmt.fetchKeys(); }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Copy address helper
+  const copyAddr = (addr: string) => {
+    navigator.clipboard.writeText(addr).catch(() => {});
+    setCopiedAddress(addr);
+    setTimeout(() => setCopiedAddress(null), 1500);
+  };
+
+  // Check if any key is expiring soon (for warning banner)
+  const expiringKey = mgmt.serverKeys.find(k => getKeyStatus(k) === 'expiring');
+
+  const displayKeys = showExpired
+    ? mgmt.serverKeys
+    : mgmt.serverKeys.filter(k => { const s = getKeyStatus(k); return s !== 'expired' && s !== 'revoked'; });
+
+  return (
+    <div>
+      {/* Expiring Soon Banner */}
+      {expiringKey && (
+        <div style={{
+          display: 'flex', alignItems: 'center', gap: 12,
+          background: 'rgba(249,115,22,0.12)',
+          border: '1px solid rgba(249,115,22,0.25)',
+          borderRadius: 10, padding: '12px 16px', marginBottom: 16,
+        }}>
+          {/* key icon circle */}
+          <div style={{
+            width: 32, height: 32, borderRadius: '50%',
+            background: 'rgba(249,115,22,0.18)',
+            display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+          }}>
+            <Key size={15} color="#f97316" />
+          </div>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ fontSize: 13, fontWeight: 600, color: '#f97316' }}>Session key expiring soon</div>
+            <div className="text-text-muted" style={{ fontSize: 12, marginTop: 2 }}>
+              <span className="mono">{expiringKey.session_key.slice(0, 6)}…{expiringKey.session_key.slice(-4)}</span>
+              {' '}· {formatExpiry(expiringKey.expires_at, 'relative')} remaining
+            </div>
+          </div>
+          <button
+            className="btn btn-ghost btn-sm"
+            style={{ borderColor: 'rgba(249,115,22,0.4)', color: '#f97316', flexShrink: 0 }}
+            onClick={() => setKeyForUpdate(expiringKey)}
+          >
+            Renew Key
+          </button>
+        </div>
+      )}
+
+      {/* Main card */}
+      <div className="card">
+        {/* Card header */}
+        <div className="card-header">
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <Key size={16} style={{ color: 'var(--text-muted)' }} />
+            <span className="card-title">Session Keys</span>
+            <span style={{
+              background: 'var(--bg-elevated)', border: '1px solid var(--border)',
+              borderRadius: 999, padding: '1px 8px', fontSize: 12,
+              color: 'var(--text-muted)',
+            }} className="mono">
+              {mgmt.serverKeys.length}
+            </span>
+          </div>
+          <div style={{ display: 'flex', gap: 8 }}>
+            <button
+              className="btn btn-ghost btn-sm"
+              onClick={mgmt.fetchKeys}
+              disabled={mgmt.isLoading}
+              title="Refresh"
+            >
+              <RefreshCw size={13} className={mgmt.isLoading ? 'animate-spin' : ''} />
+              Refresh
+            </button>
+            <button
+              className="btn btn-primary btn-sm"
+              onClick={() => setShowRegisterModal(true)}
+            >
+              <Plus size={13} />
+              Register New
+            </button>
+          </div>
+        </div>
+
+        {/* Table or empty state */}
+        {mgmt.isLoading && mgmt.serverKeys.length === 0 ? (
+          <div style={{ padding: '40px 0', textAlign: 'center' }}>
+            <span className="spinner" />
+          </div>
+        ) : mgmt.serverKeys.length === 0 ? (
+          <div style={{ padding: '48px 24px', textAlign: 'center' }}>
+            <div style={{ fontSize: 14, marginBottom: 16, color: 'var(--text-muted)' }}>
+              No session keys yet. Register one to sign state updates without MetaMask prompts.
+            </div>
+            <button className="btn btn-primary" onClick={() => setShowRegisterModal(true)}>
+              <Plus size={14} />
+              Register New Key
+            </button>
+          </div>
+        ) : (
+          <div style={{ overflowX: 'auto' }}>
+            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
+              <thead>
+                <tr style={{ borderBottom: '1px solid var(--border)' }}>
+                  <th style={{ padding: '10px 16px', textAlign: 'left', color: 'var(--text-muted)', fontWeight: 500, fontSize: 12 }}>Address</th>
+                  <th style={{ padding: '10px 16px', textAlign: 'left', color: 'var(--text-muted)', fontWeight: 500, fontSize: 12 }}>Assets</th>
+                  <th
+                    style={{ padding: '10px 16px', textAlign: 'left', color: 'var(--text-muted)', fontWeight: 500, fontSize: 12, cursor: 'pointer', userSelect: 'none' }}
+                    onClick={() => setExpFmt(f => NEXT_FMT[f])}
+                    title={FMT_HINT[expFmt]}
+                  >
+                    Expiration ↕
+                  </th>
+                  <th style={{ padding: '10px 16px', textAlign: 'left', color: 'var(--text-muted)', fontWeight: 500, fontSize: 12 }}>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+                      <button
+                        onClick={() => setShowExpired(v => !v)}
+                        title={showExpired ? 'Hide expired' : 'Show expired'}
+                        style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 0, display: 'flex', alignItems: 'center', color: 'var(--text-muted)' }}
+                      >
+                        {showExpired ? <Eye size={12} /> : <EyeOff size={12} />}
+                      </button>
+                      Status
+                    </div>
+                  </th>
+                  <th style={{ padding: '10px 16px', textAlign: 'left', color: 'var(--text-muted)', fontWeight: 500, fontSize: 12 }}>Version</th>
+                  <th style={{ padding: '10px 16px', textAlign: 'right', color: 'var(--text-muted)', fontWeight: 500, fontSize: 12 }}>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {displayKeys.map(key => {
+                  const status = getKeyStatus(key);
+                  const isDisabled = status === 'expired' || status === 'revoked';
+                  const isCurrentKey = sessionKey?.sessionKeyAddress.toLowerCase() === key.session_key.toLowerCase();
+                  const rowOpacity = status === 'revoked' ? 0.55 : status === 'expired' ? 0.7 : 1;
+
+                  return (
+                    <tr
+                      key={`${key.session_key}-${key.version}`}
+                      style={{ borderBottom: '1px solid var(--border)', opacity: rowOpacity }}
+                    >
+                      {/* Address */}
+                      <td style={{ padding: '12px 16px' }}>
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                          <Key
+                            size={12}
+                            color={isDisabled ? 'var(--text-muted)' : status === 'expiring' ? '#f97316' : '#22c55e'}
+                          />
+                          <span className="mono" style={{ fontSize: 12 }}>
+                            {key.session_key.slice(0, 6)}…{key.session_key.slice(-4)}
+                          </span>
+                          {isCurrentKey && (
+                            <span style={{
+                              background: 'var(--accent-dim)', color: 'var(--accent)',
+                              borderRadius: 4, padding: '1px 6px', fontSize: 10, fontWeight: 700,
+                            }}>
+                              IN USE
+                            </span>
+                          )}
+                          <button
+                            className="btn btn-ghost btn-sm"
+                            style={{ padding: '2px 6px', opacity: 0.6 }}
+                            onClick={() => copyAddr(key.session_key)}
+                            title="Copy address"
+                          >
+                            {copiedAddress === key.session_key ? <Check size={11} /> : <Copy size={11} />}
+                          </button>
+                        </div>
+                      </td>
+
+                      {/* Assets */}
+                      <td style={{ padding: '12px 16px' }}>
+                        <span className="mono" style={{ fontSize: 12, color: 'var(--text-muted)' }}>
+                          {key.assets.join(', ')}
+                        </span>
+                      </td>
+
+                      {/* Expiration */}
+                      <td style={{ padding: '12px 16px' }}>
+                        <span
+                          className="ts-toggle"
+                          onClick={() => setExpFmt(f => NEXT_FMT[f])}
+                          data-tip={FMT_HINT[expFmt]}
+                          style={{ color: status === 'expiring' ? '#f97316' : undefined }}
+                        >
+                          {formatExpiry(key.expires_at, expFmt)}
+                        </span>
+                      </td>
+
+                      {/* Status */}
+                      <td style={{ padding: '12px 16px' }}>
+                        <StatusBadge status={status} />
+                      </td>
+
+                      {/* Version */}
+                      <td style={{ padding: '12px 16px' }}>
+                        <span className="mono" style={{ fontSize: 12, color: 'var(--text-muted)' }}>v{key.version}</span>
+                      </td>
+
+                      {/* Actions */}
+                      <td style={{ padding: '12px 16px', textAlign: 'right' }}>
+                        <div style={{ display: 'flex', gap: 6, justifyContent: 'flex-end' }}>
+                          {status === 'expiring' ? (
+                            <button
+                              className="btn btn-ghost btn-sm"
+                              style={{ borderColor: 'rgba(249,115,22,0.4)', color: '#f97316' }}
+                              onClick={() => setKeyForUpdate(key)}
+                            >
+                              Renew
+                            </button>
+                          ) : (
+                            <button
+                              className="btn btn-ghost btn-sm"
+                              disabled={isDisabled}
+                              onClick={() => setKeyForUpdate(key)}
+                            >
+                              Update
+                            </button>
+                          )}
+                          <button
+                            className="btn btn-danger btn-sm"
+                            disabled={isDisabled}
+                            onClick={() => setKeyForRevoke(key)}
+                          >
+                            Revoke
+                          </button>
+                          {!isDisabled && !isCurrentKey && (
+                            <button
+                              className="btn btn-ghost btn-sm"
+                              onClick={() => onSelectKey(key.session_key as Address)}
+                            >
+                              Use
+                            </button>
+                          )}
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {/* Register / Update modal */}
+      {(showRegisterModal || keyForUpdate) && (
+        <SessionKeyRegisterForm
+          mode={keyForUpdate ? 'update' : 'register'}
+          initialAssets={keyForUpdate?.assets}
+          initialExpiryUnix={keyForUpdate ? BigInt(keyForUpdate.expires_at) : undefined}
+          supportedAssets={supportedAssets}
+          isSubmitting={mgmt.isSubmitting}
+          onSubmit={async (assets: string[], expiresAt: bigint) => {
+            if (!address) return;
+            if (keyForUpdate) {
+              const sk = await mgmt.update(address, keyForUpdate, assets, expiresAt);
+              if (sk) onKeyActivated(sk);
+            } else {
+              const sk = await mgmt.register(address, assets, expiresAt);
+              if (sk) onKeyActivated(sk);
+            }
+            setShowRegisterModal(false);
+            setKeyForUpdate(null);
+          }}
+          onCancel={() => { setShowRegisterModal(false); setKeyForUpdate(null); }}
+        />
+      )}
+
+      {/* Revoke confirmation modal */}
+      {keyForRevoke && (
+        <SessionKeyRevokeModal
+          sessionKeyAddress={keyForRevoke.session_key as Address}
+          isSubmitting={mgmt.isSubmitting}
+          onConfirm={async () => {
+            if (!address) return;
+            await mgmt.revoke(address, keyForRevoke);
+            if (sessionKey?.sessionKeyAddress.toLowerCase() === keyForRevoke.session_key.toLowerCase()) {
+              onKeyCleared();
+            }
+            onRefreshAllKeys();
+            setKeyForRevoke(null);
+          }}
+          onCancel={() => setKeyForRevoke(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/playground/src/components/TokenSelector.tsx
+++ b/playground/src/components/TokenSelector.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { ChevronDown } from 'lucide-react';
+import { ChevronDown, Droplets } from 'lucide-react';
 import type { Asset, Blockchain, Channel } from '@yellow-org/sdk';
 import { ChannelType, ChannelStatus } from '@yellow-org/sdk';
 import { tokenIconUrl, chainIconUrl } from '../icons';
 import { chainDisplayName } from '../chainMeta';
+import { FAUCET_ASSETS } from '../utils';
 
 interface Props {
   assets: Asset[];
@@ -109,8 +110,14 @@ function AssetRow({
   return (
     <>
       <TokenIcon symbol={asset.symbol} size={22} />
-      <span className="font-medium text-text-primary flex-1 text-left">
+      <span className="font-medium text-text-primary flex-1 text-left flex items-center gap-1.5">
         {asset.symbol.toUpperCase()}
+        {FAUCET_ASSETS.has(asset.symbol.toLowerCase()) && (
+          <span className="tooltip-wrap">
+            <Droplets size={13} className="text-accent flex-shrink-0" />
+            <span className="tip">Faucet available</span>
+          </span>
+        )}
       </span>
       <div className="flex items-center gap-1.5">
         {assetChains.map(chain => (

--- a/playground/src/components/WalletBar.tsx
+++ b/playground/src/components/WalletBar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Key, X } from 'lucide-react';
+import { Key, X, FlaskConical } from 'lucide-react';
 import type { Address } from 'viem';
 import type { Blockchain } from '@yellow-org/sdk';
 import CopyButton from './CopyButton';
@@ -8,7 +8,7 @@ import type { StoredSessionKey } from '../sessionKey';
 import { secondsUntilExpiry } from '../sessionKey';
 import { chainDisplayName } from '../chainMeta';
 
-export type AppTab = 'main' | 'history';
+export type AppTab = 'main' | 'history' | 'keys';
 
 interface Props {
   address: Address | null;
@@ -55,8 +55,11 @@ export default function WalletBar({
     <nav className="sticky top-0 z-10 flex items-center justify-between px-6 h-14 bg-bg-surface border-b border-border relative">
       {/* Left: brand + node status */}
       <div className="flex items-center gap-3">
-        <span className="text-accent font-semibold tracking-tight">Nitrolite</span>
-        <span className="text-text-muted text-xs uppercase tracking-wider">Playground</span>
+        <span className="mono font-bold tracking-tight text-accent text-[14px]">Nitrolite</span>
+        <span className="flex items-center gap-1 text-[11px] px-2 py-0.5 rounded font-medium uppercase tracking-wider" style={{ background: 'var(--accent)', color: '#0a0a0a' }}>
+          Playground
+          <FlaskConical size={11} strokeWidth={2.5} />
+        </span>
 
         {nodeError ? (
           <span className="flex items-center gap-1.5 text-error text-xs">
@@ -90,6 +93,12 @@ export default function WalletBar({
             onClick={() => onTabChange('history')}
           >
             History
+          </button>
+          <button
+            className={`tab${activeTab === 'keys' ? ' active' : ''}`}
+            onClick={() => onTabChange('keys')}
+          >
+            Session Keys
           </button>
         </div>
       )}

--- a/playground/src/components/WalletBar.tsx
+++ b/playground/src/components/WalletBar.tsx
@@ -52,19 +52,19 @@ export default function WalletBar({
   const sortedChains = [...chains].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
 
   return (
-    <nav className="sticky top-0 z-10 flex items-center justify-between px-6 h-14 bg-bg-surface border-b border-border relative">
+    <nav className="sticky top-0 z-10 flex items-center gap-3 px-6 h-14 bg-bg-surface border-b border-border">
       {/* Left: brand + node status */}
-      <div className="flex items-center gap-3">
+      <div className="flex items-center gap-3 flex-1 min-w-0">
         <span className="mono font-bold tracking-tight text-accent text-[14px]">Nitrolite</span>
-        <span className="flex items-center gap-1 text-[11px] px-2 py-0.5 rounded font-medium uppercase tracking-wider" style={{ background: 'var(--accent)', color: '#0a0a0a' }}>
+        <span className="flex items-center gap-1 text-[11px] px-2 py-0.5 rounded font-medium uppercase tracking-wider flex-shrink-0" style={{ background: 'var(--accent)', color: '#0a0a0a' }}>
           Playground
           <FlaskConical size={11} strokeWidth={2.5} />
         </span>
 
         {nodeError ? (
-          <span className="flex items-center gap-1.5 text-error text-xs">
+          <span className="flex items-center gap-1.5 text-error text-xs min-w-0">
             <span className="dot error" />
-            <span className="truncate max-w-[200px]" title={nodeError}>{nodeError}</span>
+            <span className="truncate" title={nodeError}>{nodeError}</span>
           </span>
         ) : lastCommsAt ? (
           <span className="flex items-center gap-1.5 text-text-muted text-xs">
@@ -81,7 +81,7 @@ export default function WalletBar({
 
       {/* Center: tab selector (only when wallet connected) */}
       {address && (
-        <div className="absolute left-1/2 flex items-center gap-1" style={{ transform: 'translateX(-50%)' }}>
+        <div className="flex items-center gap-1 flex-shrink-0">
           <button
             className={`tab${activeTab === 'main' ? ' active' : ''}`}
             onClick={() => onTabChange('main')}
@@ -104,15 +104,15 @@ export default function WalletBar({
       )}
 
       {/* Right: session key + chain + address + disconnect */}
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-2 flex-1 justify-end min-w-0">
         {address && sessionKey && (
           <span
-            className="chip text-xs"
+            className="chip text-xs flex-shrink-0"
             title={`Session key ${sessionKey.sessionKeyAddress} · expires at ${new Date(Number(sessionKey.expiresAt) * 1000).toLocaleString()}`}
             style={{ borderColor: 'rgba(245,166,35,0.4)', color: 'var(--accent)' }}
           >
             <Key size={11} />
-            <span className="mono">{sessionKey.sessionKeyAddress.slice(0, 6)}…{sessionKey.sessionKeyAddress.slice(-4)} · {formatSkExpiry(sessionKey)}</span>
+            <span className="mono">{formatSkExpiry(sessionKey)}</span>
             <button
               type="button"
               className="text-text-muted hover:text-error transition-colors"

--- a/playground/src/components/WalletBar.tsx
+++ b/playground/src/components/WalletBar.tsx
@@ -8,6 +8,8 @@ import type { StoredSessionKey } from '../sessionKey';
 import { secondsUntilExpiry } from '../sessionKey';
 import { chainDisplayName } from '../chainMeta';
 
+export type AppTab = 'main' | 'history';
+
 interface Props {
   address: Address | null;
   chainId: bigint | null;
@@ -16,10 +18,12 @@ interface Props {
   nodeError: string | null;
   isConnecting: boolean;
   sessionKey: StoredSessionKey | null;
+  activeTab: AppTab;
   onConnect: () => void;
   onDisconnect: () => void;
   onSwitchChain: (chainId: bigint) => void;
   onClearSessionKey: () => void;
+  onTabChange: (tab: AppTab) => void;
 }
 
 export default function WalletBar({
@@ -30,12 +34,13 @@ export default function WalletBar({
   nodeError,
   isConnecting,
   sessionKey,
+  activeTab,
   onConnect,
   onDisconnect,
   onSwitchChain,
   onClearSessionKey,
+  onTabChange,
 }: Props) {
-  // Tick every second so "Xs ago" stays fresh
   const [, setTick] = useState(0);
   useEffect(() => {
     const id = setInterval(() => setTick(t => t + 1), 1000);
@@ -47,31 +52,49 @@ export default function WalletBar({
   const sortedChains = [...chains].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
 
   return (
-    <nav className="sticky top-0 z-10 flex items-center justify-between px-6 h-14 bg-bg-surface border-b border-border">
+    <nav className="sticky top-0 z-10 flex items-center justify-between px-6 h-14 bg-bg-surface border-b border-border relative">
+      {/* Left: brand + node status */}
       <div className="flex items-center gap-3">
         <span className="text-accent font-semibold tracking-tight">Nitrolite</span>
         <span className="text-text-muted text-xs uppercase tracking-wider">Playground</span>
-      </div>
 
-      <div className="flex items-center gap-3 text-xs">
         {nodeError ? (
-          <span className="flex items-center gap-1.5 text-error">
+          <span className="flex items-center gap-1.5 text-error text-xs">
             <span className="dot error" />
             <span className="truncate max-w-[200px]" title={nodeError}>{nodeError}</span>
           </span>
         ) : lastCommsAt ? (
-          <span className="flex items-center gap-1.5 text-text-muted">
+          <span className="flex items-center gap-1.5 text-text-muted text-xs">
             <span className="dot" />
             <span className="mono">{timeAgo(lastCommsAt)}</span>
           </span>
         ) : address ? (
-          <span className="flex items-center gap-1.5 text-text-muted">
+          <span className="flex items-center gap-1.5 text-text-muted text-xs">
             <span className="dot muted" />
             <span>connecting…</span>
           </span>
         ) : null}
       </div>
 
+      {/* Center: tab selector (only when wallet connected) */}
+      {address && (
+        <div className="absolute left-1/2 flex items-center gap-1" style={{ transform: 'translateX(-50%)' }}>
+          <button
+            className={`tab${activeTab === 'main' ? ' active' : ''}`}
+            onClick={() => onTabChange('main')}
+          >
+            Main
+          </button>
+          <button
+            className={`tab${activeTab === 'history' ? ' active' : ''}`}
+            onClick={() => onTabChange('history')}
+          >
+            History
+          </button>
+        </div>
+      )}
+
+      {/* Right: session key + chain + address + disconnect */}
       <div className="flex items-center gap-2">
         {address && sessionKey && (
           <span
@@ -121,11 +144,9 @@ export default function WalletBar({
             </button>
           </>
         ) : (
-          <>
-            <button className="btn btn-primary btn-sm" onClick={onConnect} disabled={isConnecting}>
-              {isConnecting ? <span className="spinner" /> : 'Connect MetaMask'}
-            </button>
-          </>
+          <button className="btn btn-primary btn-sm" onClick={onConnect} disabled={isConnecting}>
+            {isConnecting ? <span className="spinner" /> : 'Connect MetaMask'}
+          </button>
         )}
       </div>
     </nav>

--- a/playground/src/components/WalletBar.tsx
+++ b/playground/src/components/WalletBar.tsx
@@ -112,7 +112,7 @@ export default function WalletBar({
             style={{ borderColor: 'rgba(245,166,35,0.4)', color: 'var(--accent)' }}
           >
             <Key size={11} />
-            <span>SK · {formatSkExpiry(sessionKey)}</span>
+            <span className="mono">{sessionKey.sessionKeyAddress.slice(0, 6)}…{sessionKey.sessionKeyAddress.slice(-4)} · {formatSkExpiry(sessionKey)}</span>
             <button
               type="button"
               className="text-text-muted hover:text-error transition-colors"

--- a/playground/src/hooks/useNitrolite.ts
+++ b/playground/src/hooks/useNitrolite.ts
@@ -51,10 +51,15 @@ export function useNitrolite(
   const currentChainIdRef = useRef<bigint | null>(currentChainId ?? null);
   useEffect(() => { currentChainIdRef.current = currentChainId ?? null; }, [currentChainId]);
 
+  // Stored factory that creates a final Client with the pre-computed RPC options.
+  // Used by the fast-path rebuild (signer-only change) to skip the probe phase.
+  const buildClientRef = useRef<((s: StateSigner, t: TransactionSigner) => Promise<Client>) | null>(null);
+  // Track previous identity so we can detect signer-only changes.
+  const prevAddressRef = useRef<Address | null>(null);
+  const prevWalletClientRef = useRef<WalletClient | null>(null);
+
   const touch = useCallback(() => setLastCommsAt(new Date()), []);
 
-  // Pick the chain to read the on-chain balance from: prefer the current wallet
-  // chain when the asset is deployed there, otherwise fall back to suggestedBlockchainId.
   const balanceChainFor = useCallback((a: Asset): bigint => {
     const cid = currentChainIdRef.current;
     if (cid != null && a.tokens.some(t => t.blockchainId === cid)) return cid;
@@ -71,7 +76,6 @@ export function useNitrolite(
       setBalances(next);
       touch();
 
-      // Re-fetch on-chain balances so they reflect completed deposits/withdrawals.
       const assets = assetsRef.current;
       const ocb: Record<string, Decimal | null> = {};
       await Promise.all(
@@ -90,10 +94,12 @@ export function useNitrolite(
     }
   }, [address, touch, balanceChainFor]);
 
-  // Lifecycle: rebuild client when address or walletClient changes
   useEffect(() => {
     if (!address || !walletClient) {
-      // teardown
+      // Teardown
+      buildClientRef.current = null;
+      prevAddressRef.current = null;
+      prevWalletClientRef.current = null;
       const prev = clientRef.current;
       clientRef.current = null;
       setClient(null);
@@ -102,65 +108,74 @@ export function useNitrolite(
       return;
     }
 
+    // Detect what changed this run.
+    const addressChanged = address !== prevAddressRef.current;
+    const walletClientChanged = walletClient !== prevWalletClientRef.current;
+    prevAddressRef.current = address;
+    prevWalletClientRef.current = walletClient;
+
+    // Build signer for the new session-key state (shared between both paths).
+    let stateSigner: StateSigner;
+    if (sessionKey && sessionKey.walletAddress.toLowerCase() === address.toLowerCase()) {
+      stateSigner = buildSessionKeyStateSigner(sessionKey);
+    } else {
+      const walletSigner = new WalletStateSigner(walletClient) as unknown as StateSigner;
+      stateSigner = new ChannelDefaultSigner(walletSigner);
+    }
+    const txSigner = new WalletTransactionSigner(walletClient) as unknown as TransactionSigner;
+
+    // ── Fast path: only the signer changed ───────────────────────────────────
+    // Skip probe, config fetch, and asset fetch. Swap the client silently
+    // without touching isConnecting / isConnected / chains / assets / balances.
+    if (!addressChanged && !walletClientChanged && buildClientRef.current) {
+      let cancelled = false;
+      const prev = clientRef.current;
+
+      buildClientRef.current(stateSigner, txSigner).then(async newClient => {
+        if (cancelled) { await newClient.close().catch(() => {}); return; }
+        clientRef.current = newClient;
+        setClient(newClient);
+        touch();
+        if (prev) await prev.close().catch(() => {});
+      }).catch(err => {
+        if (!cancelled) setNodeError(err instanceof Error ? err.message : String(err));
+      });
+
+      return () => { cancelled = true; };
+    }
+
+    // ── Full rebuild: address or walletClient changed ─────────────────────────
     let cancelled = false;
     setIsConnecting(true);
     setNodeError(null);
 
     const timer = setTimeout(async () => {
-      // Tear down any existing client before building a new one
       const prev = clientRef.current;
       clientRef.current = null;
       if (prev) {
-        try {
-          await prev.close();
-        } catch {
-          /* ignore */
-        }
+        try { await prev.close(); } catch { /* ignore */ }
       }
 
       try {
-        // State signer choice: session key when active (no MetaMask popup), else
-        // wallet-backed default. txSigner is always wallet-backed because on-chain
-        // txs (deposit/withdraw/checkpoint/approve) must come from the user.
-        let stateSigner: StateSigner;
-        if (sessionKey && sessionKey.walletAddress.toLowerCase() === address.toLowerCase()) {
-          stateSigner = buildSessionKeyStateSigner(sessionKey);
-        } else {
-          // Wrap in ChannelDefaultSigner so the SDK prepends the 0x00 type byte that
-          // the nitronode expects (raw EIP-191 sigs are rejected as "signature type 28").
-          const walletSigner = new WalletStateSigner(walletClient) as unknown as StateSigner;
-          stateSigner = new ChannelDefaultSigner(walletSigner);
-        }
-        const txSigner = new WalletTransactionSigner(walletClient) as unknown as TransactionSigner;
-
-        // Build a temporary client to discover supported chains, then rebuild with their RPCs.
-        // The first connect just needs *some* RPC; we'll add them per chain after getConfig().
         const probe = await Client.create(NODE_URL, stateSigner, txSigner);
-        if (cancelled) {
-          await probe.close().catch(() => {});
-          return;
-        }
+        if (cancelled) { await probe.close().catch(() => {}); return; }
 
         const cfg = await probe.getConfig();
         const chains = cfg.blockchains;
         const assets = await probe.getAssets();
-        if (cancelled) {
-          await probe.close().catch(() => {});
-          return;
-        }
+        if (cancelled) { await probe.close().catch(() => {}); return; }
         await probe.close().catch(() => {});
 
-        // Build final client with all RPC options applied
         const opts = chains
           .map(c => rpcUrlFor(c.id))
           .map((url, i) => (url ? withBlockchainRPC(chains[i].id, url) : null))
           .filter((o): o is NonNullable<typeof o> => o !== null);
 
-        const finalClient = await Client.create(NODE_URL, stateSigner, txSigner, ...opts);
-        if (cancelled) {
-          await finalClient.close().catch(() => {});
-          return;
-        }
+        // Store the builder so signer-only changes can reuse it.
+        buildClientRef.current = (s, t) => Client.create(NODE_URL, s, t, ...opts);
+
+        const finalClient = await buildClientRef.current(stateSigner, txSigner);
+        if (cancelled) { await finalClient.close().catch(() => {}); return; }
 
         clientRef.current = finalClient;
         setClient(finalClient);
@@ -171,7 +186,6 @@ export function useNitrolite(
         setIsConnecting(false);
         touch();
 
-        // Initial balances
         const entries = await finalClient.getBalances(address);
         const nextBal: Record<string, Decimal> = {};
         for (const e of entries) nextBal[e.asset] = e.balance;
@@ -179,7 +193,6 @@ export function useNitrolite(
           setBalances(nextBal);
           touch();
 
-          // On-chain balances per asset on the current wallet chain (or suggestedBlockchainId).
           const ocb: Record<string, Decimal | null> = {};
           await Promise.all(
             assets.map(async a => {
@@ -200,7 +213,7 @@ export function useNitrolite(
           setIsConnected(false);
         }
       }
-    }, 200); // debounce per plan H-2
+    }, 200);
 
     return () => {
       cancelled = true;
@@ -208,8 +221,6 @@ export function useNitrolite(
     };
   }, [address, walletClient, sessionKey, touch]);
 
-  // Re-read on-chain balances whenever the wallet chain changes so the deposit
-  // tab always reflects what the user holds on the currently connected chain.
   useEffect(() => {
     const c = clientRef.current;
     const assets = assetsRef.current;
@@ -227,7 +238,6 @@ export function useNitrolite(
     ).then(() => setOnChainBalances(prev => ({ ...prev, ...ocb }))).catch(() => {});
   }, [address, currentChainId]);
 
-  // Cleanup on unmount
   useEffect(() => {
     return () => {
       const prev = clientRef.current;

--- a/playground/src/hooks/useSessionKey.ts
+++ b/playground/src/hooks/useSessionKey.ts
@@ -5,8 +5,10 @@ import type { Address } from 'viem';
 import type { Client } from '@yellow-org/sdk';
 import {
   loadSessionKey,
+  loadAllSessionKeys,
   saveSessionKey,
   clearSessionKey,
+  selectKeyInStorage,
   registerSessionKey,
   type StoredSessionKey,
 } from '../sessionKey';
@@ -15,9 +17,12 @@ const NODE_URL = import.meta.env.VITE_NITRONODE_URL ?? 'wss://nitronode-sandbox.
 
 export interface UseSessionKeyResult {
   sessionKey: StoredSessionKey | null;
+  allKeys: StoredSessionKey[];
   isRegistering: boolean;
-  register: (client: Client, assetSymbols: string[]) => Promise<void>;
+  register: (client: Client, assetSymbols: string[], expiresAt?: bigint) => Promise<void>;
+  selectKey: (sessionKeyAddress: Address) => void;
   clear: () => void;
+  refreshAllKeys: () => void;
 }
 
 /**
@@ -29,14 +34,17 @@ export interface UseSessionKeyResult {
 export function useSessionKey(address: Address | null): UseSessionKeyResult {
   const [sessionKey, setSessionKey] = useState<StoredSessionKey | null>(null);
   const [isRegistering, setIsRegistering] = useState(false);
+  const [allKeys, setAllKeys] = useState<StoredSessionKey[]>([]);
 
   // Load on address change. loadSessionKey clears expired entries internally.
   useEffect(() => {
     if (!address) {
       setSessionKey(null);
+      setAllKeys([]);
       return;
     }
     setSessionKey(loadSessionKey(NODE_URL, address));
+    setAllKeys(loadAllSessionKeys(NODE_URL, address));
   }, [address]);
 
   // Re-check expiry once a minute so the chip can flip to "expired"/banner can
@@ -49,44 +57,29 @@ export function useSessionKey(address: Address | null): UseSessionKeyResult {
         if (prev?.privateKey === fresh?.privateKey) return prev;
         return fresh;
       });
+      setAllKeys(loadAllSessionKeys(NODE_URL, address));
     }, 60_000);
     return () => clearInterval(id);
   }, [address]);
 
   const register = useCallback(
-    async (client: Client, assetSymbols: string[]) => {
+    async (client: Client, assetSymbols: string[], expiresAt?: bigint) => {
       if (!address || !assetSymbols.length) {
         showErrorToast('Cannot register: missing address or assets');
         return;
       }
       setIsRegistering(true);
       try {
-        // Find next version. Include inactive so we don't collide with prior
-        // (expired or revoked) registrations recorded on the node.
-        let nextVersion = 1n;
-        try {
-          const existing = await client.getLastChannelKeyStates(address, undefined, {
-            includeInactive: true,
-          });
-          if (existing.length) {
-            const highest = existing.reduce((max, s) => {
-              const v = BigInt(s.version);
-              return v > max ? v : max;
-            }, 0n);
-            nextVersion = highest + 1n;
-          }
-        } catch {
-          // First-ever registration may legitimately throw; fall back to 1.
-        }
-
         const sk = await registerSessionKey({
           client,
           walletAddress: address,
           assets: assetSymbols,
-          nextVersion,
+          nextVersion: 1n,
+          expiresAt,
         });
         saveSessionKey(NODE_URL, sk);
         setSessionKey(sk);
+        setAllKeys(loadAllSessionKeys(NODE_URL, address));
         toast.success('Session key active — state ops will no longer prompt MetaMask');
       } catch (err) {
         const e = err as { code?: number; message?: string };
@@ -99,11 +92,26 @@ export function useSessionKey(address: Address | null): UseSessionKeyResult {
     [address],
   );
 
+  const selectKey = useCallback((sessionKeyAddress: Address) => {
+    if (!address) return;
+    const selected = selectKeyInStorage(NODE_URL, address, sessionKeyAddress);
+    if (selected) {
+      setSessionKey(selected);
+      setAllKeys(loadAllSessionKeys(NODE_URL, address));
+      toast(`Switched to session key ${sessionKeyAddress.slice(0, 6)}…${sessionKeyAddress.slice(-4)}`);
+    }
+  }, [address]);
+
   const clear = useCallback(() => {
     if (address) clearSessionKey(NODE_URL, address);
     setSessionKey(null);
+    if (address) setAllKeys(loadAllSessionKeys(NODE_URL, address));
     toast('Session key cleared');
   }, [address]);
 
-  return { sessionKey, isRegistering, register, clear };
+  const refreshAllKeys = useCallback(() => {
+    if (address) setAllKeys(loadAllSessionKeys(NODE_URL, address));
+  }, [address]);
+
+  return { sessionKey, allKeys, isRegistering, register, selectKey, clear, refreshAllKeys };
 }

--- a/playground/src/hooks/useSessionKeyManagement.ts
+++ b/playground/src/hooks/useSessionKeyManagement.ts
@@ -1,0 +1,156 @@
+import { useState, useCallback } from 'react';
+import { toast } from 'sonner';
+import { showErrorToast } from '../toastError';
+import type { Address, WalletClient } from 'viem';
+import {
+  Client,
+  ChannelDefaultSigner,
+  type StateSigner,
+  type TransactionSigner,
+  type ChannelSessionKeyStateV1,
+} from '@yellow-org/sdk';
+import {
+  registerSessionKey,
+  updateSessionKey,
+  loadAllSessionKeys,
+  saveSessionKey,
+  saveKeyInactive,
+  type StoredSessionKey,
+} from '../sessionKey';
+import { WalletStateSigner, WalletTransactionSigner } from '../walletSigners';
+
+const NODE_URL = import.meta.env.VITE_NITRONODE_URL ?? 'wss://nitronode-sandbox.yellow.org/v1/ws';
+
+interface UseSessionKeyManagementResult {
+  serverKeys: ChannelSessionKeyStateV1[];
+  isLoading: boolean;
+  isSubmitting: boolean;
+  fetchKeys: () => Promise<void>;
+  register: (walletAddress: Address, assets: string[], expiresAt: bigint) => Promise<StoredSessionKey | null>;
+  update: (walletAddress: Address, currentKey: ChannelSessionKeyStateV1, assets: string[], expiresAt: bigint) => Promise<StoredSessionKey | null>;
+  revoke: (walletAddress: Address, currentKey: ChannelSessionKeyStateV1) => Promise<void>;
+}
+
+export function useSessionKeyManagement(
+  client: Client | null,
+  address: Address | null,
+  walletClient: WalletClient | null,
+): UseSessionKeyManagementResult {
+  const [serverKeys, setServerKeys] = useState<ChannelSessionKeyStateV1[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const fetchKeys = useCallback(async () => {
+    if (!client || !address) return;
+    setIsLoading(true);
+    try {
+      const keys = await client.getLastChannelKeyStates(address, undefined, { includeInactive: true });
+      setServerKeys(keys);
+    } catch (err) {
+      showErrorToast(`Failed to load session keys: ${(err as Error).message ?? String(err)}`);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [client, address]);
+
+  // Build a temporary wallet-backed Client so signChannelSessionKeyState always
+  // uses the 0x00 wallet signer regardless of what the main client's signer is.
+  const buildWalletOnlyClient = useCallback(async (): Promise<Client | null> => {
+    if (!walletClient) return null;
+    try {
+      const stateSigner = new ChannelDefaultSigner(
+        new WalletStateSigner(walletClient) as unknown as StateSigner,
+      );
+      const txSigner = new WalletTransactionSigner(walletClient) as unknown as TransactionSigner;
+      return await Client.create(NODE_URL, stateSigner, txSigner);
+    } catch {
+      return null;
+    }
+  }, [walletClient]);
+
+  const register = useCallback(async (
+    walletAddress: Address,
+    assets: string[],
+    expiresAt: bigint,
+  ): Promise<StoredSessionKey | null> => {
+    if (!walletClient) { showErrorToast('Wallet not connected'); return null; }
+    setIsSubmitting(true);
+    const signingClient = await buildWalletOnlyClient();
+    if (!signingClient) { showErrorToast('Could not create signing client'); setIsSubmitting(false); return null; }
+    try {
+      const sk = await registerSessionKey({ client: signingClient, walletAddress, assets, nextVersion: 1n, expiresAt });
+      saveSessionKey(NODE_URL, sk);
+      toast.success('Session key registered');
+      await fetchKeys();
+      return sk;
+    } catch (err) {
+      const e = err as { code?: number; message?: string };
+      if (e?.code === 4001) toast('Cancelled');
+      else showErrorToast(`Registration failed: ${e?.message ?? String(err)}`);
+      return null;
+    } finally {
+      setIsSubmitting(false);
+      signingClient.close().catch(() => {});
+    }
+  }, [walletClient, buildWalletOnlyClient, fetchKeys]);
+
+  const update = useCallback(async (
+    walletAddress: Address,
+    currentKey: ChannelSessionKeyStateV1,
+    assets: string[],
+    expiresAt: bigint,
+  ): Promise<StoredSessionKey | null> => {
+    if (!walletClient) { showErrorToast('Wallet not connected'); return null; }
+    const localKey = loadAllSessionKeys(NODE_URL, walletAddress)
+      .find(k => k.sessionKeyAddress.toLowerCase() === currentKey.session_key.toLowerCase());
+    if (!localKey) { showErrorToast('Session key not found in local storage'); return null; }
+    setIsSubmitting(true);
+    const signingClient = await buildWalletOnlyClient();
+    if (!signingClient) { showErrorToast('Could not create signing client'); setIsSubmitting(false); return null; }
+    try {
+      const sk = await updateSessionKey({ client: signingClient, existingKey: localKey, assets, expiresAt });
+      saveSessionKey(NODE_URL, sk);
+      toast.success('Session key updated');
+      await fetchKeys();
+      return sk;
+    } catch (err) {
+      const e = err as { code?: number; message?: string };
+      if (e?.code === 4001) toast('Cancelled');
+      else showErrorToast(`Update failed: ${e?.message ?? String(err)}`);
+      return null;
+    } finally {
+      setIsSubmitting(false);
+      signingClient.close().catch(() => {});
+    }
+  }, [walletClient, buildWalletOnlyClient, fetchKeys]);
+
+  const revoke = useCallback(async (
+    walletAddress: Address,
+    currentKey: ChannelSessionKeyStateV1,
+  ): Promise<void> => {
+    if (!walletClient) { showErrorToast('Wallet not connected'); return; }
+    const localKey = loadAllSessionKeys(NODE_URL, walletAddress)
+      .find(k => k.sessionKeyAddress.toLowerCase() === currentKey.session_key.toLowerCase());
+    if (!localKey) { showErrorToast('Session key not found in local storage'); return; }
+    setIsSubmitting(true);
+    const signingClient = await buildWalletOnlyClient();
+    if (!signingClient) { showErrorToast('Could not create signing client'); setIsSubmitting(false); return; }
+    try {
+      const expiredAt = BigInt(Math.floor(Date.now() / 1000) - 1);
+      const revokedSk = await updateSessionKey({ client: signingClient, existingKey: localKey, assets: localKey.assets, expiresAt: expiredAt });
+      // Persist expired expiresAt to localStorage so allSessionKeys reflects the change immediately.
+      saveKeyInactive(NODE_URL, revokedSk);
+      toast.success('Session key revoked');
+      await fetchKeys();
+    } catch (err) {
+      const e = err as { code?: number; message?: string };
+      if (e?.code === 4001) toast('Cancelled');
+      else showErrorToast(`Revoke failed: ${e?.message ?? String(err)}`);
+    } finally {
+      setIsSubmitting(false);
+      signingClient.close().catch(() => {});
+    }
+  }, [walletClient, buildWalletOnlyClient, fetchKeys]);
+
+  return { serverKeys, isLoading, isSubmitting, fetchKeys, register, update, revoke };
+}

--- a/playground/src/index.css
+++ b/playground/src/index.css
@@ -245,6 +245,145 @@ body {
   max-width: calc(100vw - 32px);
 }
 
+/* ── History: quick-filter cell wrapper ── */
+.qf {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  border-radius: 5px;
+  padding: 2px 4px;
+  margin: -2px -4px;
+  transition: background 0.1s;
+}
+.qf:hover { background: rgba(255,255,255,0.05); }
+.qf.qf-on { background: var(--accent-dim); }
+.qf.qf-on:hover { background: rgba(245,166,35,0.2); }
+.qf::after {
+  content: attr(data-tip);
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 4px 9px;
+  font-size: 11px;
+  color: var(--text-primary);
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.12s;
+  z-index: 300;
+}
+.qf:hover::after { opacity: 1; }
+
+/* ── History: address + copy layout ── */
+.addr-cell {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+.copy-btn-addr {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 2px;
+  color: var(--text-muted);
+  display: inline-flex;
+  line-height: 1;
+  flex-shrink: 0;
+  transition: color 0.12s, opacity 0.12s;
+  opacity: 0;
+}
+.addr-cell:hover .copy-btn-addr { opacity: 1; }
+.copy-btn-addr:hover { color: var(--accent); opacity: 1 !important; }
+
+/* ── History: timestamp format toggle ── */
+.ts-toggle {
+  position: relative;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+}
+.ts-toggle::after {
+  content: attr(data-tip);
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 4px 9px;
+  font-size: 11px;
+  color: var(--text-primary);
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.12s;
+  z-index: 300;
+  font-family: 'Inter', sans-serif;
+}
+.ts-toggle:hover::after { opacity: 1; }
+.ts-toggle:hover > * { color: var(--accent); }
+
+/* ── History: column header filter popovers ── */
+.th-popover-wrap {
+  position: relative;
+  display: inline-block;
+}
+.th-inner {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  user-select: none;
+}
+.th-inner.filterable { cursor: pointer; }
+.th-inner.filterable:hover { color: var(--text-primary); }
+.th-inner.filter-active { color: var(--accent); }
+.th-popover {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px;
+  z-index: 200;
+  min-width: 170px;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.5);
+}
+.th-popover-title {
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-bottom: 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-family: 'Inter', sans-serif;
+}
+.th-popover-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 10px;
+  justify-content: flex-end;
+}
+.th-text-input {
+  background: var(--bg-base);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-size: 12px;
+  color: var(--text-primary);
+  font-family: 'JetBrains Mono', monospace;
+  outline: none;
+  width: 100%;
+  display: block;
+}
+.th-text-input:focus { border-color: var(--accent); }
+.th-text-input::placeholder { color: var(--text-muted); }
+
 /* ── Scrollbar ── */
 ::-webkit-scrollbar { width: 6px; height: 6px; }
 ::-webkit-scrollbar-track { background: transparent; }

--- a/playground/src/sessionKey.ts
+++ b/playground/src/sessionKey.ts
@@ -20,6 +20,7 @@ export interface StoredSessionKey {
   assets: string[];
   expiresAt: string;     // unix seconds, bigint stringified
   userSig: Hex;          // raw EIP-191 (no signer type prefix)
+  isActive?: boolean;    // true = this key is the current signing key
 }
 
 export function storageKeyFor(nodeUrl: string, walletAddress: Address): string {
@@ -34,50 +35,105 @@ export function secondsUntilExpiry(sk: StoredSessionKey): number {
   return Number(sk.expiresAt) - Math.floor(Date.now() / 1000);
 }
 
-export function loadSessionKey(nodeUrl: string, walletAddress: Address): StoredSessionKey | null {
+// Internal helper: read the array from localStorage, migrating old single-key format if needed
+function loadStoredArray(nodeUrl: string, walletAddress: Address): StoredSessionKey[] {
   const key = storageKeyFor(nodeUrl, walletAddress);
   const raw = localStorage.getItem(key);
-  if (!raw) return null;
+  if (!raw) return [];
   try {
-    const parsed = JSON.parse(raw) as StoredSessionKey;
-    if (isExpired(parsed)) {
-      localStorage.removeItem(key);
-      return null;
+    const parsed = JSON.parse(raw);
+    // Migration: if old format is a single object (not array), wrap it
+    if (!Array.isArray(parsed)) {
+      const single = parsed as StoredSessionKey;
+      return [{ ...single, isActive: true }];
     }
-    return parsed;
+    return parsed as StoredSessionKey[];
   } catch {
-    localStorage.removeItem(key);
-    return null;
+    return [];
   }
 }
 
-export function saveSessionKey(nodeUrl: string, sk: StoredSessionKey): void {
-  localStorage.setItem(storageKeyFor(nodeUrl, sk.walletAddress), JSON.stringify(sk));
+// Internal helper: write array back to localStorage
+function saveStoredArray(nodeUrl: string, walletAddress: Address, keys: StoredSessionKey[]): void {
+  localStorage.setItem(storageKeyFor(nodeUrl, walletAddress), JSON.stringify(keys));
 }
 
+// Load the active (signing) key. Returns null if none or if expired.
+export function loadSessionKey(nodeUrl: string, walletAddress: Address): StoredSessionKey | null {
+  const keys = loadStoredArray(nodeUrl, walletAddress);
+  const active = keys.find(k => k.isActive);
+  if (!active) return null;
+  if (isExpired(active)) {
+    // Clear the isActive flag but keep the entry for history display
+    saveStoredArray(nodeUrl, walletAddress, keys.map(k =>
+      k.sessionKeyAddress === active.sessionKeyAddress ? { ...k, isActive: false } : k
+    ));
+    return null;
+  }
+  return active;
+}
+
+// Load ALL stored keys (including expired/revoked, for display in Session Keys tab)
+export function loadAllSessionKeys(nodeUrl: string, walletAddress: Address): StoredSessionKey[] {
+  return loadStoredArray(nodeUrl, walletAddress);
+}
+
+// Save/update a key in the array (upserts by sessionKeyAddress). Marks it as active.
+export function saveSessionKey(nodeUrl: string, sk: StoredSessionKey): void {
+  const keys = loadStoredArray(nodeUrl, sk.walletAddress);
+  // Mark all others inactive
+  const updated = keys
+    .filter(k => k.sessionKeyAddress !== sk.sessionKeyAddress)
+    .map(k => ({ ...k, isActive: false }));
+  updated.push({ ...sk, isActive: true });
+  saveStoredArray(nodeUrl, sk.walletAddress, updated);
+}
+
+// Clear the active key flag (keeps the entry in history) — called when user clears
 export function clearSessionKey(nodeUrl: string, walletAddress: Address): void {
-  localStorage.removeItem(storageKeyFor(nodeUrl, walletAddress));
+  const keys = loadStoredArray(nodeUrl, walletAddress);
+  saveStoredArray(nodeUrl, walletAddress, keys.map(k => ({ ...k, isActive: false })));
+}
+
+// Update a key's stored data (e.g. after revoke, to persist the new expiresAt) without
+// marking it as active. Upserts by sessionKeyAddress.
+export function saveKeyInactive(nodeUrl: string, sk: StoredSessionKey): void {
+  const keys = loadStoredArray(nodeUrl, sk.walletAddress);
+  const rest = keys.filter(k => k.sessionKeyAddress !== sk.sessionKeyAddress);
+  rest.push({ ...sk, isActive: false });
+  saveStoredArray(nodeUrl, sk.walletAddress, rest);
+}
+
+// Select a different key as the active signing key
+export function selectKeyInStorage(nodeUrl: string, walletAddress: Address, sessionKeyAddress: Address): StoredSessionKey | null {
+  const keys = loadStoredArray(nodeUrl, walletAddress);
+  const target = keys.find(k => k.sessionKeyAddress.toLowerCase() === sessionKeyAddress.toLowerCase());
+  if (!target || isExpired(target)) return null;
+  saveStoredArray(nodeUrl, walletAddress, keys.map(k => ({
+    ...k,
+    isActive: k.sessionKeyAddress.toLowerCase() === sessionKeyAddress.toLowerCase(),
+  })));
+  return { ...target, isActive: true };
 }
 
 /**
- * Register a fresh session key against the node using a wallet-backed Client.
- * Returns the persisted record. Caller must already have a Client whose state
- * signer is the wallet (i.e. SK is not active yet) so `signChannelSessionKeyState`
- * pops MetaMask exactly once.
+ * Register a fresh session key. `client` must be wallet-backed (no SK signer active)
+ * so that `signChannelSessionKeyState` produces a 0x00-prefixed wallet signature.
+ * Pass a temporary wallet-only Client from the caller when an SK is active.
  */
 export async function registerSessionKey(args: {
   client: Client;
   walletAddress: Address;
   assets: string[];
   nextVersion: bigint;
+  expiresAt?: bigint;
 }): Promise<StoredSessionKey> {
   const { client, walletAddress, assets, nextVersion } = args;
 
   const skPrivateKey = generatePrivateKey();
   const skAccount = privateKeyToAccount(skPrivateKey);
   const skMsgSigner = new EthereumMsgSigner(skPrivateKey);
-
-  const expiresAtSec = BigInt(Math.floor(Date.now() / 1000) + EXPIRY_SECONDS);
+  const expiresAtSec = args.expiresAt ?? BigInt(Math.floor(Date.now() / 1000) + EXPIRY_SECONDS);
 
   const state: ChannelSessionKeyStateV1 = {
     user_address: walletAddress,
@@ -89,11 +145,8 @@ export async function registerSessionKey(args: {
     session_key_sig: '',
   };
 
-  // user_sig — MetaMask popup (single, EIP-191). SDK strips the signer-type prefix.
   state.user_sig = await client.signChannelSessionKeyState(state);
-  // session_key_sig — purely local (no popup).
   state.session_key_sig = await client.signChannelSessionKeyOwnership(state, skMsgSigner);
-
   await client.submitChannelSessionKeyState(state);
 
   return {
@@ -103,6 +156,45 @@ export async function registerSessionKey(args: {
     version: state.version,
     assets,
     expiresAt: state.expires_at,
+    userSig: state.user_sig as Hex,
+  };
+}
+
+/**
+ * Update an existing session key in-place (same address + private key, incremented version).
+ * Used for renew and revoke. `client` must be wallet-backed — pass a temporary wallet-only
+ * Client from the caller when an SK is active.
+ */
+export async function updateSessionKey(args: {
+  client: Client;
+  existingKey: StoredSessionKey;
+  assets: string[];
+  expiresAt: bigint;
+}): Promise<StoredSessionKey> {
+  const { client, existingKey, assets, expiresAt } = args;
+
+  const nextVersion = BigInt(existingKey.version) + 1n;
+
+  const state: ChannelSessionKeyStateV1 = {
+    user_address: existingKey.walletAddress,
+    session_key: existingKey.sessionKeyAddress,
+    version: nextVersion.toString(),
+    assets,
+    expires_at: expiresAt.toString(),
+    user_sig: '',
+    session_key_sig: '',
+  };
+
+  const skMsgSigner = new EthereumMsgSigner(existingKey.privateKey);
+  state.user_sig = await client.signChannelSessionKeyState(state);
+  state.session_key_sig = await client.signChannelSessionKeyOwnership(state, skMsgSigner);
+  await client.submitChannelSessionKeyState(state);
+
+  return {
+    ...existingKey,
+    version: nextVersion.toString(),
+    assets,
+    expiresAt: expiresAt.toString(),
     userSig: state.user_sig as Hex,
   };
 }

--- a/playground/src/utils.ts
+++ b/playground/src/utils.ts
@@ -1,5 +1,7 @@
 import { isAddress } from 'viem';
 
+export const FAUCET_ASSETS = new Set(['yusd']);
+
 export function formatAddress(address: string): string {
   if (!address || address.length < 10) return address;
   return `${address.slice(0, 6)}…${address.slice(-4)}`;


### PR DESCRIPTION
## New UI surfaces

### Session Keys tab (third top-level tab)

A `SessionKeysTab` component added as the third tab in the WalletBar tab group (`Main | History | Session Keys`). It is only visible when a wallet is connected.

Features:
- **Key table** with columns: Address (truncated mono + copy button), Assets, Expiration, Status, Version, Actions
- **3-way expiry format toggle** on the Expiration column header — cycles `relative` → `UTC date` → `unix timestamp` on click, same UX pattern as the HistoryTab timestamp toggle; format is global to the tab (one click updates all rows)
- **Status badges**: Active (green), Expiring Soon (orange, < 1h), Expired (gray, dimmed row), Revoked (red, dimmed row)
- **Hide / Show expired** toggle to reduce visual clutter
- **Expiring Soon banner** above the card when any key is within the warning threshold
- **Refresh** button re-fetches keys from the server via `client.getLastChannelKeyStates`
- **Register New** primary button opens the register modal
- **Per-row actions depend on status + local private key presence**:
  - Active → Update, Revoke, Use (if not current)
  - Expiring → Renew, Revoke, Use (if not current)
  - Expired/Revoked + key still in localStorage → **Reactivate** (re-registers via update flow at version+1 with future expiry)
  - Expired/Revoked + no local key → no row actions (cannot update without the private key)

### Register / Update modal (`SessionKeyRegisterForm`)

A single component used for both registration and renewal/update, with `mode: 'register' | 'update'`.

- **Asset checkboxes** — select a subset of supported assets; defaults to all selected; "Select all · Clear" shortcuts
- **Expiry picker** — segmented control with three modes: Duration (number + hours/days unit selector, shows computed timestamp below), Date (`datetime-local` input), Unix (raw seconds); switching modes cross-converts the current value
- **Summary box** — read-only sentence describing what the key will authorise and when it expires
- Validation: at least one asset, expiry must be > now + 60s; submit button disabled until valid
- Update mode: pre-fills current assets and expiry, shows "Updating from vN to vN+1"

### Revoke modal (`SessionKeyRevokeModal`)

Confirmation-only modal: shows the truncated key address and asks for explicit confirmation before calling revoke (which sets `expires_at` to the current unix time and submits a new version).

### WalletBar SK chip

The WalletBar SK chip is the single global indicator of the active signing key. To prevent the nav from overflowing on narrow viewports it shows just `🔑 <expiry> ✕` (full address + expiry timestamp in the hover tooltip). The nav layout was also restructured into three flex regions (left / center / right) so the tab selector no longer collides with right-side chips when the window is shrunk.

There is intentionally **no per-channel signer selector** — the active session key is a wallet-level attribute, not a channel attribute, and exposing it per-row falsely implied a per-channel override. Switching the active key is done from the Session Keys tab via the "Use" button.

---

## Data layer changes

### Multi-key localStorage with `isActive` flag

Previously a single `StoredSessionKey` object was stored per `(nodeUrl, walletAddress)` pair. The key is now a `StoredSessionKey[]` array, where exactly one entry may have `isActive: true` at any time.

New functions in `sessionKey.ts`:
- `loadAllSessionKeys` — returns the full array (including expired/revoked), used by SessionKeysTab
- `loadSessionKey` — returns the active non-expired entry, unchanged API for the rest of the app
- `saveKeyInactive` — upserts an entry without marking it active (used after revoke to persist the new expiry)
- `selectKeyInStorage` — sets a different array entry as the active signing key
- Automatic migration: if the stored value is a plain object (old format), it is wrapped into an array with `isActive: true`

### `updateSessionKey` vs `registerSessionKey`

`registerSessionKey` always generates a **fresh** keypair and submits at version 1. Each call creates an entirely new session key address with no server history.

`updateSessionKey` (new) reuses the **existing** private key and address, increments the version, and re-submits. This is the correct path for renew (extend expiry, possibly change assets), revoke (set `expires_at` to now), and the new Reactivate flow on expired/revoked keys. It avoids unnecessary key proliferation and keeps key identity stable across renewals.

### `useSessionKey` additions

- `allKeys: StoredSessionKey[]` — reactive list of all stored keys for the current wallet, used by `SessionKeysTab` to determine which expired/revoked entries can be reactivated
- `selectKey(address)` — select a different stored key as the active signer; triggers client hot-swap
- `refreshAllKeys()` — force a re-read of localStorage (called after register/update/revoke)

---

## Signing correctness fix

`registerSessionKey` and `updateSessionKey` require a **wallet-backed** Client (no SK signer active) because `signChannelSessionKeyState` must produce a `0x00`-prefixed EIP-191 wallet signature. If the main app Client already has an SK signer active, passing it to these functions would produce a `0x01`-prefixed session-key signature, which the broker rejects.

`useSessionKeyManagement` fixes this by building a **temporary wallet-only Client** for every register/update/revoke call:

```typescript
const walletOnlyClient = await Client.create(NODE_URL, walletDefaultSigner, txSigner);
// ... use walletOnlyClient for the signing call only ...
await walletOnlyClient.close();
```

The temporary client is created, used once, and immediately closed. The main app Client is never touched.

---

## Nitrolite client hot-swap

Previously any change to `sessionKey` (or `walletClient`) triggered a full Client rebuild: probe phase, config fetch, asset fetch, `isConnecting = true` flash, UI flicker.

`useNitrolite` now separates two rebuild scenarios:

1. **Full rebuild** — triggered when `address` or `walletClient` changes (new wallet, new chain). Runs the complete probe → config → assets sequence, sets `isConnecting`.

2. **Fast-path (signer-only change)** — triggered when only `sessionKey` changes (register, "Use" button in the Session Keys tab, clear via the WalletBar chip). The hook stores a `buildClientRef` factory that captures the pre-computed per-chain RPC options from the last full rebuild. Switching the signer reuses that factory to create a new Client directly, skipping the probe phase entirely. `isConnecting` is never set, so the UI does not flicker and chains/assets/balances are preserved.

---

## Testing notes

To verify this feature end-to-end against a running Nitronode:

- [x] Connect a wallet; navigate to the **Session Keys** tab — should be empty with a "Register New" button
- [x] Click **Register New**, select a subset of assets, set a 2-hour duration expiry, click Register & Sign — MetaMask pops up once; the new key appears in the table with status "Active" and a truncated address
- [x] Click **Register New** again to add a second key with different assets — both appear in the table
- [x] Click **Update** on the first key — modal opens pre-filled; change expiry to 7 days and click Update & Sign — version increments in the table (e.g. v1 → v2); address stays the same
- [x] Click **Revoke** on the first key — confirm in the modal — status changes to "Revoked" immediately (local optimistic update); row dims; action buttons disabled
- [x] Make a state update (e.g. transfer) while a key is selected — no MetaMask popup
- [x] Make a state update while "Wallet" is selected — MetaMask prompts for signature
- [x] Disconnect and reconnect wallet — active key should be restored from localStorage
- [x] Click **Hide expired** in the Session Keys tab — revoked/expired rows disappear; click again to restore
- [x] Click the Expiration column header repeatedly — format cycles relative → UTC date → unix across all rows
- [x] Let a key expire (use a very short expiry, e.g. 2 minutes) — status badge changes to "Expired", row dims, "Expiring Soon" banner appears before expiry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a dedicated Session Keys tab with key registration, updates, revocation, and expiration tracking.
  * Added a History tab displaying transaction history with filtering, pagination, and detailed confirmation timelines.
  * Added Faucet functionality to request test assets for supported tokens.
  * Introduced tab-based navigation for streamlined access to main actions, history, and session key management.

* **Documentation**
  * Added comprehensive design specifications and HTML mockups for Session Keys, History, and Channels integration UX flows.
  * Added detailed session key usage and implementation guidance documents.

* **Style**
  * Added favicon to the playground.
  * Enhanced UI styling for history filters, session key tables, and navigation components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/layer-3/nitrolite/pull/795?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->