### PR TITLE
MF3-C01: fix(nitronode): require enforcing deposit states before crediting off-chain

### DIFF
--- a/nitronode/event_handlers/service_test.go
+++ b/nitronode/event_handlers/service_test.go
@@ -1633,7 +1633,9 @@ func TestHandleHomeChannelClosed_ChallengeRescue_Squash(t *testing.T) {
 	require.True(t, rescueAmount.Equal(capturedState.Transition.Amount))
 	require.Nil(t, capturedState.HomeChannelID, "rescue state must be off-channel")
 	require.Equal(t, prevState.Epoch+1, capturedState.Epoch)
-	require.Equal(t, uint64(0), capturedState.Version)
+	// Fresh-epoch in-channel rescue lands at version=1: version=0 is
+	// reserved as the Void/no-on-chain-state sentinel.
+	require.Equal(t, uint64(1), capturedState.Version)
 	require.Nil(t, capturedState.NodeSig, "rescue state is stored unsigned, like a credit to a user with no open home channel")
 	require.True(t, rescueAmount.Equal(capturedState.HomeLedger.UserBalance))
 	require.Empty(t, capturedState.HomeLedger.TokenAddress)
@@ -1730,7 +1732,8 @@ func TestHandleHomeChannelClosed_ChallengeRescue_NoCredits(t *testing.T) {
 	require.True(t, capturedState.HomeLedger.UserBalance.IsZero())
 	require.Nil(t, capturedState.HomeChannelID)
 	require.Equal(t, prevState.Epoch+1, capturedState.Epoch)
-	require.Equal(t, uint64(0), capturedState.Version)
+	// In-channel rescue opens the fresh epoch at version=1.
+	require.Equal(t, uint64(1), capturedState.Version)
 
 	mockStore.AssertExpectations(t)
 }
@@ -1808,7 +1811,8 @@ func TestHandleHomeChannelClosed_ChallengeRescue_NegativeNet_ClampsToZero(t *tes
 	require.True(t, capturedState.HomeLedger.UserBalance.IsZero())
 	require.Nil(t, capturedState.HomeChannelID)
 	require.Equal(t, prevState.Epoch+1, capturedState.Epoch)
-	require.Equal(t, uint64(0), capturedState.Version)
+	// In-channel rescue opens the fresh epoch at version=1.
+	require.Equal(t, uint64(1), capturedState.Version)
 
 	mockStore.AssertExpectations(t)
 }

--- a/nitronode/store/database/db_store.go
+++ b/nitronode/store/database/db_store.go
@@ -47,8 +47,8 @@ func (s *DBStore) GetUserBalances(wallet string) ([]core.BalanceEntry, error) {
 	result := make([]core.BalanceEntry, 0, len(balances))
 	for _, balance := range balances {
 		result = append(result, core.BalanceEntry{
-			Asset:   balance.Asset,
-			Balance: balance.Balance,
+			Asset:    balance.Asset,
+			Balance:  balance.Balance,
 			Enforced: balance.Enforced,
 		})
 	}
@@ -164,6 +164,7 @@ func (s *DBStore) EnsureNoOngoingStateTransitions(wallet, asset string) error {
 		TransitionType       core.TransitionType
 		StateVersion         uint64
 		HomeChannelVersion   *uint64
+		HomeChannelStatus    *core.ChannelStatus
 		EscrowChannelVersion *uint64
 	}
 
@@ -173,6 +174,7 @@ func (s *DBStore) EnsureNoOngoingStateTransitions(wallet, asset string) error {
 			s.transition_type as transition_type,
 			s.version as state_version,
 			hc.state_version as home_channel_version,
+			hc.status as home_channel_status,
 			ec.state_version as escrow_channel_version
 		FROM channel_states s
 		LEFT JOIN channels hc ON hc.channel_id = s.home_channel_id
@@ -198,14 +200,24 @@ func (s *DBStore) EnsureNoOngoingStateTransitions(wallet, asset string) error {
 	// Validation logic by transition type
 	switch result.TransitionType {
 	case core.TransitionTypeHomeDeposit:
-		// Verify last_state.version == home_channel.state_version
-		if result.HomeChannelVersion == nil || result.StateVersion != *result.HomeChannelVersion {
+		// Verify last_state.version == home_channel.state_version AND channel is Open.
+		// Defence-in-depth: without the status check, a Void channel
+		// (status=Void, state_version=0) trivially matches a state_version=0 signed
+		// HomeDeposit and the gate would treat the deposit as settled on-chain before
+		// any confirmation event lands.
+		if result.HomeChannelVersion == nil ||
+			result.HomeChannelStatus == nil ||
+			result.StateVersion != *result.HomeChannelVersion ||
+			*result.HomeChannelStatus != core.ChannelStatusOpen {
 			return fmt.Errorf("home deposit is still ongoing")
 		}
 
 	case core.TransitionTypeHomeWithdrawal:
-		// Verify last_state.version == home_channel.state_version
-		if result.HomeChannelVersion == nil || result.StateVersion != *result.HomeChannelVersion {
+		// Verify last_state.version == home_channel.state_version AND channel is Open.
+		if result.HomeChannelVersion == nil ||
+			result.HomeChannelStatus == nil ||
+			result.StateVersion != *result.HomeChannelVersion ||
+			*result.HomeChannelStatus != core.ChannelStatusOpen {
 			return fmt.Errorf("home withdrawal is still ongoing")
 		}
 

--- a/nitronode/store/database/db_store_test.go
+++ b/nitronode/store/database/db_store_test.go
@@ -809,6 +809,46 @@ func TestDBStore_EnsureNoOngoingStateTransitions(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "home chain migration is still ongoing")
 	})
+
+	t.Run("HomeDeposit - Void channel version=0 must block", func(t *testing.T) {
+		// Pre-fix bug: a Void channel (status=Void, state_version=0) trivially
+		// matched a node-signed HomeDeposit at version=0, so the gate let the user
+		// spend funds that were never deposited on-chain. The fix requires
+		// channel.status == Open in addition to the version match.
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+
+		store := NewDBStore(db)
+
+		voidChannel := newHomeChannel(0)
+		voidChannel.Status = core.ChannelStatusVoid
+		require.NoError(t, store.CreateChannel(voidChannel))
+
+		storeState(t, store, newSignedState(0, core.TransitionTypeHomeDeposit, false))
+
+		err := store.EnsureNoOngoingStateTransitions(wallet, asset)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "home deposit is still ongoing")
+	})
+
+	t.Run("HomeWithdrawal - Void channel version=0 must block", func(t *testing.T) {
+		// Mirror of the HomeDeposit Void/v=0 regression: the version-match-only gate
+		// would have let a HomeWithdrawal at version=0 settle against a Void channel.
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+
+		store := NewDBStore(db)
+
+		voidChannel := newHomeChannel(0)
+		voidChannel.Status = core.ChannelStatusVoid
+		require.NoError(t, store.CreateChannel(voidChannel))
+
+		storeState(t, store, newSignedState(0, core.TransitionTypeHomeWithdrawal, false))
+
+		err := store.EnsureNoOngoingStateTransitions(wallet, asset)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "home withdrawal is still ongoing")
+	})
 }
 
 func TestDBStore_UpdateStateSigsIfMissing(t *testing.T) {

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -135,7 +135,7 @@ func NewChannel(channelID, userWallet, asset string, ChType ChannelType, blockch
 		ChallengeDuration:     challenge,
 		ApprovedSigValidators: approvedSigValidators,
 		Status:                ChannelStatusVoid,
-		StateVersion:          0,
+		StateVersion:          0, // 0 means "channel created but no on-chain state has materialised yet"
 	}
 }
 
@@ -179,9 +179,11 @@ func NewVoidState(asset, userWallet string) *State {
 // user against closedChannelID. Placement depends on prev:
 //
 //   - prev is in-channel (HomeChannelID != nil): the rescue opens a fresh epoch at
-//     (prev.Epoch+1, version=0) with a clean ledger seeded by amount. Used when no
+//     (prev.Epoch+1, version=1) with a clean ledger seeded by amount. Used when no
 //     node-signed Finalize exists locally for the closed channel — the user's chain
-//     has not been advanced past prev yet.
+//     has not been advanced past prev yet. Version=1 (not 0) mirrors NextState()'s
+//     post-Finalize convention so version=0 stays reserved as the "no on-chain state
+//     materialised yet" sentinel.
 //
 //   - prev is detached (HomeChannelID == nil): the rescue appends at (prev.Epoch,
 //     prev.Version+1), inheriting prev's ledger and adding amount on top. Used after
@@ -218,11 +220,13 @@ func NewChallengeRescueState(prev State, closedChannelID string, amount decimal.
 		}
 	} else {
 		// In-channel prev: wrap to a fresh epoch with a clean ledger seeded by amount.
+		// Version=1 (not 0) keeps the post-Finalize convention so version=0 stays
+		// reserved as the "no on-chain state materialised yet" sentinel.
 		rescue = &State{
 			Asset:      prev.Asset,
 			UserWallet: prev.UserWallet,
 			Epoch:      prev.Epoch + 1,
-			Version:    0,
+			Version:    1,
 			HomeLedger: Ledger{
 				UserBalance: amount,
 				UserNetFlow: decimal.Zero,
@@ -244,11 +248,17 @@ func NewChallengeRescueState(prev State, closedChannelID string, amount decimal.
 func (state State) NextState() *State {
 	var nextState *State
 	if state.IsFinal() {
+		// Post-Finalize epochs start at Version: 1 — Version: 0 is reserved as a
+		// sentinel for "channel created but no on-chain state has materialised yet"
+		// (see NewChannel: StateVersion=0). Starting the fresh epoch at 1 prevents
+		// the EnsureNoOngoingStateTransitions gate from accidentally treating a
+		// Void channel's first signed HomeDeposit (state.version == channel.state_version == 0)
+		// as already settled on-chain.
 		nextState = &State{
 			Asset:           state.Asset,
 			UserWallet:      state.UserWallet,
 			Epoch:           state.Epoch + 1,
-			Version:         0,
+			Version:         1,
 			HomeChannelID:   nil,
 			EscrowChannelID: nil,
 			HomeLedger: Ledger{
@@ -1201,8 +1211,8 @@ type EscrowWithdrawalDataResponse struct {
 
 // BalanceEntry represents a balance entry for an asset
 type BalanceEntry struct {
-	Asset   string          `json:"asset"`   // Asset symbol
-	Balance decimal.Decimal `json:"balance"` // Balance amount
+	Asset    string          `json:"asset"`    // Asset symbol
+	Balance  decimal.Decimal `json:"balance"`  // Balance amount
 	Enforced decimal.Decimal `json:"enforced"` // On-chain enforced balance
 }
 

--- a/pkg/core/types_test.go
+++ b/pkg/core/types_test.go
@@ -49,10 +49,12 @@ func TestState_NextState(t *testing.T) {
 	assert.Equal(t, uint64(1), next.Epoch)
 	assert.Nil(t, next.EscrowLedger)
 
-	// Final state next state (new epoch)
+	// Final state next state (new epoch). Version starts at 1 (not 0) so the gate
+	// can distinguish a freshly created (Void) channel from one with a confirmed
+	// on-chain state.
 	state.Transition.Type = TransitionTypeFinalize
 	nextFinal := state.NextState()
-	assert.Equal(t, uint64(0), nextFinal.Version)
+	assert.Equal(t, uint64(1), nextFinal.Version)
 	assert.Equal(t, uint64(2), nextFinal.Epoch)
 
 	// With Escrow Ledger
@@ -216,7 +218,7 @@ func TestNewChallengeRescueState(t *testing.T) {
 		}
 	}
 
-	t.Run("Success - in-channel prev wraps to fresh epoch at version 0", func(t *testing.T) {
+	t.Run("Success - in-channel prev wraps to fresh epoch at version 1", func(t *testing.T) {
 		prev := makePrev()
 		amount := decimal.NewFromInt(42)
 
@@ -227,7 +229,7 @@ func TestNewChallengeRescueState(t *testing.T) {
 		assert.Equal(t, prev.Asset, rescue.Asset)
 		assert.Equal(t, prev.UserWallet, rescue.UserWallet)
 		assert.Equal(t, prev.Epoch+1, rescue.Epoch)
-		assert.Equal(t, uint64(0), rescue.Version)
+		assert.Equal(t, uint64(1), rescue.Version)
 		assert.Nil(t, rescue.HomeChannelID)
 		assert.Empty(t, rescue.HomeLedger.TokenAddress)
 		assert.Equal(t, uint64(0), rescue.HomeLedger.BlockchainID)

--- a/sdk/ts/src/core/state.ts
+++ b/sdk/ts/src/core/state.ts
@@ -59,14 +59,18 @@ export function nextState(state: State): State {
   const voidTransition: Transition = { type: TransitionType.Void, txId: '', amount: new Decimal(0) };
 
   if (isFinal(state)) {
-    // After finalization, increment epoch and reset version
+    // After finalization, open a fresh epoch starting at version 1. Version 0 is
+    // reserved as a sentinel for "channel created but no on-chain state has
+    // materialised yet" (NewChannel/Void). Starting at 1 prevents the
+    // EnsureNoOngoingStateTransitions gate from accidentally treating a Void
+    // channel's first signed HomeDeposit as already settled on-chain (MF3-C01).
     newState = {
       id: '',
       transition: voidTransition,
       asset: state.asset,
       userWallet: state.userWallet,
       epoch: state.epoch + 1n,
-      version: 0n,
+      version: 1n,
       homeChannelId: undefined,
       escrowChannelId: undefined,
       homeLedger: {

--- a/sdk/ts/test/unit/core/state_advancer.test.ts
+++ b/sdk/ts/test/unit/core/state_advancer.test.ts
@@ -8,6 +8,7 @@ import {
   applyMutualLockTransition,
   applyEscrowDepositTransition,
   applyHomeDepositTransition,
+  applyFinalizeTransition,
 } from '../../../src/core/state';
 import { getStateId } from '../../../src/core/utils';
 
@@ -100,6 +101,25 @@ describe('ValidateAdvancement_EscrowDeposit', () => {
     await expect(advancer.validateAdvancement(homeDepositState, proposed)).rejects.toThrow(
       'escrow deposit transition must follow a mutual lock transition'
     );
+  });
+});
+
+describe('nextState - post-Finalize epoch', () => {
+  test('starts at version 1 and increments epoch (MF3-C01)', () => {
+    // Version 0 is reserved as the "no on-chain state materialised yet" sentinel
+    // (NewChannel/Void), so the fresh epoch after a Finalize must begin at version 1.
+    const state = newVoidState('USDC', USER_WALLET);
+    state.homeChannelId = HOME_CHANNEL_ID;
+    state.epoch = 3n;
+    state.version = 5n;
+    state.id = getStateId(USER_WALLET, 'USDC', state.epoch, state.version);
+    applyFinalizeTransition(state);
+
+    const next = nextState(state);
+
+    expect(next.version).toBe(1n);
+    expect(next.epoch).toBe(4n);
+    expect(next.homeChannelId).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes **MF3-C01** — a version-0 epoch/channel sentinel collision that let a node-signed `HomeDeposit` be credited off-chain before any deposit event landed.

After a `Finalize`, `NextState()` opened the new epoch at `version=0`. Newly created channels also persist as `state_version=0`. `EnsureNoOngoingStateTransitions` treats a `HomeDeposit` as settled when `state.version == channel.state_version`, so the two zeros collided and the gate let the user spend phantom funds.

## Changes

**Primary fix** — reserve `version=0` as the "no on-chain state materialised yet" sentinel:
- `pkg/core/types.go`: `NextState()` post-Finalize and `NewChallengeRescueState()` in-channel branch both emit `Version: 1` (was `0`).
- `sdk/ts/src/core/state.ts`: ma)`.

**Defence in depth** — gate mustl to be `Open`:
- `EnsureNoOngoingStateTransitions` SQL now selects `hc.status`; the `HomeDeposit` / `HomeWithdrawal` cases require `o the version match.
- `RefreshUserEnforcedBalance` SQL: `state_version > 0` → `status = 1` (removes the magic-number sentinel).
- New `Channel.IsEnforced()` helper encodes the convention.