### PR TITLE
feat(faucet-app): toggle per-IP rate limit + move flood protection to ingress

### DIFF
--- a/faucet-app/chart/config/sandbox-v1/faucet.yaml.gotmpl
+++ b/faucet-app/chart/config/sandbox-v1/faucet.yaml.gotmpl
@@ -11,6 +11,12 @@ config:
     tipAmount: 10
   minTransferCount: 5
   cooldownPeriod: 24h
+  # Per-IP flood protection comes from the ingress annotations below
+  # (limit-connections / limit-rps). The app keeps only the per-wallet
+  # cooldown so a single IP can still drip multiple wallets per day —
+  # accepted because each wallet is one-shot and MIN_TRANSFER_COUNT
+  # guards the faucet's runway separately.
+  ipRateLimitEnabled: false
   trustedProxies: ""
   envSecret: ""
 # ownerAddress: "0xccdaC3e7BB78572a5f67A3AA85188FAA8F35549C"
@@ -49,3 +55,12 @@ networking:
     annotations:
       nginx.ingress.kubernetes.io/use-regex: "true"
       nginx.ingress.kubernetes.io/rewrite-target: /$2
+      # ── Per-IP flood protection (NGINX-level) ────────────────────────────
+      # Replaces the app-level per-IP bucket. Effective only when ingress-nginx
+      # sees real client IPs; sandbox-v1 has no Cloudflare in front, so source
+      # IP comes from the GCP LB — verify externalTrafficPolicy=Local on the
+      # ingress-nginx Service before relying on these. Lower than nitronode's
+      # numbers because faucet is rare-write.
+      nginx.ingress.kubernetes.io/limit-connections: "10"        # concurrent / IP
+      nginx.ingress.kubernetes.io/limit-rps: "5"                 # new conns/s / IP
+      nginx.ingress.kubernetes.io/limit-burst-multiplier: "3"

--- a/faucet-app/chart/config/stress-v1/faucet.yaml.gotmpl
+++ b/faucet-app/chart/config/stress-v1/faucet.yaml.gotmpl
@@ -11,6 +11,8 @@ config:
     tipAmount: 10
   minTransferCount: 5
   cooldownPeriod: 24h
+  # Per-IP flood protection lives on the ingress (see annotations below).
+  ipRateLimitEnabled: false
   trustedProxies: ""
   envSecret: ""
 # ownerAddress: "0x5FF0Fdb7A3Cda14387d5ea5A550381d6114D1177"
@@ -49,3 +51,9 @@ networking:
     annotations:
       nginx.ingress.kubernetes.io/use-regex: "true"
       nginx.ingress.kubernetes.io/rewrite-target: /$2
+      # ── Per-IP flood protection (NGINX-level) ────────────────────────────
+      # Replaces the app-level per-IP bucket; see sandbox-v1 for caveats on
+      # source-IP propagation. Lower numbers because faucet is rare-write.
+      nginx.ingress.kubernetes.io/limit-connections: "10"
+      nginx.ingress.kubernetes.io/limit-rps: "5"
+      nginx.ingress.kubernetes.io/limit-burst-multiplier: "3"

--- a/faucet-app/chart/templates/helpers/_common.tpl
+++ b/faucet-app/chart/templates/helpers/_common.tpl
@@ -81,6 +81,8 @@ Returns common environment variables
   value: {{ .Values.config.minTransferCount | print | quote }}
 - name: COOLDOWN_PERIOD
   value: {{ .Values.config.cooldownPeriod | print | quote }}
+- name: IP_RATE_LIMIT_ENABLED
+  value: {{ .Values.config.ipRateLimitEnabled | print | quote }}
 {{- with .Values.config.trustedProxies }}
 - name: TRUSTED_PROXIES
   value: {{ . | print | quote }}

--- a/faucet-app/chart/values.yaml
+++ b/faucet-app/chart/values.yaml
@@ -19,8 +19,14 @@ config:
     tipAmount: 10
   # -- Minimum number of transfers the server should have a balance for to operate
   minTransferCount: 5
-  # -- Cooldown between requests per wallet/IP (Go duration, e.g. 24h, 1h30m)
+  # -- Cooldown between requests per wallet/IP (Go duration, e.g. 24h, 1h30m).
+  # Applies to both the per-address and per-IP buckets when both are active.
   cooldownPeriod: 24h
+  # -- Whether the per-IP rate-limit bucket is active. Set `false` when
+  # ingress-level limits (limit-rps, limit-connections) handle per-IP flood
+  # protection — see networking.ingress.annotations in the per-env values.
+  # Leave `true` only if the faucet is exposed without a fronting ingress.
+  ipRateLimitEnabled: true
   # -- Comma-separated trusted proxy IPs/CIDRs; empty means direct exposure only
   trustedProxies: ""
   # -- Additional environment variables as key-value pairs

--- a/faucet-app/server/.env.example
+++ b/faucet-app/server/.env.example
@@ -24,6 +24,13 @@ OWNER_PRIVATE_KEY=your_owner_private_key_here_without_0x_prefix
 # Optional: default is 24h
 # COOLDOWN_PERIOD=your_cooldown_period_here (e.g., 24h, 1h, 30m)
 
+# Whether the per-IP rate-limit bucket is active.
+# Set false when the fronting ingress enforces per-IP limits — without
+# TRUSTED_PROXIES the app sees the proxy's IP for every request and the
+# per-IP bucket collapses to a single global slot.
+# Optional: default is true.
+# IP_RATE_LIMIT_ENABLED=true
+
 # Nitronode WebSocket URL
 # REQUIRED: The WebSocket endpoint for your Nitronode instance
 NITRONODE_URL=wss://nitronode.example.com/ws

--- a/faucet-app/server/internal/config/config.go
+++ b/faucet-app/server/internal/config/config.go
@@ -24,7 +24,13 @@ type Config struct {
 	StandardTipAmount string `env:"STANDARD_TIP_AMOUNT" env-required:"true" env-description:"Default amount to send per request"`
 	MinTransferCount  int    `env:"MIN_TRANSFER_COUNT" env-required:"true" env-description:"Number of transfers a server should have a balance for to operate"`
 	CooldownPeriod    string `env:"COOLDOWN_PERIOD" env-default:"24h" env-description:"Cooldown between requests per wallet/IP (e.g. 24h, 1h30m)"`
-	TrustedProxies    string `env:"TRUSTED_PROXIES" env-default:"" env-description:"Comma-separated trusted proxy IPs; empty means direct exposure only"`
+	// IPRateLimitEnabled toggles the per-IP bucket. With ingress-level
+	// limits (limit-rps, limit-connections) handling flood protection, the
+	// per-IP app cooldown becomes redundant — and worse, collapses to a
+	// single bucket whenever TRUSTED_PROXIES is unset, since gin's
+	// ClientIP() then returns the ingress pod's address for every request.
+	IPRateLimitEnabled bool   `env:"IP_RATE_LIMIT_ENABLED" env-default:"true" env-description:"Whether the per-IP rate-limit bucket is active. Disable when the ingress is enforcing per-IP limits."`
+	TrustedProxies     string `env:"TRUSTED_PROXIES" env-default:"" env-description:"Comma-separated trusted proxy IPs; empty means direct exposure only"`
 
 	// Log carries LOG_LEVEL / LOG_FORMAT / LOG_OUTPUT (see pkg/log).
 	Log log.Config

--- a/faucet-app/server/internal/server/server.go
+++ b/faucet-app/server/internal/server/server.go
@@ -129,12 +129,24 @@ func (s *Server) requestTokens(c *gin.Context) {
 
 	userAddress = common.HexToAddress(userAddress).Hex()
 
-	// Atomically check-and-record both keys under one lock. This prevents a
-	// blocked IP from burning the wallet's cooldown slot and eliminates TOCTOU.
-	// Every accepted request (including ones that later fail) consumes a slot,
-	// preventing unlimited probing via induced failures.
+	// Atomically check-and-record. When the per-IP bucket is enabled, both
+	// keys are checked under one lock so a blocked IP cannot burn the wallet's
+	// cooldown slot. When disabled (ingress handles per-IP flood protection),
+	// only the wallet bucket is checked. Every accepted request — including
+	// ones that later fail — consumes the slot, blocking probing via induced
+	// failures.
 	clientIP := c.ClientIP()
-	if allowed, blocked := s.rateLimiter.checkAndRecordBoth(userAddress, clientIP); !allowed {
+	var (
+		allowed bool
+		blocked string
+	)
+	if s.config.IPRateLimitEnabled {
+		allowed, blocked = s.rateLimiter.checkAndRecordBoth(userAddress, clientIP)
+	} else {
+		allowed = s.rateLimiter.checkAndRecord(userAddress)
+		blocked = "address"
+	}
+	if !allowed {
 		if blocked == "address" {
 			s.logger.Warn("rate limit exceeded", "key", "address", "address", userAddress)
 		} else {

--- a/faucet-app/server/internal/server/server_test.go
+++ b/faucet-app/server/internal/server/server_test.go
@@ -50,6 +50,7 @@ func defaultConfig() *config.Config {
 		StandardTipAmountDecimal: decimal.RequireFromString("10"),
 		CooldownPeriod:           "24h",
 		CooldownPeriodDuration:   24 * time.Hour,
+		IPRateLimitEnabled:       true,
 		Log:                      log.Config{Level: log.LevelDebug},
 	}
 }
@@ -290,6 +291,39 @@ func TestRateLimiting(t *testing.T) {
 		w2 := httptest.NewRecorder()
 		srv.router.ServeHTTP(w2, req2)
 		assert.Equal(t, http.StatusTooManyRequests, w2.Code)
+	})
+
+	t.Run("with IP rate limit disabled, same IP different wallet succeeds", func(t *testing.T) {
+		mock := defaultMock()
+		cfgNoIP := *cfg
+		cfgNoIP.IPRateLimitEnabled = false
+		srv := NewServer(log.NewNoopLogger(), &cfgNoIP, mock)
+
+		addr1 := common.HexToAddress("0x742D35CC6634c0532925a3B8c17D18fBe3b78890").Hex()
+		addr2 := common.HexToAddress("0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF").Hex()
+
+		body1, _ := json.Marshal(FaucetRequest{UserAddress: addr1})
+		body2, _ := json.Marshal(FaucetRequest{UserAddress: addr2})
+
+		req1 := httptest.NewRequest("POST", "/requestTokens", bytes.NewReader(body1))
+		req1.Header.Set("Content-Type", "application/json")
+		w1 := httptest.NewRecorder()
+		srv.router.ServeHTTP(w1, req1)
+		assert.Equal(t, http.StatusOK, w1.Code)
+
+		// Different wallet, same IP — accepted because per-IP bucket is off.
+		req2 := httptest.NewRequest("POST", "/requestTokens", bytes.NewReader(body2))
+		req2.Header.Set("Content-Type", "application/json")
+		w2 := httptest.NewRecorder()
+		srv.router.ServeHTTP(w2, req2)
+		assert.Equal(t, http.StatusOK, w2.Code)
+
+		// Same wallet still rejected — per-address cooldown stays in force.
+		req3 := httptest.NewRequest("POST", "/requestTokens", bytes.NewReader(body1))
+		req3.Header.Set("Content-Type", "application/json")
+		w3 := httptest.NewRecorder()
+		srv.router.ServeHTTP(w3, req3)
+		assert.Equal(t, http.StatusTooManyRequests, w3.Code)
 	})
 }
 


### PR DESCRIPTION
## Summary

The faucet sits behind the same nginx ingress as nitronode, so per-IP flood protection belongs on the ingress where source IPs are already propagated for nitronode's own rate-limit annotations. Today the app's per-IP bucket actively misbehaves: `TRUSTED_PROXIES` is unset in sandbox/stress, so gin's `ClientIP()` returns the ingress pod address for every request — meaning every wallet across every IP collapses into a single shared cooldown slot. First drip on any wallet locks out the rest of the cluster until the cooldown expires.

- Adds `IP_RATE_LIMIT_ENABLED` (default `true`) so the per-IP bucket can be disabled at runtime without having to populate `TRUSTED_PROXIES`. When disabled, `requestTokens` falls back to `checkAndRecord` on the wallet key only — per-address cooldown stays in force.
- Exposes the toggle in the chart as `config.ipRateLimitEnabled` and emits it through `_common.tpl` env helper.
- Per-env values for `sandbox-v1` and `stress-v1` flip the toggle to `false` and add `nginx.ingress.kubernetes.io/limit-connections`, `limit-rps`, and `limit-burst-multiplier` annotations to the faucet ingress. Limits are lower than nitronode's (10 conn / 5 rps / x3 burst) because the faucet is rare-write.
- Test added: with the toggle off, same IP / different wallets both succeed, but a duplicate wallet request is still rejected.

## Test plan

- [ ] `go test ./faucet-app/...` passes (covers the new toggled-off branch + the existing same-IP-different-wallet rejection when toggled on).
- [ ] `helm template faucet faucet-app/chart -f faucet-app/chart/config/sandbox-v1/faucet.yaml.gotmpl --set image.tag=test` renders `IP_RATE_LIMIT_ENABLED=false` and the three `limit-*` annotations.
- [ ] After rollout: hitting `/requestTokens` from two browsers on the same WAN IP with two different wallets succeeds for both (instead of the second getting 429).
- [ ] Burst test: 30 rapid `/requestTokens` POSTs from a single client get throttled by the ingress (`503` once `limit-rps * burst-multiplier` is exceeded) rather than reaching the app.

## Notes

- Faucet is currently non-prod only (`installed: {{ ne .Environment.Name "prod-v1" }}` in helmfile), so no prod-v1 config change needed.
- `TRUSTED_PROXIES` left empty intentionally — once the per-IP app bucket is off, the app no longer needs the real client IP. If we ever re-enable per-IP at the app, we'll also need to set `TRUSTED_PROXIES` to the ingress-nginx pod CIDR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)