### PR TITLE
MF3-L01: fix(core): align transaction ID with referencing transition TxID

### DIFF
--- a/nitronode/store/database/transaction.go
+++ b/nitronode/store/database/transaction.go
@@ -14,10 +14,12 @@ var (
 	ErrRecordTransaction            = "failed to record transaction"
 )
 
-// Transaction represents an immutable transaction in the system
-// ID is deterministic based on transaction initiation:
-// 1) Initiated by User: Hash(ToAccount, SenderNewStateID)
-// 2) Initiated by Node: Hash(FromAccount, ReceiverNewStateID)
+// Transaction represents an immutable transaction in the system.
+// ID equals the TxID of the transition that references this transaction
+// (the single source of truth, canonicalised and validated in the state
+// advancer). The TxID is deterministic: Hash(transition.AccountID, newStateID).
+// For transfers, the sender's TransferSend and the receiver's TransferReceive
+// share one TxID and therefore reference this single transaction.
 type Transaction struct {
 	// ID is a 64-character deterministic hash
 	ID                 string               `gorm:"column:id;primaryKey;size:64"`

--- a/pkg/core/state_advancer_test.go
+++ b/pkg/core/state_advancer_test.go
@@ -369,3 +369,32 @@ func TestValidateAdvancement_RejectsOverflowEscrowLedger(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid escrow ledger")
 	assert.Contains(t, err.Error(), "uint256")
 }
+
+// TestValidateAdvancement_RejectsForgedTxID pins the validation boundary that
+// NewTransactionFromTransition now relies on: the advancer recomputes the
+// canonical TxID from the proposed state and rejects any transition carrying a
+// forged TxID, even when the type, account, and amount are otherwise valid.
+func TestValidateAdvancement_RejectsForgedTxID(t *testing.T) {
+	t.Parallel()
+
+	advancer := NewStateAdvancerV1(newMockAssetStore())
+	sig := "0xSig"
+	chanID := "0xChannel"
+
+	current := NewVoidState("USDC", "0xUser")
+	current.HomeChannelID = &chanID
+	current.ID = GetStateID("0xUser", "USDC", 0, 0)
+
+	proposed := current.NextState()
+	_, err := proposed.ApplyHomeDepositTransition(decimal.NewFromInt(10))
+	require.NoError(t, err)
+	proposed.UserSig = &sig
+
+	// Forge the TxID while leaving the type, account, and amount intact, so the
+	// only divergence from the recomputed transition is the transaction ID.
+	proposed.Transition.TxID = "0xforgedtxid"
+
+	err = advancer.ValidateAdvancement(*current, *proposed)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "transaction ID mismatch")
+}

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -928,16 +928,18 @@ func NewTransactionFromTransition(senderState *State, receiverState *State, tran
 	}
 
 	var receiverStateID *string
-	var txID string
-	var err error
 	if receiverState != nil {
 		receiverStateID = &receiverState.ID
-		txID, err = GetReceiverTransactionID(fromAccount, receiverState.ID)
-	} else {
-		txID, err = GetSenderTransactionID(toAccount, senderState.ID)
 	}
-	if err != nil {
-		return nil, err
+
+	// The transaction ID must equal the transition's TxID so that the transition
+	// row references this transaction. For transfers, the sender's TransferSend and
+	// the receiver's TransferReceive share the same TxID, so both must point at this
+	// single transaction. The TxID is canonicalised and validated in the state
+	// advancer, making it the single source of truth.
+	txID := transition.TxID
+	if txID == "" {
+		return nil, fmt.Errorf("transition has empty txID")
 	}
 
 	return NewTransaction(

--- a/pkg/core/types_test.go
+++ b/pkg/core/types_test.go
@@ -580,6 +580,14 @@ func TestNewTransactionFromTransition(t *testing.T) {
 	assert.Equal(t, TransactionTypeTransfer, tx.TxType)
 	assert.Equal(t, transferTxID, tx.ID)
 
+	// The receiver's TransferReceive transition must carry the same TxID as the
+	// sender's TransferSend, so both states reference the single transfer
+	// transaction recorded above.
+	receiveTransition, err := receiverState.ApplyTransferReceiveTransition(senderState.UserWallet, decimal.NewFromInt(10), transferTxID)
+	require.NoError(t, err)
+	assert.Equal(t, transferTxID, receiveTransition.TxID)
+	assert.Equal(t, transition.TxID, receiveTransition.TxID)
+
 	// TransferSend error: nil receiverState
 	_, err = NewTransactionFromTransition(senderState, nil, transition)
 	assert.Error(t, err)

--- a/pkg/core/types_test.go
+++ b/pkg/core/types_test.go
@@ -550,23 +550,46 @@ func TestNewTransactionFromTransition(t *testing.T) {
 	senderState.EscrowChannelID = new(string)
 	*senderState.EscrowChannelID = "EC"
 
-	// HomeDeposit
-	transition := Transition{Type: TransitionTypeHomeDeposit, Amount: decimal.NewFromInt(10)}
+	// HomeDeposit: transaction ID must equal the transition's TxID,
+	// computed over the HomeChannelID (AccountID), not the UserWallet.
+	homeDepositTxID, err := GetSenderTransactionID(*senderState.HomeChannelID, senderState.ID)
+	require.NoError(t, err)
+	transition := Transition{Type: TransitionTypeHomeDeposit, Amount: decimal.NewFromInt(10), AccountID: *senderState.HomeChannelID, TxID: homeDepositTxID}
 	tx, err := NewTransactionFromTransition(senderState, nil, transition)
 	require.NoError(t, err)
 	assert.Equal(t, TransactionTypeHomeDeposit, tx.TxType)
+	assert.Equal(t, homeDepositTxID, tx.ID)
 
-	// TransferSend
-	transition = Transition{Type: TransitionTypeTransferSend, Amount: decimal.NewFromInt(10), AccountID: "REC"}
+	// EscrowDeposit: same divergence — ID over EscrowChannelID, not UserWallet.
+	escrowDepositTxID, err := GetSenderTransactionID(*senderState.EscrowChannelID, senderState.ID)
+	require.NoError(t, err)
+	transition = Transition{Type: TransitionTypeEscrowDeposit, Amount: decimal.NewFromInt(10), AccountID: *senderState.EscrowChannelID, TxID: escrowDepositTxID}
+	tx, err = NewTransactionFromTransition(senderState, nil, transition)
+	require.NoError(t, err)
+	assert.Equal(t, TransactionTypeEscrowDeposit, tx.TxType)
+	assert.Equal(t, escrowDepositTxID, tx.ID)
+
+	// TransferSend: sender and receiver transitions share this TxID, computed
+	// over the recipient (AccountID) and the sender's state ID.
+	transferTxID, err := GetSenderTransactionID("REC", senderState.ID)
+	require.NoError(t, err)
+	transition = Transition{Type: TransitionTypeTransferSend, Amount: decimal.NewFromInt(10), AccountID: "REC", TxID: transferTxID}
 	receiverState := NewVoidState("A", "REC")
 	tx, err = NewTransactionFromTransition(senderState, receiverState, transition)
 	require.NoError(t, err)
 	assert.Equal(t, TransactionTypeTransfer, tx.TxType)
+	assert.Equal(t, transferTxID, tx.ID)
 
 	// TransferSend error: nil receiverState
 	_, err = NewTransactionFromTransition(senderState, nil, transition)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "receiver state must not be nil")
+
+	// Empty TxID is rejected.
+	transition = Transition{Type: TransitionTypeHomeDeposit, Amount: decimal.NewFromInt(10), AccountID: *senderState.HomeChannelID}
+	_, err = NewTransactionFromTransition(senderState, nil, transition)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "empty txID")
 
 	// Invalid
 	transition = Transition{Type: 255}


### PR DESCRIPTION
## Finding (MF3-L01)

Each transition stores a `txID` pointing to its transaction. The ID `NewTransactionFromTransition` generated did **not** match that `txID` for `HomeDeposit`, `TransferSend`, and `TransferReceive` (and, missed by the finding, `EscrowDeposit`).

## Root cause

Two ID conventions collided:

- **Transition `TxID`** (set by `Apply*`, validated in `state_advancer.go` via `Equal`) = `getTransactionID(transition.AccountID, stateID)`.
- **Transaction `ID`** (recomputed in `NewTransactionFromTransition`) = `getTransactionID(toAccount|fromAccount, stateID)`.

They matched only when `AccountID` equalled `toAccount`/`fromAccount`. They diverged for:

| Transition | transition.TxID | old recomputed ID |
|---|---|---|
| HomeDeposit | (HomeChannelID, sID) | (UserWallet, sID) |
| EscrowDeposit | (EscrowChannelID, sID) | (UserWallet, sID) |
| TransferSend | (recipient, sID) | (UserWallet, receiverID) |
| TransferReceive | shares Send's TxID | — |

TransferSend/Receive share one TxID (`channel_v1/handler.go:108`), so a transfer must produce a single transaction referenced by both. The old code produced an ID neither transition referenced → dangling `tx_id`.

## Fix

`NewTransactionFromTransition` now uses `transition.TxID` directly as the transaction ID (rejecting empty). The `TxID` is canonicalised and validated in the state advancer, so it is the single source of truth and cannot be forged by a client. Fixes all four cases by construction and drops the fragile parallel recompute.

- `pkg/core/types.go` — use `transition.TxID`.
- `nitronode/store/database/transaction.go` — doc comment updated to the new convention.
- `pkg/core/types_test.go` — assert `tx.ID == transition.TxID` for HomeDeposit / EscrowDeposit / TransferSend, plus empty-TxID rejection.

## Notes

- Pre-fix rows carry the old (wrong) IDs. No backfill included — history intentionally out of scope.

## Testing

- `go test ./pkg/core/... ./nitronode/...` — pass
- `go vet` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)