### PR TITLE
MF-L02: fix(nitronode): lock user balance row in HandleHomeChannelCreated + backfill unsigned receiver states

### DIFF
--- a/nitronode/event_handlers/service.go
+++ b/nitronode/event_handlers/service.go
@@ -69,6 +69,19 @@ func (s *EventHandlerService) HandleHomeChannelCreated(ctx context.Context, tx c
 		logger.Warn("channel type mismatch during HomeChannelCreated event", "channelId", chanID, "expectedType", core.ChannelTypeHome, "actualType", channel.Type)
 		return nil
 	}
+
+	// Acquire the user's balance-row lock before mutating channel status or
+	// backfilling the off-chain head. Receiver/release issuance paths lock
+	// the same row up front and then re-check Status via CheckActiveChannel;
+	// without this lock an in-flight RPC can read Status=Void, decide to store
+	// an unsigned receiver row, and commit before we flip to Open — leaving
+	// the latest head unsigned on a technically opened channel. See
+	// HandleHomeChannelCheckpointed and HandleHomeChannelClosed for the same
+	// pattern.
+	if _, err := tx.LockUserState(channel.UserWallet, channel.Asset); err != nil {
+		return err
+	}
+
 	if channel.Status >= core.ChannelStatusOpen {
 		logger.Warn("ignoring replayed HomeChannelCreated event on already-initialized channel",
 			"channelId", chanID, "currentStatus", channel.Status, "currentStateVersion", channel.StateVersion, "eventStateVersion", event.StateVersion)
@@ -87,6 +100,17 @@ func (s *EventHandlerService) HandleHomeChannelCreated(ctx context.Context, tx c
 	}
 
 	if err := tx.UpdateStateSigsIfMissing(event.ChannelID, event.StateVersion, event.UserSig, ""); err != nil {
+		return err
+	}
+
+	// Backfill the node signature on any unsigned receiver-credit state that
+	// landed while the channel was still Void. An unsigned head is possible when
+	// an incoming transfer or release was stored by a concurrent RPC before this
+	// Created event arrived and flipped the channel to Open. The guard inside
+	// backfillOffChainHeadNodeSig ensures only transfer_receive / release heads
+	// are signed, so this is a no-op for the normal case where the head is the
+	// CREATE state itself (already node-signed via the RPC path).
+	if err := s.backfillOffChainHeadNodeSig(ctx, tx, event.ChannelID); err != nil {
 		return err
 	}
 

--- a/nitronode/event_handlers/service.go
+++ b/nitronode/event_handlers/service.go
@@ -215,8 +215,13 @@ func (s *EventHandlerService) HandleHomeChannelCheckpointed(ctx context.Context,
 // backfillOffChainHeadNodeSig loads the off-chain head state for channelID (the highest
 // stored version, regardless of signature status) and node-signs it when the row is
 // present and the node signature is missing. The user signature is intentionally left
-// untouched: when the head was created during a challenge it carries no user signature,
-// and the user must countersign and acknowledge it via the regular RPC flow.
+// untouched: the user must countersign and acknowledge it via the regular RPC flow.
+//
+// Called from two contexts:
+//   - challenge clearance (HandleHomeChannelCheckpointed): the head is an unsigned
+//     receiver credit accumulated during the dispute window.
+//   - channel open (HandleHomeChannelCreated): the head is an unsigned receiver credit
+//     stored by a concurrent RPC while the channel was still Void.
 func (s *EventHandlerService) backfillOffChainHeadNodeSig(ctx context.Context, tx core.ChannelHubEventHandlerStore, channelID string) error {
 	head, err := tx.GetLastStateByChannelID(channelID, false)
 	if err != nil {
@@ -225,14 +230,12 @@ func (s *EventHandlerService) backfillOffChainHeadNodeSig(ctx context.Context, t
 	if head == nil || head.NodeSig != nil {
 		return nil
 	}
-	// Per the challenge-clearance spec the only states accumulated during the dispute
-	// window are receiver credits (transfer_receive, release) — user-initiated ops are
-	// rejected upstream while the channel is Challenged. If the head is some other
-	// transition kind, the invariant has broken upstream and we must not silently
-	// node-sign it. Log it and bail so the caller surfaces the inconsistency.
+	// Only receiver credits (transfer_receive, release) should appear as unsigned heads
+	// in either call context. Any other transition kind means an invariant broke upstream;
+	// do not silently node-sign it — log and bail so the caller surfaces the inconsistency.
 	if head.Transition.Type != core.TransitionTypeTransferReceive &&
 		head.Transition.Type != core.TransitionTypeRelease {
-		log.FromContext(ctx).Warn("off-chain head after challenge clearance is not a receiver state, skipping node-sig backfill",
+		log.FromContext(ctx).Warn("off-chain head is not a receiver state, skipping node-sig backfill",
 			"channelId", channelID,
 			"transitionType", head.Transition.Type,
 			"version", head.Version,

--- a/nitronode/event_handlers/service_test.go
+++ b/nitronode/event_handlers/service_test.go
@@ -44,6 +44,7 @@ func TestHandleHomeChannelCreated_Success(t *testing.T) {
 
 	// Mock expectations
 	mockStore.On("GetChannelByID", channelID).Return(channel, nil)
+	mockStore.On("LockUserState", userWallet, "usdc").Return(decimal.Zero, nil)
 	mockStore.On("UpdateChannel", mock.MatchedBy(func(ch core.Channel) bool {
 		return ch.ChannelID == channelID &&
 			ch.Status == core.ChannelStatusOpen &&
@@ -51,6 +52,8 @@ func TestHandleHomeChannelCreated_Success(t *testing.T) {
 	})).Return(nil)
 	mockStore.On("RefreshUserEnforcedBalance", userWallet, "usdc").Return(nil)
 	mockStore.On("UpdateStateSigsIfMissing", channelID, uint64(1), "", "").Return(nil)
+	// backfillOffChainHeadNodeSig: no unsigned head present → no-op.
+	mockStore.On("GetLastStateByChannelID", channelID, false).Return(nil, nil)
 
 	// Execute
 	err := service.HandleHomeChannelCreated(ctx, mockStore, event)
@@ -99,6 +102,8 @@ func TestHandleHomeChannelCreated_IgnoresReplayOnInitializedChannel(t *testing.T
 			}
 
 			mockStore.On("GetChannelByID", channelID).Return(channel, nil)
+			// LockUserState is called before the replay guard, so it fires even on replays.
+			mockStore.On("LockUserState", channel.UserWallet, channel.Asset).Return(decimal.Zero, nil)
 
 			err := service.HandleHomeChannelCreated(ctx, mockStore, event)
 
@@ -109,6 +114,207 @@ func TestHandleHomeChannelCreated_IgnoresReplayOnInitializedChannel(t *testing.T
 			mockStore.AssertNotCalled(t, "UpdateStateSigsIfMissing", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 		})
 	}
+}
+
+// TestHandleHomeChannelCreated_AcquiresUserLockBeforeMutation pins the race fix:
+// the handler must call LockUserState(userWallet, asset) before UpdateChannel so an
+// in-flight receiver-issuance RPC cannot read Status=Void, store an unsigned receiver
+// row, and commit before we flip to Open. See HandleHomeChannelCheckpointed and
+// HandleHomeChannelClosed for the same pattern.
+func TestHandleHomeChannelCreated_AcquiresUserLockBeforeMutation(t *testing.T) {
+	mockStore := new(MockStore)
+	ctx := log.SetContextLogger(context.Background(), log.NewNoopLogger())
+
+	service := &EventHandlerService{}
+
+	channelID := "0xHomeChannel123"
+	userWallet := "0x1234567890123456789012345678901234567890"
+	asset := "usdc"
+
+	channel := &core.Channel{
+		ChannelID:    channelID,
+		UserWallet:   userWallet,
+		Asset:        asset,
+		Type:         core.ChannelTypeHome,
+		Status:       core.ChannelStatusVoid,
+		StateVersion: 0,
+	}
+
+	event := &core.HomeChannelCreatedEvent{
+		ChannelID:    channelID,
+		StateVersion: 1,
+	}
+
+	var locked bool
+	mockStore.On("GetChannelByID", channelID).Return(channel, nil)
+	mockStore.On("LockUserState", userWallet, asset).
+		Run(func(mock.Arguments) { locked = true }).
+		Return(decimal.Zero, nil)
+	mockStore.On("UpdateChannel", mock.MatchedBy(func(core.Channel) bool {
+		require.True(t, locked, "LockUserState must be called before UpdateChannel")
+		return true
+	})).Return(nil)
+	mockStore.On("RefreshUserEnforcedBalance", userWallet, asset).Return(nil)
+	mockStore.On("UpdateStateSigsIfMissing", channelID, uint64(1), "", "").Return(nil)
+	// backfillOffChainHeadNodeSig: no unsigned head → no-op.
+	mockStore.On("GetLastStateByChannelID", channelID, false).Return(nil, nil)
+
+	err := service.HandleHomeChannelCreated(ctx, mockStore, event)
+	require.NoError(t, err)
+	mockStore.AssertExpectations(t)
+}
+
+// TestHandleHomeChannelCreated_BackfillsUnsignedReceiverStateOnOpen covers the race path
+// where a transfer_receive or release state was stored unsigned while the channel was still
+// Void — because CheckActiveChannel returned Void at the time of issuance. Once the
+// HomeChannelCreated event opens the channel, the handler must backfill the node signature
+// on the unsigned head so future flows treat the credit as fully co-signed.
+func TestHandleHomeChannelCreated_BackfillsUnsignedReceiverStateOnOpen(t *testing.T) {
+	mockStore := new(MockStore)
+	ctx := log.SetContextLogger(context.Background(), log.NewNoopLogger())
+
+	service, nodeAddress := newTestEventHandlerService(t)
+
+	channelID := "0xHomeChannel123"
+	userWallet := "0x1234567890123456789012345678901234567890"
+	asset := "USDC"
+	homeChannelIDPtr := channelID
+	createVersion := uint64(0)
+	headVersion := uint64(1)
+
+	channel := &core.Channel{
+		ChannelID:    channelID,
+		UserWallet:   userWallet,
+		Asset:        asset,
+		Type:         core.ChannelTypeHome,
+		Status:       core.ChannelStatusVoid,
+		StateVersion: createVersion,
+	}
+
+	// Unsigned transfer_receive credit stored before the channel opened.
+	headState := &core.State{
+		ID:            core.GetStateID(userWallet, asset, 0, headVersion),
+		Asset:         asset,
+		UserWallet:    userWallet,
+		Epoch:         0,
+		Version:       headVersion,
+		HomeChannelID: &homeChannelIDPtr,
+		Transition:    core.Transition{Type: core.TransitionTypeTransferReceive},
+		HomeLedger: core.Ledger{
+			TokenAddress: "0xtoken",
+			BlockchainID: 1,
+			UserBalance:  decimal.NewFromInt(100),
+			UserNetFlow:  decimal.Zero,
+			NodeBalance:  decimal.Zero,
+			NodeNetFlow:  decimal.Zero,
+		},
+	}
+
+	event := &core.HomeChannelCreatedEvent{
+		ChannelID:    channelID,
+		StateVersion: createVersion,
+	}
+
+	mockStore.On("GetChannelByID", channelID).Return(channel, nil)
+	mockStore.On("LockUserState", userWallet, asset).Return(decimal.Zero, nil)
+	mockStore.On("UpdateChannel", mock.MatchedBy(func(ch core.Channel) bool {
+		return ch.ChannelID == channelID &&
+			ch.Status == core.ChannelStatusOpen &&
+			ch.StateVersion == createVersion
+	})).Return(nil)
+	mockStore.On("RefreshUserEnforcedBalance", userWallet, asset).Return(nil)
+	// Sig backfill for the create state (event.UserSig is empty).
+	mockStore.On("UpdateStateSigsIfMissing", channelID, createVersion, "", "").Return(nil)
+	// backfillOffChainHeadNodeSig finds the unsigned receiver credit above the create state.
+	mockStore.On("GetLastStateByChannelID", channelID, false).Return(headState, nil)
+
+	var capturedNodeSig string
+	mockStore.On("UpdateStateSigsIfMissing", channelID, headVersion, "", mock.AnythingOfType("string")).
+		Run(func(args mock.Arguments) {
+			capturedNodeSig = args.String(3)
+		}).Return(nil)
+
+	err := service.HandleHomeChannelCreated(ctx, mockStore, event)
+	require.NoError(t, err)
+	require.NotEmpty(t, capturedNodeSig, "node signature must be populated on backfill")
+
+	// Verify the produced signature is from the configured node key.
+	packer := core.NewStatePackerV1(mockEventHandlerAssetStore{})
+	packed, err := packer.PackState(*headState)
+	require.NoError(t, err)
+	sigBytes, err := hexutil.Decode(capturedNodeSig)
+	require.NoError(t, err)
+	validator := core.NewChannelSigValidator(nil)
+	require.NoError(t, validator.Verify(nodeAddress, packed, sigBytes))
+
+	mockStore.AssertExpectations(t)
+}
+
+// TestHandleHomeChannelCreated_HeadAlreadySigned_NoBackfill verifies that when the off-chain
+// head already carries a node signature (the normal case where the create-state is node-signed
+// via the RPC path), the backfill is a no-op and no additional UpdateStateSigsIfMissing call
+// is issued for the head version.
+func TestHandleHomeChannelCreated_HeadAlreadySigned_NoBackfill(t *testing.T) {
+	mockStore := new(MockStore)
+	ctx := log.SetContextLogger(context.Background(), log.NewNoopLogger())
+
+	service, _ := newTestEventHandlerService(t)
+
+	channelID := "0xHomeChannel123"
+	userWallet := "0x1234567890123456789012345678901234567890"
+	asset := "usdc"
+	homeChannelIDPtr := channelID
+	createVersion := uint64(0)
+	headVersion := uint64(1)
+	existingNodeSig := "0xnodesigalreadyhere"
+
+	channel := &core.Channel{
+		ChannelID:    channelID,
+		UserWallet:   userWallet,
+		Asset:        asset,
+		Type:         core.ChannelTypeHome,
+		Status:       core.ChannelStatusVoid,
+		StateVersion: createVersion,
+	}
+
+	// Head state is already node-signed — backfill must be a no-op.
+	headState := &core.State{
+		ID:            core.GetStateID(userWallet, asset, 0, headVersion),
+		Asset:         asset,
+		UserWallet:    userWallet,
+		Epoch:         0,
+		Version:       headVersion,
+		HomeChannelID: &homeChannelIDPtr,
+		Transition:    core.Transition{Type: core.TransitionTypeTransferReceive},
+		HomeLedger: core.Ledger{
+			TokenAddress: "0xtoken",
+			BlockchainID: 1,
+			UserBalance:  decimal.NewFromInt(100),
+			UserNetFlow:  decimal.Zero,
+			NodeBalance:  decimal.Zero,
+			NodeNetFlow:  decimal.Zero,
+		},
+		NodeSig: &existingNodeSig,
+	}
+
+	event := &core.HomeChannelCreatedEvent{
+		ChannelID:    channelID,
+		StateVersion: createVersion,
+	}
+
+	mockStore.On("GetChannelByID", channelID).Return(channel, nil)
+	mockStore.On("LockUserState", userWallet, asset).Return(decimal.Zero, nil)
+	mockStore.On("UpdateChannel", mock.Anything).Return(nil)
+	mockStore.On("RefreshUserEnforcedBalance", userWallet, asset).Return(nil)
+	mockStore.On("UpdateStateSigsIfMissing", channelID, createVersion, "", "").Return(nil)
+	mockStore.On("GetLastStateByChannelID", channelID, false).Return(headState, nil)
+
+	err := service.HandleHomeChannelCreated(ctx, mockStore, event)
+	require.NoError(t, err)
+
+	mockStore.AssertExpectations(t)
+	// Head already node-signed → no second backfill call for the head version.
+	mockStore.AssertNotCalled(t, "UpdateStateSigsIfMissing", channelID, headVersion, "", mock.AnythingOfType("string"))
 }
 
 func TestHandleHomeChannelCheckpointed_Success(t *testing.T) {

--- a/nitronode/event_handlers/service_test.go
+++ b/nitronode/event_handlers/service_test.go
@@ -169,85 +169,98 @@ func TestHandleHomeChannelCreated_AcquiresUserLockBeforeMutation(t *testing.T) {
 // Void — because CheckActiveChannel returned Void at the time of issuance. Once the
 // HomeChannelCreated event opens the channel, the handler must backfill the node signature
 // on the unsigned head so future flows treat the credit as fully co-signed.
+// Both allowed backfill transition types are covered.
 func TestHandleHomeChannelCreated_BackfillsUnsignedReceiverStateOnOpen(t *testing.T) {
-	mockStore := new(MockStore)
-	ctx := log.SetContextLogger(context.Background(), log.NewNoopLogger())
-
-	service, nodeAddress := newTestEventHandlerService(t)
-
-	channelID := "0xHomeChannel123"
-	userWallet := "0x1234567890123456789012345678901234567890"
-	asset := "USDC"
-	homeChannelIDPtr := channelID
-	createVersion := uint64(0)
-	headVersion := uint64(1)
-
-	channel := &core.Channel{
-		ChannelID:    channelID,
-		UserWallet:   userWallet,
-		Asset:        asset,
-		Type:         core.ChannelTypeHome,
-		Status:       core.ChannelStatusVoid,
-		StateVersion: createVersion,
+	cases := []struct {
+		name           string
+		transitionType core.TransitionType
+	}{
+		{"transfer_receive", core.TransitionTypeTransferReceive},
+		{"release", core.TransitionTypeRelease},
 	}
 
-	// Unsigned transfer_receive credit stored before the channel opened.
-	headState := &core.State{
-		ID:            core.GetStateID(userWallet, asset, 0, headVersion),
-		Asset:         asset,
-		UserWallet:    userWallet,
-		Epoch:         0,
-		Version:       headVersion,
-		HomeChannelID: &homeChannelIDPtr,
-		Transition:    core.Transition{Type: core.TransitionTypeTransferReceive},
-		HomeLedger: core.Ledger{
-			TokenAddress: "0xtoken",
-			BlockchainID: 1,
-			UserBalance:  decimal.NewFromInt(100),
-			UserNetFlow:  decimal.Zero,
-			NodeBalance:  decimal.Zero,
-			NodeNetFlow:  decimal.Zero,
-		},
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockStore := new(MockStore)
+			ctx := log.SetContextLogger(context.Background(), log.NewNoopLogger())
+
+			service, nodeAddress := newTestEventHandlerService(t)
+
+			channelID := "0xHomeChannel123"
+			userWallet := "0x1234567890123456789012345678901234567890"
+			asset := "USDC"
+			homeChannelIDPtr := channelID
+			createVersion := uint64(0)
+			headVersion := uint64(1)
+
+			channel := &core.Channel{
+				ChannelID:    channelID,
+				UserWallet:   userWallet,
+				Asset:        asset,
+				Type:         core.ChannelTypeHome,
+				Status:       core.ChannelStatusVoid,
+				StateVersion: createVersion,
+			}
+
+			// Unsigned receiver credit stored before the channel opened.
+			headState := &core.State{
+				ID:            core.GetStateID(userWallet, asset, 0, headVersion),
+				Asset:         asset,
+				UserWallet:    userWallet,
+				Epoch:         0,
+				Version:       headVersion,
+				HomeChannelID: &homeChannelIDPtr,
+				Transition:    core.Transition{Type: tc.transitionType},
+				HomeLedger: core.Ledger{
+					TokenAddress: "0xtoken",
+					BlockchainID: 1,
+					UserBalance:  decimal.NewFromInt(100),
+					UserNetFlow:  decimal.Zero,
+					NodeBalance:  decimal.Zero,
+					NodeNetFlow:  decimal.Zero,
+				},
+			}
+
+			event := &core.HomeChannelCreatedEvent{
+				ChannelID:    channelID,
+				StateVersion: createVersion,
+			}
+
+			mockStore.On("GetChannelByID", channelID).Return(channel, nil)
+			mockStore.On("LockUserState", userWallet, asset).Return(decimal.Zero, nil)
+			mockStore.On("UpdateChannel", mock.MatchedBy(func(ch core.Channel) bool {
+				return ch.ChannelID == channelID &&
+					ch.Status == core.ChannelStatusOpen &&
+					ch.StateVersion == createVersion
+			})).Return(nil)
+			mockStore.On("RefreshUserEnforcedBalance", userWallet, asset).Return(nil)
+			// Sig backfill for the create state (event.UserSig is empty).
+			mockStore.On("UpdateStateSigsIfMissing", channelID, createVersion, "", "").Return(nil)
+			// backfillOffChainHeadNodeSig finds the unsigned receiver credit above the create state.
+			mockStore.On("GetLastStateByChannelID", channelID, false).Return(headState, nil)
+
+			var capturedNodeSig string
+			mockStore.On("UpdateStateSigsIfMissing", channelID, headVersion, "", mock.AnythingOfType("string")).
+				Run(func(args mock.Arguments) {
+					capturedNodeSig = args.String(3)
+				}).Return(nil)
+
+			err := service.HandleHomeChannelCreated(ctx, mockStore, event)
+			require.NoError(t, err)
+			require.NotEmpty(t, capturedNodeSig, "node signature must be populated on backfill")
+
+			// Verify the produced signature is from the configured node key.
+			packer := core.NewStatePackerV1(mockEventHandlerAssetStore{})
+			packed, err := packer.PackState(*headState)
+			require.NoError(t, err)
+			sigBytes, err := hexutil.Decode(capturedNodeSig)
+			require.NoError(t, err)
+			validator := core.NewChannelSigValidator(nil)
+			require.NoError(t, validator.Verify(nodeAddress, packed, sigBytes))
+
+			mockStore.AssertExpectations(t)
+		})
 	}
-
-	event := &core.HomeChannelCreatedEvent{
-		ChannelID:    channelID,
-		StateVersion: createVersion,
-	}
-
-	mockStore.On("GetChannelByID", channelID).Return(channel, nil)
-	mockStore.On("LockUserState", userWallet, asset).Return(decimal.Zero, nil)
-	mockStore.On("UpdateChannel", mock.MatchedBy(func(ch core.Channel) bool {
-		return ch.ChannelID == channelID &&
-			ch.Status == core.ChannelStatusOpen &&
-			ch.StateVersion == createVersion
-	})).Return(nil)
-	mockStore.On("RefreshUserEnforcedBalance", userWallet, asset).Return(nil)
-	// Sig backfill for the create state (event.UserSig is empty).
-	mockStore.On("UpdateStateSigsIfMissing", channelID, createVersion, "", "").Return(nil)
-	// backfillOffChainHeadNodeSig finds the unsigned receiver credit above the create state.
-	mockStore.On("GetLastStateByChannelID", channelID, false).Return(headState, nil)
-
-	var capturedNodeSig string
-	mockStore.On("UpdateStateSigsIfMissing", channelID, headVersion, "", mock.AnythingOfType("string")).
-		Run(func(args mock.Arguments) {
-			capturedNodeSig = args.String(3)
-		}).Return(nil)
-
-	err := service.HandleHomeChannelCreated(ctx, mockStore, event)
-	require.NoError(t, err)
-	require.NotEmpty(t, capturedNodeSig, "node signature must be populated on backfill")
-
-	// Verify the produced signature is from the configured node key.
-	packer := core.NewStatePackerV1(mockEventHandlerAssetStore{})
-	packed, err := packer.PackState(*headState)
-	require.NoError(t, err)
-	sigBytes, err := hexutil.Decode(capturedNodeSig)
-	require.NoError(t, err)
-	validator := core.NewChannelSigValidator(nil)
-	require.NoError(t, validator.Verify(nodeAddress, packed, sigBytes))
-
-	mockStore.AssertExpectations(t)
 }
 
 // TestHandleHomeChannelCreated_HeadAlreadySigned_NoBackfill verifies that when the off-chain


### PR DESCRIPTION
## Summary

- Adds `LockUserState` to `HandleHomeChannelCreated` before the channel status flip, serializing it against concurrent receiver/release issuance RPCs and closing the race where an unsigned receiver state could land on a newly-opened channel
- Adds `backfillOffChainHeadNodeSig` at the end of the handler to node-sign any unsigned `transfer_receive`/`release` head that arrived while the channel was still Void
- Updates the comment and warning log in `backfillOffChainHeadNodeSig` to be caller-agnostic (previously described only the challenge-clearance path; function now has two callers)
- Adds 5 tests: lock ordering, backfill with signature verification, no-backfill when head already signed, updated success and replay tests

## Test plan

- [ ] `go test ./nitronode/event_handlers/...` passes
- [ ] `TestHandleHomeChannelCreated_AcquiresUserLockBeforeMutation` — pins lock-before-mutation ordering
- [ ] `TestHandleHomeChannelCreated_BackfillsUnsignedReceiverStateOnOpen` — verifies node sig produced and valid
- [ ] `TestHandleHomeChannelCreated_HeadAlreadySigned_NoBackfill` — verifies no double-sign

🤖 Generated with [Claude Code](https://claude.com/claude-code)