### PR TITLE
MF3-M04: fix(nitronode): fix uint8 overflow in quorum weight accumulators

### DIFF
--- a/nitronode/api/app_session_v1/create_app_session.go
+++ b/nitronode/api/app_session_v1/create_app_session.go
@@ -75,7 +75,7 @@ func (h *Handler) CreateAppSession(c *rpc.Context) {
 	// derivation, and stored participant list all see the canonical (lowercase, 0x-prefixed)
 	// representation regardless of how the caller cased the address or whether they
 	// included the 0x prefix.
-	var totalWeights uint8
+	var totalWeights uint16
 	participantWeights := make(map[string]uint8)
 	for i, participant := range reqPayload.Definition.Participants {
 		participantWallet, err := core.NormalizeHexAddress(participant.WalletAddress)
@@ -89,12 +89,12 @@ func (h *Handler) CreateAppSession(c *rpc.Context) {
 			c.Fail(rpc.Errorf("duplicate participant address: %s", participant.WalletAddress), "")
 			return
 		}
-		totalWeights += participant.SignatureWeight
+		totalWeights += uint16(participant.SignatureWeight)
 		participantWeights[participantWallet] = participant.SignatureWeight
 		appDef.Participants[i].WalletAddress = participantWallet
 	}
 
-	if reqPayload.Definition.Quorum > totalWeights {
+	if uint16(reqPayload.Definition.Quorum) > totalWeights {
 		c.Fail(rpc.Errorf("target quorum (%d) cannot be greater than total sum of weights (%d)",
 			reqPayload.Definition.Quorum, totalWeights), "")
 		return

--- a/nitronode/api/app_session_v1/create_app_session_test.go
+++ b/nitronode/api/app_session_v1/create_app_session_test.go
@@ -1170,6 +1170,88 @@ func TestCreateAppSession_AppRegistryDisabled(t *testing.T) {
 	mockStore.AssertExpectations(t)
 }
 
+// TestCreateAppSession_TotalWeightsOver255 verifies that session creation succeeds when the
+// real sum of participant weights exceeds 255 but the quorum is still achievable. With a
+// uint8 accumulator the sum wraps modulo 256, which can make a valid quorum look unreachable
+// at creation time (e.g. weights 200+200=400 wraps to 144, and quorum=200 falsely appears
+// to exceed total). The accumulator must be at least uint16 to avoid this.
+func TestCreateAppSession_TotalWeightsOver255(t *testing.T) {
+	mockStore := new(MockStore)
+	storeTxProvider := func(fn StoreTxHandler) error {
+		return fn(mockStore)
+	}
+
+	mockSigner := NewMockChannelSigner()
+	mockAssetStore := new(MockAssetStore)
+	mockStatePacker := new(MockStatePacker)
+
+	handler := NewHandler(
+		storeTxProvider,
+		mockAssetStore,
+		&MockActionGateway{},
+		mockSigner,
+		core.NewStateAdvancerV1(mockAssetStore),
+		mockStatePacker,
+		"0xnode",
+		true,
+		metrics.NewNoopRuntimeMetricExporter(),
+		32, 1024, 256, 16, 100,
+	)
+
+	// Two participants each with weight 200; real total = 400, wraps to 144 in uint8.
+	// Quorum = 200 is achievable (wallet1 alone covers it) but 200 > 144 would have
+	// triggered a false rejection before the fix.
+	wallet1 := NewTestAppSessionWallet(t)
+	participant1 := wallet1.Address
+	participant2 := "0x2222222222222222222222222222222222222222"
+
+	appDef := app.AppDefinitionV1{
+		ApplicationID: "test-app",
+		Participants: []app.AppParticipantV1{
+			{WalletAddress: participant1, SignatureWeight: 200},
+			{WalletAddress: participant2, SignatureWeight: 200},
+		},
+		Quorum: 200,
+		Nonce:  12345,
+	}
+	sig1 := wallet1.SignCreateRequest(t, appDef, "")
+
+	reqPayload := rpc.AppSessionsV1CreateAppSessionRequest{
+		Definition: rpc.AppDefinitionV1{
+			Application: "test-app",
+			Participants: []rpc.AppParticipantV1{
+				{WalletAddress: participant1, SignatureWeight: 200},
+				{WalletAddress: participant2, SignatureWeight: 200},
+			},
+			Quorum: 200,
+			Nonce:  "12345",
+		},
+		QuorumSigs: []string{sig1},
+	}
+
+	mockStore.On("GetApp", "test-app").Return(&app.AppInfoV1{
+		App: app.AppV1{ID: "test-app", CreationApprovalNotRequired: true},
+	}, nil).Once()
+	mockStore.On("CreateAppSession", mock.Anything).Return(nil).Once()
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, string(rpc.AppSessionsV1CreateAppSessionMethod), payload),
+	}
+
+	handler.CreateAppSession(ctx)
+
+	require.NotNil(t, ctx.Response)
+	if respErr := ctx.Response.Error(); respErr != nil {
+		t.Fatalf("Unexpected error: total weights 400 with quorum 200 must be accepted, got: %v", respErr)
+	}
+	assert.Equal(t, rpc.MsgTypeResp, ctx.Response.Type)
+	mockStore.AssertExpectations(t)
+}
+
 // TestCreateAppSession_DuplicateParticipantAcrossCases verifies that two participant
 // addresses that differ only in letter case are detected as duplicates. Without address
 // normalization the duplicate-check map would key on the raw representation and accept

--- a/nitronode/api/app_session_v1/create_app_session_test.go
+++ b/nitronode/api/app_session_v1/create_app_session_test.go
@@ -1391,10 +1391,10 @@ func TestCreateAppSession_TotalWeightsWrapToZero(t *testing.T) {
 	mockStore.AssertExpectations(t)
 }
 
-// TestCreateAppSession_QuorumExceedsRealTotalOver255_Rejected verifies that when total
-// weights exceed 255, a quorum genuinely larger than the real total is still rejected.
-// (The fix must not disable the quorum>total guard for the >255 range.)
-func TestCreateAppSession_QuorumExceedsRealTotalOver255_Rejected(t *testing.T) {
+// TestCreateAppSession_QuorumExceedsTotalWeights_Rejected verifies that a quorum genuinely
+// larger than the real total weight is rejected. Uses small weights (100+100=200) because
+// Quorum is uint8 and cannot exceed 255, so this guard cannot be exercised with total > 255.
+func TestCreateAppSession_QuorumExceedsTotalWeights_Rejected(t *testing.T) {
 	mockStore := new(MockStore)
 	storeTxProvider := func(fn StoreTxHandler) error {
 		return fn(mockStore)

--- a/nitronode/api/app_session_v1/create_app_session_test.go
+++ b/nitronode/api/app_session_v1/create_app_session_test.go
@@ -1313,3 +1313,139 @@ func TestCreateAppSession_DuplicateParticipantAcrossCases(t *testing.T) {
 	mockStore.AssertNotCalled(t, "GetApp", mock.Anything)
 	mockStore.AssertNotCalled(t, "CreateAppSession", mock.Anything)
 }
+
+// TestCreateAppSession_TotalWeightsWrapToZero tests the 128+128=256 case where uint8 wraps
+// to exactly 0 — the most damaging overflow (any quorum > 0 appears unreachable).
+func TestCreateAppSession_TotalWeightsWrapToZero(t *testing.T) {
+	mockStore := new(MockStore)
+	storeTxProvider := func(fn StoreTxHandler) error {
+		return fn(mockStore)
+	}
+
+	mockSigner := NewMockChannelSigner()
+	mockAssetStore := new(MockAssetStore)
+	mockStatePacker := new(MockStatePacker)
+
+	handler := NewHandler(
+		storeTxProvider,
+		mockAssetStore,
+		&MockActionGateway{},
+		mockSigner,
+		core.NewStateAdvancerV1(mockAssetStore),
+		mockStatePacker,
+		"0xnode",
+		true,
+		metrics.NewNoopRuntimeMetricExporter(),
+		32, 1024, 256, 16, 100,
+	)
+
+	// 128+128=256 wraps to 0 in uint8 — any quorum > 0 would appear unreachable.
+	wallet1 := NewTestAppSessionWallet(t)
+	participant1 := wallet1.Address
+	participant2 := "0x2222222222222222222222222222222222222222"
+
+	appDef := app.AppDefinitionV1{
+		ApplicationID: "test-app",
+		Participants: []app.AppParticipantV1{
+			{WalletAddress: participant1, SignatureWeight: 128},
+			{WalletAddress: participant2, SignatureWeight: 128},
+		},
+		Quorum: 128,
+		Nonce:  12345,
+	}
+	sig1 := wallet1.SignCreateRequest(t, appDef, "")
+
+	reqPayload := rpc.AppSessionsV1CreateAppSessionRequest{
+		Definition: rpc.AppDefinitionV1{
+			Application: "test-app",
+			Participants: []rpc.AppParticipantV1{
+				{WalletAddress: participant1, SignatureWeight: 128},
+				{WalletAddress: participant2, SignatureWeight: 128},
+			},
+			Quorum: 128,
+			Nonce:  "12345",
+		},
+		QuorumSigs: []string{sig1},
+	}
+
+	mockStore.On("GetApp", "test-app").Return(&app.AppInfoV1{
+		App: app.AppV1{ID: "test-app", CreationApprovalNotRequired: true},
+	}, nil).Once()
+	mockStore.On("CreateAppSession", mock.Anything).Return(nil).Once()
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, string(rpc.AppSessionsV1CreateAppSessionMethod), payload),
+	}
+
+	handler.CreateAppSession(ctx)
+
+	require.NotNil(t, ctx.Response)
+	if respErr := ctx.Response.Error(); respErr != nil {
+		t.Fatalf("total weights 256 (128+128) with quorum 128 must be accepted, got: %v", respErr)
+	}
+	assert.Equal(t, rpc.MsgTypeResp, ctx.Response.Type)
+	mockStore.AssertExpectations(t)
+}
+
+// TestCreateAppSession_QuorumExceedsRealTotalOver255_Rejected verifies that when total
+// weights exceed 255, a quorum genuinely larger than the real total is still rejected.
+// (The fix must not disable the quorum>total guard for the >255 range.)
+func TestCreateAppSession_QuorumExceedsRealTotalOver255_Rejected(t *testing.T) {
+	mockStore := new(MockStore)
+	storeTxProvider := func(fn StoreTxHandler) error {
+		return fn(mockStore)
+	}
+
+	handler := NewHandler(
+		storeTxProvider,
+		new(MockAssetStore),
+		&MockActionGateway{},
+		NewMockChannelSigner(),
+		core.NewStateAdvancerV1(new(MockAssetStore)),
+		new(MockStatePacker),
+		"0xnode",
+		true,
+		metrics.NewNoopRuntimeMetricExporter(),
+		32, 1024, 256, 16, 100,
+	)
+
+	// Real total = 200+200 = 400; quorum = 255 (max uint8 but still < 400, so valid).
+	// quorum cannot exceed 255 because the wire type is uint8 — so we can't test quorum=401.
+	// Instead test that quorum=255 (which is < 400) is accepted.
+	// To test actual rejection: use quorum=255 with total weights=100+100=200 (uint8-range).
+	participant1 := "0x1111111111111111111111111111111111111111"
+	participant2 := "0x2222222222222222222222222222222222222222"
+
+	reqPayload := rpc.AppSessionsV1CreateAppSessionRequest{
+		Definition: rpc.AppDefinitionV1{
+			Application: "test-app",
+			Participants: []rpc.AppParticipantV1{
+				{WalletAddress: participant1, SignatureWeight: 100},
+				{WalletAddress: participant2, SignatureWeight: 100},
+			},
+			Quorum: 255, // quorum (255) > real total (200) → must be rejected
+			Nonce:  "12345",
+		},
+		QuorumSigs: []string{"0xdeadbeef"},
+	}
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, string(rpc.AppSessionsV1CreateAppSessionMethod), payload),
+	}
+
+	handler.CreateAppSession(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.Error(t, respErr)
+	assert.Contains(t, respErr.Error(), "quorum")
+	mockStore.AssertExpectations(t)
+}

--- a/nitronode/api/app_session_v1/handler.go
+++ b/nitronode/api/app_session_v1/handler.go
@@ -76,7 +76,7 @@ func NewHandler(
 func (h *Handler) verifyQuorum(tx Store, appSessionId, applicationID string, participantWeights map[string]uint8, requiredQuorum uint8, data []byte, signatures []string) error {
 	// Verify signatures and calculate quorum
 	signedWeights := make(map[string]bool)
-	var achievedQuorum uint8
+	var achievedQuorum uint16
 
 	appSessionSignerValidator := app.NewAppSessionKeySigValidatorV1(
 		func(sessionKeyAddr string) (string, error) {
@@ -112,12 +112,12 @@ func (h *Handler) verifyQuorum(tx Store, appSessionId, applicationID string, par
 		// Add weight if not already counted
 		if !signedWeights[userWallet] {
 			signedWeights[userWallet] = true
-			achievedQuorum += weight
+			achievedQuorum += uint16(weight)
 		}
 	}
 
 	// Check if quorum is met
-	if achievedQuorum < requiredQuorum {
+	if achievedQuorum < uint16(requiredQuorum) {
 		return rpc.Errorf("quorum not met: achieved %d, required %d", achievedQuorum, requiredQuorum)
 	}
 

--- a/nitronode/api/app_session_v1/rebalance_app_sessions_test.go
+++ b/nitronode/api/app_session_v1/rebalance_app_sessions_test.go
@@ -1356,3 +1356,117 @@ func TestRebalanceAppSessions_Error_DifferentApplications(t *testing.T) {
 	mockStore.AssertNotCalled(t, "RecordLedgerEntry", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	mockStore.AssertNotCalled(t, "RecordTransaction", mock.Anything, mock.Anything)
 }
+
+// TestRebalanceAppSessions_VerifyQuorumWeightOver255 ensures verifyQuorum handles combined
+// participant weights exceeding 255 correctly through the RebalanceAppSessions path.
+// RebalanceAppSessions requires ≥2 sessions; both sessions use the >255 weight configuration.
+func TestRebalanceAppSessions_VerifyQuorumWeightOver255(t *testing.T) {
+	mockStore := new(MockStore)
+
+	storeTxProvider := func(fn StoreTxHandler) error {
+		return fn(mockStore)
+	}
+
+	handler := NewHandler(
+		storeTxProvider,
+		nil,
+		&MockActionGateway{},
+		nil,
+		nil,
+		nil,
+		"0xNode",
+		false,
+		metrics.NewNoopRuntimeMetricExporter(),
+		32, 1024, 256, 16, 100,
+	)
+
+	wallet1 := NewTestAppSessionWallet(t)
+	wallet2 := NewTestAppSessionWallet(t)
+
+	// Two sessions, each with two participants weight 200+200=400 and quorum=200.
+	// Old uint8 code wraps achievedQuorum to 144, rejects the valid coalition for each session.
+	sessionID1 := "0x1111111111111111111111111111111111111111111111111111111111111111"
+	sessionID2 := "0x2222222222222222222222222222222222222222222222222222222222222222"
+
+	mkSession := func(id string) *app.AppSessionV1 {
+		return &app.AppSessionV1{
+			SessionID:     id,
+			ApplicationID: "test-app",
+			Participants: []app.AppParticipantV1{
+				{WalletAddress: wallet1.Address, SignatureWeight: 200},
+				{WalletAddress: wallet2.Address, SignatureWeight: 200},
+			},
+			Quorum:  200,
+			Status:  app.AppSessionStatusOpen,
+			Version: 1,
+		}
+	}
+
+	allocs := map[string]map[string]decimal.Decimal{
+		wallet1.Address: {"USDC": decimal.NewFromInt(100)},
+		wallet2.Address: {"USDC": decimal.NewFromInt(50)},
+	}
+
+	mkUpdate := func(id string) (rpc.SignedAppStateUpdateV1, string, string) {
+		core := app.AppStateUpdateV1{
+			AppSessionID: id,
+			Intent:       app.AppStateUpdateIntentRebalance,
+			Version:      2,
+			Allocations: []app.AppAllocationV1{
+				{Participant: wallet1.Address, Asset: "USDC", Amount: decimal.NewFromInt(80)},
+				{Participant: wallet2.Address, Asset: "USDC", Amount: decimal.NewFromInt(70)},
+			},
+		}
+		s1 := wallet1.SignAppStateUpdate(t, core)
+		s2 := wallet2.SignAppStateUpdate(t, core)
+		return rpc.SignedAppStateUpdateV1{
+			AppStateUpdate: rpc.AppStateUpdateV1{
+				AppSessionID: id,
+				Intent:       app.AppStateUpdateIntentRebalance,
+				Version:      "2",
+				Allocations: []rpc.AppAllocationV1{
+					{Participant: wallet1.Address, Asset: "USDC", Amount: "80"},
+					{Participant: wallet2.Address, Asset: "USDC", Amount: "70"},
+				},
+			},
+			QuorumSigs: []string{s1, s2},
+		}, wallet1.Address, wallet2.Address
+	}
+
+	update1, w1addr, w2addr := mkUpdate(sessionID1)
+	update2, _, _ := mkUpdate(sessionID2)
+
+	reqPayload := rpc.AppSessionsV1RebalanceAppSessionsRequest{
+		SignedUpdates: []rpc.SignedAppStateUpdateV1{update1, update2},
+	}
+
+	for _, id := range []string{sessionID1, sessionID2} {
+		mockStore.On("GetAppSession", id).Return(mkSession(id), nil)
+		mockStore.On("GetParticipantAllocations", id).Return(allocs, nil)
+		mockStore.On("UpdateAppSession", mock.MatchedBy(func(s app.AppSessionV1) bool {
+			return s.SessionID == id && s.Version == 2
+		})).Return(nil).Once()
+	}
+	// Each session: wallet1 net -20, wallet2 net +20 → per-session net = 0, no RecordTransaction.
+	mockStore.On("RecordLedgerEntry", w1addr, sessionID1, "USDC", decimal.NewFromInt(-20)).Return(nil)
+	mockStore.On("RecordLedgerEntry", w2addr, sessionID1, "USDC", decimal.NewFromInt(20)).Return(nil)
+	mockStore.On("RecordLedgerEntry", w1addr, sessionID2, "USDC", decimal.NewFromInt(-20)).Return(nil)
+	mockStore.On("RecordLedgerEntry", w2addr, sessionID2, "USDC", decimal.NewFromInt(20)).Return(nil)
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, "app_sessions.v1.rebalance_app_sessions", payload),
+	}
+
+	handler.RebalanceAppSessions(ctx)
+
+	require.NotNil(t, ctx.Response)
+	if respErr := ctx.Response.Error(); respErr != nil {
+		t.Fatalf("combined weight 400 with quorum 200 must pass verifyQuorum in RebalanceAppSessions, got: %v", respErr)
+	}
+	assert.Equal(t, rpc.MsgTypeResp, ctx.Response.Type)
+	mockStore.AssertExpectations(t)
+}

--- a/nitronode/api/app_session_v1/submit_app_state_test.go
+++ b/nitronode/api/app_session_v1/submit_app_state_test.go
@@ -2132,3 +2132,117 @@ func TestSubmitAppState_OperateIntent_DuplicateAllocation_Rejected(t *testing.T)
 	// RecordLedgerEntry must never be called — the request should be rejected before ledger writes
 	mockStore.AssertNotCalled(t, "RecordLedgerEntry", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
+
+// TestSubmitAppState_VerifyQuorumWeightOver255 checks that verifyQuorum correctly accepts a
+// signing coalition whose combined weight exceeds 255. With a uint8 accumulator the sum wraps
+// modulo 256 (e.g. 200+200=400 becomes 144), causing a valid coalition to be spuriously
+// rejected. The accumulator must be at least uint16.
+func TestSubmitAppState_VerifyQuorumWeightOver255(t *testing.T) {
+	mockStore := new(MockStore)
+	storeTxProvider := func(fn StoreTxHandler) error {
+		return fn(mockStore)
+	}
+
+	mockSigner := NewMockChannelSigner()
+	mockAssetStore := new(MockAssetStore)
+	mockStatePacker := new(MockStatePacker)
+
+	handler := NewHandler(
+		storeTxProvider,
+		mockAssetStore,
+		&MockActionGateway{},
+		mockSigner,
+		core.NewStateAdvancerV1(mockAssetStore),
+		mockStatePacker,
+		"0xNode",
+		true,
+		metrics.NewNoopRuntimeMetricExporter(),
+		32, 1024, 256, 16, 100,
+	)
+
+	appSessionID := "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+
+	// Two participants each with weight 200; together 400 > 255, wraps to 144 in uint8.
+	// Quorum = 200: a valid coalition of both signers must be accepted.
+	wallet1 := NewTestAppSessionWallet(t)
+	wallet2 := NewTestAppSessionWallet(t)
+	participant1 := wallet1.Address
+	participant2 := wallet2.Address
+
+	existingSession := &app.AppSessionV1{
+		SessionID:     appSessionID,
+		ApplicationID: "test-app",
+		Participants: []app.AppParticipantV1{
+			{WalletAddress: participant1, SignatureWeight: 200},
+			{WalletAddress: participant2, SignatureWeight: 200},
+		},
+		Quorum:      200,
+		Status:      app.AppSessionStatusOpen,
+		Version:     1,
+		SessionData: "",
+	}
+
+	currentAllocations := map[string]map[string]decimal.Decimal{
+		participant1: {"USDC": decimal.NewFromInt(100)},
+		participant2: {"USDC": decimal.NewFromInt(50)},
+	}
+	sessionBalances := map[string]decimal.Decimal{
+		"USDC": decimal.NewFromInt(150),
+	}
+
+	appStateUpdate := app.AppStateUpdateV1{
+		AppSessionID: appSessionID,
+		Intent:       app.AppStateUpdateIntentOperate,
+		Version:      2,
+		Allocations: []app.AppAllocationV1{
+			{Participant: participant1, Asset: "USDC", Amount: decimal.NewFromInt(100)},
+			{Participant: participant2, Asset: "USDC", Amount: decimal.NewFromInt(50)},
+		},
+		SessionData: "",
+	}
+	// Both participants sign — combined weight 400, wraps to 144 in uint8.
+	sig1 := wallet1.SignAppStateUpdate(t, appStateUpdate)
+	sig2 := wallet2.SignAppStateUpdate(t, appStateUpdate)
+
+	reqPayload := rpc.AppSessionsV1SubmitAppStateRequest{
+		AppStateUpdate: rpc.AppStateUpdateV1{
+			AppSessionID: appSessionID,
+			Intent:       app.AppStateUpdateIntentOperate,
+			Version:      "2",
+			Allocations: []rpc.AppAllocationV1{
+				{Participant: participant1, Asset: "USDC", Amount: "100"},
+				{Participant: participant2, Asset: "USDC", Amount: "50"},
+			},
+			SessionData: "",
+		},
+		QuorumSigs: []string{sig1, sig2},
+	}
+
+	mockStore.On("GetApp", "test-app").Return(&app.AppInfoV1{
+		App: app.AppV1{ID: "test-app", OwnerWallet: "0x0000000000000000000000000000000000000001"},
+	}, nil).Maybe()
+	mockStore.On("GetAppSession", appSessionID).Return(existingSession, nil)
+	mockStore.On("GetParticipantAllocations", appSessionID).Return(currentAllocations, nil)
+	mockStore.On("GetAppSessionBalances", appSessionID).Return(sessionBalances, nil)
+	mockAssetStore.On("GetAssetDecimals", "USDC").Return(uint8(6), nil)
+	mockStore.On("UpdateAppSession", mock.MatchedBy(func(s app.AppSessionV1) bool {
+		return s.Version == 2
+	})).Return(nil)
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, string(rpc.AppSessionsV1SubmitAppStateMethod), payload),
+	}
+
+	handler.SubmitAppState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	if respErr := ctx.Response.Error(); respErr != nil {
+		t.Fatalf("combined weight 400 with quorum 200 must pass verifyQuorum, got: %v", respErr)
+	}
+	assert.Equal(t, rpc.MsgTypeResp, ctx.Response.Type)
+	mockStore.AssertExpectations(t)
+}

--- a/nitronode/api/app_session_v1/submit_app_state_test.go
+++ b/nitronode/api/app_session_v1/submit_app_state_test.go
@@ -2246,3 +2246,114 @@ func TestSubmitAppState_VerifyQuorumWeightOver255(t *testing.T) {
 	assert.Equal(t, rpc.MsgTypeResp, ctx.Response.Type)
 	mockStore.AssertExpectations(t)
 }
+
+// TestSubmitAppState_VerifyQuorumWrapToZero tests the 128+128=256 boundary case in
+// verifyQuorum: uint8 wraps to 0, making any quorum > 0 appear unreachable.
+func TestSubmitAppState_VerifyQuorumWrapToZero(t *testing.T) {
+	mockStore := new(MockStore)
+	storeTxProvider := func(fn StoreTxHandler) error {
+		return fn(mockStore)
+	}
+
+	mockSigner := NewMockChannelSigner()
+	mockAssetStore := new(MockAssetStore)
+	mockStatePacker := new(MockStatePacker)
+
+	handler := NewHandler(
+		storeTxProvider,
+		mockAssetStore,
+		&MockActionGateway{},
+		mockSigner,
+		core.NewStateAdvancerV1(mockAssetStore),
+		mockStatePacker,
+		"0xNode",
+		true,
+		metrics.NewNoopRuntimeMetricExporter(),
+		32, 1024, 256, 16, 100,
+	)
+
+	appSessionID := "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+
+	// 128+128=256 wraps to 0 in uint8; quorum=128 would be considered unreachable in old code.
+	wallet1 := NewTestAppSessionWallet(t)
+	wallet2 := NewTestAppSessionWallet(t)
+	participant1 := wallet1.Address
+	participant2 := wallet2.Address
+
+	existingSession := &app.AppSessionV1{
+		SessionID:     appSessionID,
+		ApplicationID: "test-app",
+		Participants: []app.AppParticipantV1{
+			{WalletAddress: participant1, SignatureWeight: 128},
+			{WalletAddress: participant2, SignatureWeight: 128},
+		},
+		Quorum:      128,
+		Status:      app.AppSessionStatusOpen,
+		Version:     1,
+		SessionData: "",
+	}
+
+	currentAllocations := map[string]map[string]decimal.Decimal{
+		participant1: {"USDC": decimal.NewFromInt(100)},
+		participant2: {"USDC": decimal.NewFromInt(50)},
+	}
+	sessionBalances := map[string]decimal.Decimal{
+		"USDC": decimal.NewFromInt(150),
+	}
+
+	appStateUpdate := app.AppStateUpdateV1{
+		AppSessionID: appSessionID,
+		Intent:       app.AppStateUpdateIntentOperate,
+		Version:      2,
+		Allocations: []app.AppAllocationV1{
+			{Participant: participant1, Asset: "USDC", Amount: decimal.NewFromInt(100)},
+			{Participant: participant2, Asset: "USDC", Amount: decimal.NewFromInt(50)},
+		},
+		SessionData: "",
+	}
+	// Both sign — combined weight 256, wraps to 0 in uint8.
+	sig1 := wallet1.SignAppStateUpdate(t, appStateUpdate)
+	sig2 := wallet2.SignAppStateUpdate(t, appStateUpdate)
+
+	reqPayload := rpc.AppSessionsV1SubmitAppStateRequest{
+		AppStateUpdate: rpc.AppStateUpdateV1{
+			AppSessionID: appSessionID,
+			Intent:       app.AppStateUpdateIntentOperate,
+			Version:      "2",
+			Allocations: []rpc.AppAllocationV1{
+				{Participant: participant1, Asset: "USDC", Amount: "100"},
+				{Participant: participant2, Asset: "USDC", Amount: "50"},
+			},
+			SessionData: "",
+		},
+		QuorumSigs: []string{sig1, sig2},
+	}
+
+	mockStore.On("GetApp", "test-app").Return(&app.AppInfoV1{
+		App: app.AppV1{ID: "test-app", OwnerWallet: "0x0000000000000000000000000000000000000001"},
+	}, nil).Maybe()
+	mockStore.On("GetAppSession", appSessionID).Return(existingSession, nil)
+	mockStore.On("GetParticipantAllocations", appSessionID).Return(currentAllocations, nil)
+	mockStore.On("GetAppSessionBalances", appSessionID).Return(sessionBalances, nil)
+	mockAssetStore.On("GetAssetDecimals", "USDC").Return(uint8(6), nil)
+	mockStore.On("UpdateAppSession", mock.MatchedBy(func(s app.AppSessionV1) bool {
+		return s.Version == 2
+	})).Return(nil)
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, string(rpc.AppSessionsV1SubmitAppStateMethod), payload),
+	}
+
+	handler.SubmitAppState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	if respErr := ctx.Response.Error(); respErr != nil {
+		t.Fatalf("combined weight 256 (128+128) with quorum 128 must pass verifyQuorum, got: %v", respErr)
+	}
+	assert.Equal(t, rpc.MsgTypeResp, ctx.Response.Type)
+	mockStore.AssertExpectations(t)
+}

--- a/nitronode/api/app_session_v1/submit_deposit_state_test.go
+++ b/nitronode/api/app_session_v1/submit_deposit_state_test.go
@@ -1001,3 +1001,155 @@ func TestSubmitDepositState_InvalidDecimalPrecision_Rejected(t *testing.T) {
 	require.NotNil(t, respErr, "Expected error for invalid decimal precision")
 	assert.Contains(t, respErr.Error(), "amount exceeds maximum decimal precision")
 }
+
+// TestSubmitDepositState_VerifyQuorumWeightOver255 ensures verifyQuorum handles combined
+// participant weights exceeding 255 correctly through the SubmitDepositState path.
+func TestSubmitDepositState_VerifyQuorumWeightOver255(t *testing.T) {
+	mockStore := new(MockStore)
+	mockSigner := NewMockChannelSigner()
+	nodeAddress := mockSigner.PublicKey().Address().String()
+	mockAssetStore := new(MockAssetStore)
+	mockStatePacker := new(MockStatePacker)
+
+	handler := &Handler{
+		assetStore:    mockAssetStore,
+		actionGateway: &MockActionGateway{},
+		stateAdvancer: core.NewStateAdvancerV1(mockAssetStore),
+		statePacker:   mockStatePacker,
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockStore)
+		},
+		signer:             mockSigner,
+		nodeAddress:        nodeAddress,
+		appRegistryEnabled: false,
+		metrics:            metrics.NewNoopRuntimeMetricExporter(),
+		maxParticipants:    32,
+		maxSessionData:     1024,
+		maxSessionKeyIDs:   256,
+		maxSignedUpdates:   16,
+	}
+
+	// Participant1 signs both channel state and app state update (weight 200).
+	// Participant2 also signs the app state update (weight 200).
+	// Combined weight 400 > 255; quorum 200. Old uint8 code would wrap to 144, reject.
+	userRawSigner1 := NewMockSigner()
+	userRawSigner2 := NewMockSigner()
+	channelWalletSigner1, _ := core.NewChannelDefaultSigner(userRawSigner1)
+	appWalletSigner1, _ := app.NewAppSessionWalletSignerV1(userRawSigner1)
+	appWalletSigner2, _ := app.NewAppSessionWalletSignerV1(userRawSigner2)
+	participant1 := strings.ToLower(userRawSigner1.PublicKey().Address().String())
+	participant2 := strings.ToLower(userRawSigner2.PublicKey().Address().String())
+	asset := "USDC"
+	homeChannelID := "0xHomeChannel123"
+	depositAmount := decimal.NewFromInt(100)
+	appSessionID := "0xAppSession456"
+
+	existingAppSession := &app.AppSessionV1{
+		SessionID:     appSessionID,
+		ApplicationID: "test-app",
+		Participants: []app.AppParticipantV1{
+			{WalletAddress: participant1, SignatureWeight: 200},
+			{WalletAddress: participant2, SignatureWeight: 200},
+		},
+		Quorum:  200,
+		Nonce:   12345,
+		Status:  app.AppSessionStatusOpen,
+		Version: 1,
+	}
+
+	currentUserState := core.State{
+		ID: core.GetStateID(participant1, asset, 1, 1),
+		Transition: core.Transition{
+			Type: core.TransitionTypeVoid,
+		},
+		Asset:         asset,
+		UserWallet:    participant1,
+		Epoch:         1,
+		Version:       1,
+		HomeChannelID: &homeChannelID,
+		HomeLedger: core.Ledger{
+			TokenAddress: "0xTokenAddress",
+			BlockchainID: 1,
+			UserBalance:  decimal.NewFromInt(500),
+			UserNetFlow:  decimal.NewFromInt(500),
+			NodeBalance:  decimal.NewFromInt(0),
+			NodeNetFlow:  decimal.NewFromInt(0),
+		},
+	}
+
+	incomingUserState := currentUserState.NextState()
+	_, err := incomingUserState.ApplyCommitTransition(appSessionID, depositAmount)
+	require.NoError(t, err)
+
+	mockStatePacker.On("PackState", mock.Anything).Return([]byte("packed"), nil)
+	packedUserState, _ := mockStatePacker.PackState(*incomingUserState)
+	userSig, _ := channelWalletSigner1.Sign(packedUserState)
+	userSigStr := userSig.String()
+	incomingUserState.UserSig = &userSigStr
+
+	appStateUpdateCore := app.AppStateUpdateV1{
+		AppSessionID: appSessionID,
+		Intent:       app.AppStateUpdateIntentDeposit,
+		Version:      2,
+		Allocations: []app.AppAllocationV1{
+			{Participant: participant1, Asset: asset, Amount: depositAmount},
+		},
+	}
+	packedAppUpdate, _ := app.PackAppStateUpdateV1(appStateUpdateCore)
+	appSigBytes1, _ := appWalletSigner1.Sign(packedAppUpdate)
+	appSigHex1 := hexutil.Encode(appSigBytes1)
+	appSigBytes2, _ := appWalletSigner2.Sign(packedAppUpdate)
+	appSigHex2 := hexutil.Encode(appSigBytes2)
+
+	appStateUpdate := rpc.AppStateUpdateV1{
+		AppSessionID: appSessionID,
+		Intent:       app.AppStateUpdateIntentDeposit,
+		Version:      "2",
+		Allocations:  []rpc.AppAllocationV1{{Participant: participant1, Asset: asset, Amount: depositAmount.String()}},
+	}
+
+	mockStore.On("LockUserState", participant1, asset).Return(decimal.Zero, nil).Once()
+	mockStore.On("CheckActiveChannel", participant1, asset).Return("0x03", core.ChannelStatusOpen, nil).Once()
+	mockStore.On("GetLastUserState", participant1, asset, false).Return(currentUserState, nil).Once()
+	mockStore.On("EnsureNoOngoingStateTransitions", participant1, asset).Return(nil).Once()
+	mockAssetStore.On("GetAssetDecimals", asset).Return(uint8(6), nil)
+	mockAssetStore.On("GetTokenDecimals", uint64(1), "0xTokenAddress").Return(uint8(6), nil).Maybe()
+	mockStore.On("GetAppSession", appSessionID).Return(existingAppSession, nil).Once()
+	mockStore.On("GetParticipantAllocations", appSessionID).Return(
+		map[string]map[string]decimal.Decimal{}, nil,
+	).Once()
+	mockStore.On("RecordLedgerEntry", participant1, appSessionID, asset, depositAmount).Return(nil).Once()
+	mockStore.On("UpdateAppSession", mock.MatchedBy(func(session app.AppSessionV1) bool {
+		return session.SessionID == appSessionID && session.Version == 2
+	})).Return(nil).Once()
+	mockStore.On("StoreUserState", mock.MatchedBy(func(state core.State) bool {
+		return state.UserWallet == participant1 && state.NodeSig != nil
+	}), mock.Anything).Return(nil).Once()
+	mockStore.On("RecordTransaction", mock.MatchedBy(func(tx core.Transaction) bool {
+		return tx.TxType == core.TransactionTypeCommit && tx.Amount.Equal(depositAmount)
+	}), mock.Anything).Return(nil).Once()
+
+	rpcState := toRPCState(*incomingUserState)
+	reqPayload := rpc.AppSessionsV1SubmitDepositStateRequest{
+		AppStateUpdate: appStateUpdate,
+		QuorumSigs:     []string{appSigHex1, appSigHex2}, // combined weight 400
+		UserState:      rpcState,
+	}
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, string(rpc.AppSessionsV1SubmitDepositStateMethod), payload),
+	}
+
+	handler.SubmitDepositState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	if respErr := ctx.Response.Error(); respErr != nil {
+		t.Fatalf("combined weight 400 with quorum 200 must pass verifyQuorum in SubmitDepositState, got: %v", respErr)
+	}
+	assert.Equal(t, rpc.MsgTypeResp, ctx.Response.Type)
+	mockStore.AssertExpectations(t)
+}

--- a/nitronode/runtime.go
+++ b/nitronode/runtime.go
@@ -150,6 +150,21 @@ func validateChannelChallengeConfig(minChallenge, maxChallenge uint32) error {
 	return nil
 }
 
+// maxParticipantsUint16Safe is the largest MaxParticipants value that cannot overflow the
+// uint16 quorum-weight accumulators: 257 × 255 = 65535 = math.MaxUint16.
+const maxParticipantsUint16Safe = 257
+
+func validateValidationLimits(vl ValidationLimits) error {
+	if vl.MaxParticipants > maxParticipantsUint16Safe {
+		return fmt.Errorf(
+			"NITRONODE_MAX_PARTICIPANTS must be ≤ %d to prevent quorum-weight overflow (uint16 ceiling), got %d",
+			maxParticipantsUint16Safe,
+			vl.MaxParticipants,
+		)
+	}
+	return nil
+}
+
 // InitBackbone initializes the backbone components of the application.
 func InitBackbone() *Backbone {
 	closers := []func() error{} // collect closer functions for resources that need cleanup
@@ -175,6 +190,9 @@ func InitBackbone() *Backbone {
 	}
 	if err := validateBlockchainGasLimit(conf.BlockchainGasLimit); err != nil {
 		logger.Fatal("invalid blockchain gas limit config", "error", err)
+	}
+	if err := validateValidationLimits(conf.ValidationLimits); err != nil {
+		logger.Fatal("invalid validation limits config", "error", err)
 	}
 
 	logger.Info("config loaded", "version", Version)


### PR DESCRIPTION
## Summary

- `totalWeights` in `CreateAppSession` and `achievedQuorum` in `verifyQuorum` were declared as `uint8`, causing silent modulo-256 wrap-around when participant weights summed above 255
- Widened both accumulators to `uint16` (sufficient for up to 32 participants × 255 weight = 8160)
- No external types changed — `SignatureWeight` and `Quorum` remain `uint8` at the wire/storage layer

## Test plan

- [ ] `TestCreateAppSession_TotalWeightsOver255` — creation succeeds when real total > 255 (previously false-rejected)
- [ ] `TestCreateAppSession_TotalWeightsWrapToZero` — 128+128=256 wrap-to-zero boundary
- [ ] `TestCreateAppSession_QuorumExceedsRealTotalOver255_Rejected` — guard still rejects quorum > real total
- [ ] `TestSubmitAppState_VerifyQuorumWeightOver255` — valid coalition with combined weight > 255 passes
- [ ] `TestSubmitAppState_VerifyQuorumWrapToZero` — 128+128 boundary through SubmitAppState
- [ ] `TestSubmitDepositState_VerifyQuorumWeightOver255` — same coverage through SubmitDepositState
- [ ] `TestRebalanceAppSessions_VerifyQuorumWeightOver255` — same coverage through RebalanceAppSessions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed quorum verification to correctly handle participant signature weights exceeding 255, ensuring app sessions are properly validated regardless of total weight magnitude.

* **Tests**
  * Added comprehensive test coverage for quorum verification edge cases and weight overflow scenarios across multiple operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->