### PR TITLE
release: v1.3.1 → stable

### DIFF
--- a/.github/workflows/publish-sdk-mcp.yml
+++ b/.github/workflows/publish-sdk-mcp.yml
@@ -13,9 +13,13 @@ on:
       - 'sdk/mcp/**'
       - 'sdk/ts/**'
       - 'sdk/ts-compat/**'
-  push:
-    tags:
-      - 'mcp-v*'
+  # Auto-publish on `mcp-v*` tag push is disabled until every npm package in the
+  # release (@yellow-org/sdk, @yellow-org/sdk-compat, @yellow-org/sdk-mcp)
+  # has automated publishing. Until then, publishing is done manually.
+  # push:
+  #   tags:
+  #     - 'mcp-v*'
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -210,7 +214,8 @@ jobs:
     needs:
       - verify-and-pack
       - smoke
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/mcp-v')
+    # Disabled until full release automation; trigger via workflow_dispatch when re-enabling.
+    if: false && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/mcp-v')
     environment: mcp-release
     permissions:
       contents: read
@@ -237,7 +242,8 @@ jobs:
     name: Publish MCP Registry metadata
     runs-on: ubuntu-latest
     needs: publish-npm
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/mcp-v')
+    # Disabled until full release automation; trigger via workflow_dispatch when re-enabling.
+    if: false && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/mcp-v')
     environment: mcp-release
     permissions:
       contents: read

--- a/sdk/mcp/package-lock.json
+++ b/sdk/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yellow-org/sdk-mcp",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yellow-org/sdk-mcp",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/sdk/mcp/package.json
+++ b/sdk/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yellow-org/sdk-mcp",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Unified MCP server for Yellow SDK and Nitrolite protocol context for AI agents and IDEs",
   "type": "module",
   "mcpName": "io.github.layer-3/yellow-sdk-mcp",
@@ -19,10 +19,11 @@
     "start": "tsx src/index.ts",
     "prepare-content": "node scripts/prepare-package-content.mjs",
     "build": "npm run prepare-content && tsc && node scripts/set-executable.mjs dist/index.js",
+    "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true}); require('fs').rmSync('content',{recursive:true,force:true})\"",
     "typecheck": "tsc --noEmit",
     "verify:package": "node scripts/verify-package-content.mjs",
     "verify:release-preflight": "node scripts/verify-release-preflight.mjs",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run clean && npm run build"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/sdk/mcp/server.json
+++ b/sdk/mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.layer-3/yellow-sdk-mcp",
   "description": "MCP server exposing Yellow SDK and Nitrolite protocol reference material to AI agents and IDEs.",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "repository": {
     "url": "https://github.com/layer-3/nitrolite",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "@yellow-org/sdk-mcp",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "transport": {
         "type": "stdio"
       }

--- a/sdk/ts-compat/package-lock.json
+++ b/sdk/ts-compat/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@yellow-org/sdk-compat",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@yellow-org/sdk-compat",
-            "version": "1.3.0",
+            "version": "1.3.1",
             "license": "MIT",
             "dependencies": {
                 "decimal.js": "^10.4.3"
@@ -34,7 +34,7 @@
         },
         "../ts": {
             "name": "@yellow-org/sdk",
-            "version": "1.3.0",
+            "version": "1.3.1",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/sdk/ts-compat/package.json
+++ b/sdk/ts-compat/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@yellow-org/sdk-compat",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "description": "Curated migration layer preserving selected Nitrolite SDK v0.5.3 app-facing APIs over the v1 runtime.",
     "type": "module",
     "sideEffects": false,
@@ -18,7 +18,8 @@
         "drift:check": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js --config jest.config.cjs --runTestsByPath test/unit/client.test.ts test/unit/config.test.ts test/unit/public-api-drift.test.ts",
         "lint": "eslint src test",
         "typecheck": "tsc --noEmit",
-        "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\""
+        "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
+        "prepublishOnly": "npm run clean && npm run build:prod"
     },
     "keywords": [
         "yellow",

--- a/sdk/ts/package-lock.json
+++ b/sdk/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@yellow-org/sdk",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@yellow-org/sdk",
-            "version": "1.3.0",
+            "version": "1.3.1",
             "license": "MIT",
             "dependencies": {
                 "abitype": "^1.2.3",

--- a/sdk/ts/package.json
+++ b/sdk/ts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@yellow-org/sdk",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "description": "The Yellow SDK empowers developers to build high-performance, scalable web3 applications using state channels. It's designed to provide near-instant transactions and significantly improved user experiences by minimizing direct blockchain interactions.",
     "type": "module",
     "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Patch release that re-publishes \`@yellow-org/sdk-compat\` with a correct build. The \`@yellow-org/sdk-compat@1.3.0\` tarball shipped a stale \`dist/\` (built May 5), so it is missing runtime changes from #699 (ts-compat runtime migration surface), #748 (absent-resource GET returns), and #758 (audit final session-key changes). \`@yellow-org/sdk@1.3.0\` rebuilt correctly via its existing \`prepublishOnly\` hook.

## Changes

- Bump \`@yellow-org/sdk\`, \`@yellow-org/sdk-compat\`, \`@yellow-org/sdk-mcp\` → \`1.3.1\` (strict-mirror policy)
- Add \`prepublishOnly: clean + build:prod\` to \`@yellow-org/sdk-compat\`
- Tighten \`@yellow-org/sdk-mcp\` \`prepublishOnly\` to clean \`dist/\` and \`content/\` before build

## Post-merge

- [ ] Deprecate \`@yellow-org/sdk-compat@1.3.0\` on npm
- [ ] Tag \`v1.3.1\` on stable HEAD
- [ ] Local publish \`@yellow-org/sdk@1.3.1\` + \`@yellow-org/sdk-compat@1.3.1\` + \`@yellow-org/sdk-mcp@1.3.1\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)