### PR TITLE
MF3-L04: fix(nitronode): enforce canonical allocations in deposit state

### DIFF
--- a/nitronode/api/app_session_v1/submit_deposit_state.go
+++ b/nitronode/api/app_session_v1/submit_deposit_state.go
@@ -185,6 +185,13 @@ func (h *Handler) SubmitDepositState(c *rpc.Context) {
 
 		incomingAllocations := make(map[string]map[string]decimal.Decimal)
 		for _, alloc := range appStateUpd.Allocations {
+			// Validate participant before any amount-diff logic so non-participant
+			// allocations are rejected even when the amount is zero (which would
+			// otherwise bypass the check below).
+			if _, ok := participantWeights[alloc.Participant]; !ok {
+				return rpc.Errorf("allocation to non-participant %s", alloc.Participant)
+			}
+
 			if alloc.Amount.IsNegative() {
 				return rpc.Errorf("negative allocation: %s for asset %s", alloc.Amount, alloc.Asset)
 			}
@@ -216,11 +223,6 @@ func (h *Handler) SubmitDepositState(c *rpc.Context) {
 			}
 
 			if alloc.Amount.GreaterThan(currentAmount) {
-				// Validate participant
-				if _, ok := participantWeights[alloc.Participant]; !ok {
-					return rpc.Errorf("allocation to non-participant %s", alloc.Participant)
-				}
-
 				// Validate that allocation asset matches user state asset
 				if alloc.Asset != userState.Asset {
 					return rpc.Errorf("app session deposit allocation for asset '%s' does not match user channel state asset '%s'", alloc.Asset, userState.Asset)
@@ -249,19 +251,27 @@ func (h *Handler) SubmitDepositState(c *rpc.Context) {
 				if currentAmount.IsZero() {
 					continue
 				}
-				if asset == userState.Asset {
-					// Skip asset being deposited to avoid double-checking
-					continue
-				}
 
-				// Check if this participant+asset is included in the incoming request
+				// Every existing nonzero allocation must be present in the signed
+				// update so the resulting allocation set is a complete snapshot.
 				incomingAmount, found := incomingAllocations[participant][asset]
 				if !found {
 					return rpc.Errorf("deposit intent missing allocation for participant %s, asset %s with current amount %s",
 						participant, asset, currentAmount.String())
 				}
 
-				// Verify amounts match exactly
+				if asset == userState.Asset {
+					// Deposited asset: allocations may only grow (the deposit
+					// itself, already validated and recorded in the loop above),
+					// never shrink.
+					if incomingAmount.LessThan(currentAmount) {
+						return rpc.Errorf("deposit intent cannot decrease allocation for participant %s, asset %s: current %s, provided %s",
+							participant, asset, currentAmount.String(), incomingAmount.String())
+					}
+					continue
+				}
+
+				// Non-deposited assets must match current state exactly.
 				if !incomingAmount.Equal(currentAmount) {
 					return rpc.Errorf("deposit intent requires non-deposited asset allocations to match current state: participant %s, asset %s, current %s, provided %s",
 						participant, asset, currentAmount.String(), incomingAmount.String())

--- a/nitronode/api/app_session_v1/submit_deposit_state.go
+++ b/nitronode/api/app_session_v1/submit_deposit_state.go
@@ -218,6 +218,13 @@ func (h *Handler) SubmitDepositState(c *rpc.Context) {
 			}
 			currentAmount := participantAllocs[alloc.Asset]
 
+			// Reject spurious zero allocations for (participant, asset) pairs with
+			// no existing balance: they move no funds but pollute the signed
+			// allocation set, keeping it from being a canonical snapshot.
+			if alloc.Amount.IsZero() && currentAmount.IsZero() {
+				return rpc.Errorf("zero allocation for participant %s, asset %s with no existing balance", alloc.Participant, alloc.Asset)
+			}
+
 			if alloc.Amount.LessThan(currentAmount) {
 				return rpc.Errorf("decreased allocation for %s for participant %s", alloc.Asset, alloc.Participant)
 			}

--- a/nitronode/api/app_session_v1/submit_deposit_state_test.go
+++ b/nitronode/api/app_session_v1/submit_deposit_state_test.go
@@ -1279,6 +1279,145 @@ func TestSubmitDepositState_MissingDepositedAssetAllocation_Rejected(t *testing.
 	mockStore.AssertNotCalled(t, "UpdateAppSession", mock.Anything)
 }
 
+// TestSubmitDepositState_SpuriousZeroAllocation_Rejected verifies that a valid
+// participant cannot include a zero allocation for a (participant, asset) pair
+// with no existing balance. Such an allocation moves no funds but would pollute
+// the signed allocation set, keeping it from being a canonical snapshot.
+func TestSubmitDepositState_SpuriousZeroAllocation_Rejected(t *testing.T) {
+	mockStore := new(MockStore)
+	mockSigner := NewMockChannelSigner()
+	nodeAddress := mockSigner.PublicKey().Address().String()
+	mockAssetStore := new(MockAssetStore)
+	mockStatePacker := new(MockStatePacker)
+
+	handler := &Handler{
+		assetStore:    mockAssetStore,
+		actionGateway: &MockActionGateway{},
+		stateAdvancer: core.NewStateAdvancerV1(mockAssetStore),
+		statePacker:   mockStatePacker,
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockStore)
+		},
+		signer:             mockSigner,
+		nodeAddress:        nodeAddress,
+		appRegistryEnabled: true,
+		metrics:            metrics.NewNoopRuntimeMetricExporter(),
+		maxParticipants:    32,
+		maxSessionData:     1024,
+		maxSessionKeyIDs:   256,
+		maxSignedUpdates:   16,
+	}
+
+	userRawSigner := NewMockSigner()
+	channelWalletSigner, _ := core.NewChannelDefaultSigner(userRawSigner)
+	appWalletSigner, _ := app.NewAppSessionWalletSignerV1(userRawSigner)
+	participant1 := strings.ToLower(userRawSigner.PublicKey().Address().String())
+	participant2 := "0x2222222222222222222222222222222222222222"
+	asset := "USDC"
+	homeChannelID := "0xHomeChannel123"
+	appSessionID := "0xAppSession123"
+
+	existingAppSession := &app.AppSessionV1{
+		SessionID:     appSessionID,
+		ApplicationID: "test-app",
+		Participants: []app.AppParticipantV1{
+			{WalletAddress: participant1, SignatureWeight: 1},
+			{WalletAddress: participant2, SignatureWeight: 1},
+		},
+		Quorum:  1,
+		Nonce:   12345,
+		Status:  app.AppSessionStatusOpen,
+		Version: 1,
+	}
+
+	currentUserState := core.State{
+		ID:         core.GetStateID(participant1, asset, 1, 1),
+		Transition: core.Transition{Type: core.TransitionTypeVoid},
+		Asset:      asset, UserWallet: participant1, Epoch: 1, Version: 1,
+		HomeChannelID: &homeChannelID,
+		HomeLedger: core.Ledger{
+			TokenAddress: "0xTokenAddress", BlockchainID: 1,
+			UserBalance: decimal.NewFromInt(500), UserNetFlow: decimal.NewFromInt(500),
+		},
+	}
+
+	depositAmount := decimal.NewFromInt(100)
+	incomingUserState := currentUserState.NextState()
+	_, err := incomingUserState.ApplyCommitTransition(appSessionID, depositAmount)
+	require.NoError(t, err)
+
+	mockStatePacker.On("PackState", mock.Anything).Return([]byte("packed"), nil)
+	packedUserState, _ := mockStatePacker.PackState(*incomingUserState)
+	userSig, _ := channelWalletSigner.Sign(packedUserState)
+	userSigStr := userSig.String()
+	incomingUserState.UserSig = &userSigStr
+
+	// participant2 is a valid participant but has no existing balance for the
+	// asset; its zero allocation is listed first so rejection happens before any
+	// ledger entry is recorded for the legitimate deposit.
+	appStateUpdateCore := app.AppStateUpdateV1{
+		AppSessionID: appSessionID,
+		Intent:       app.AppStateUpdateIntentDeposit,
+		Version:      2,
+		Allocations: []app.AppAllocationV1{
+			{Participant: participant2, Asset: asset, Amount: decimal.Zero},
+			{Participant: participant1, Asset: asset, Amount: depositAmount},
+		},
+	}
+	packedAppUpdate, _ := app.PackAppStateUpdateV1(appStateUpdateCore)
+	appSigBytes, _ := appWalletSigner.Sign(packedAppUpdate)
+	appSigHex := hexutil.Encode(appSigBytes)
+
+	appStateUpdate := rpc.AppStateUpdateV1{
+		AppSessionID: appSessionID,
+		Intent:       app.AppStateUpdateIntentDeposit,
+		Version:      "2",
+		Allocations: []rpc.AppAllocationV1{
+			{Participant: participant2, Asset: asset, Amount: "0"},
+			{Participant: participant1, Asset: asset, Amount: depositAmount.String()},
+		},
+	}
+
+	mockStore.On("GetApp", "test-app").Return(&app.AppInfoV1{
+		App: app.AppV1{ID: "test-app", OwnerWallet: "0x0000000000000000000000000000000000000001"},
+	}, nil).Maybe()
+	mockStore.On("GetAppSession", appSessionID).Return(existingAppSession, nil).Once()
+	mockStore.On("LockUserState", participant1, asset).Return(decimal.Zero, nil).Once()
+	mockStore.On("CheckActiveChannel", participant1, asset).Return("0x03", core.ChannelStatusOpen, nil).Once()
+	mockStore.On("GetLastUserState", participant1, asset, false).Return(currentUserState, nil).Once()
+	mockStore.On("EnsureNoOngoingStateTransitions", participant1, asset).Return(nil).Once()
+	mockAssetStore.On("GetAssetDecimals", asset).Return(uint8(6), nil)
+	mockAssetStore.On("GetTokenDecimals", uint64(1), "0xTokenAddress").Return(uint8(6), nil).Maybe()
+	mockStore.On("GetParticipantAllocations", appSessionID).Return(
+		map[string]map[string]decimal.Decimal{}, nil,
+	).Once()
+	// No ledger entry should be recorded — rejection happens before it.
+	mockStore.On("RecordLedgerEntry", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	rpcState := toRPCState(*incomingUserState)
+	reqPayload := rpc.AppSessionsV1SubmitDepositStateRequest{
+		AppStateUpdate: appStateUpdate,
+		QuorumSigs:     []string{appSigHex},
+		UserState:      rpcState,
+	}
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, string(rpc.AppSessionsV1SubmitDepositStateMethod), payload),
+	}
+
+	handler.SubmitDepositState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.NotNil(t, respErr, "expected error for spurious zero allocation")
+	assert.Contains(t, respErr.Error(), "zero allocation")
+	mockStore.AssertNotCalled(t, "RecordLedgerEntry", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
 // TestSubmitDepositState_VerifyQuorumWeightOver255 ensures verifyQuorum handles combined
 // participant weights exceeding 255 correctly through the SubmitDepositState path.
 func TestSubmitDepositState_VerifyQuorumWeightOver255(t *testing.T) {

--- a/nitronode/api/app_session_v1/submit_deposit_state_test.go
+++ b/nitronode/api/app_session_v1/submit_deposit_state_test.go
@@ -1001,3 +1001,280 @@ func TestSubmitDepositState_InvalidDecimalPrecision_Rejected(t *testing.T) {
 	require.NotNil(t, respErr, "Expected error for invalid decimal precision")
 	assert.Contains(t, respErr.Error(), "amount exceeds maximum decimal precision")
 }
+
+// TestSubmitDepositState_NonParticipantZeroAllocation_Rejected verifies that a
+// zero-amount allocation to a non-participant is rejected. Previously the
+// participant check sat inside the amount-increase branch, so a zero amount
+// bypassed it and let a non-participant ride along in the signed allocation set.
+func TestSubmitDepositState_NonParticipantZeroAllocation_Rejected(t *testing.T) {
+	mockStore := new(MockStore)
+	mockSigner := NewMockChannelSigner()
+	nodeAddress := mockSigner.PublicKey().Address().String()
+	mockAssetStore := new(MockAssetStore)
+	mockStatePacker := new(MockStatePacker)
+
+	handler := &Handler{
+		assetStore:    mockAssetStore,
+		actionGateway: &MockActionGateway{},
+		stateAdvancer: core.NewStateAdvancerV1(mockAssetStore),
+		statePacker:   mockStatePacker,
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockStore)
+		},
+		signer:             mockSigner,
+		nodeAddress:        nodeAddress,
+		appRegistryEnabled: true,
+		metrics:            metrics.NewNoopRuntimeMetricExporter(),
+		maxParticipants:    32,
+		maxSessionData:     1024,
+		maxSessionKeyIDs:   256,
+		maxSignedUpdates:   16,
+	}
+
+	userRawSigner := NewMockSigner()
+	channelWalletSigner, _ := core.NewChannelDefaultSigner(userRawSigner)
+	appWalletSigner, _ := app.NewAppSessionWalletSignerV1(userRawSigner)
+	participant1 := strings.ToLower(userRawSigner.PublicKey().Address().String())
+	participant2 := "0x2222222222222222222222222222222222222222"
+	nonParticipant := "0x3333333333333333333333333333333333333333"
+	asset := "USDC"
+	homeChannelID := "0xHomeChannel123"
+	appSessionID := "0xAppSession123"
+
+	existingAppSession := &app.AppSessionV1{
+		SessionID:     appSessionID,
+		ApplicationID: "test-app",
+		Participants: []app.AppParticipantV1{
+			{WalletAddress: participant1, SignatureWeight: 1},
+			{WalletAddress: participant2, SignatureWeight: 1},
+		},
+		Quorum:  1,
+		Nonce:   12345,
+		Status:  app.AppSessionStatusOpen,
+		Version: 1,
+	}
+
+	currentUserState := core.State{
+		ID:         core.GetStateID(participant1, asset, 1, 1),
+		Transition: core.Transition{Type: core.TransitionTypeVoid},
+		Asset:      asset, UserWallet: participant1, Epoch: 1, Version: 1,
+		HomeChannelID: &homeChannelID,
+		HomeLedger: core.Ledger{
+			TokenAddress: "0xTokenAddress", BlockchainID: 1,
+			UserBalance: decimal.NewFromInt(500), UserNetFlow: decimal.NewFromInt(500),
+		},
+	}
+
+	depositAmount := decimal.NewFromInt(100)
+	incomingUserState := currentUserState.NextState()
+	_, err := incomingUserState.ApplyCommitTransition(appSessionID, depositAmount)
+	require.NoError(t, err)
+
+	mockStatePacker.On("PackState", mock.Anything).Return([]byte("packed"), nil)
+	packedUserState, _ := mockStatePacker.PackState(*incomingUserState)
+	userSig, _ := channelWalletSigner.Sign(packedUserState)
+	userSigStr := userSig.String()
+	incomingUserState.UserSig = &userSigStr
+
+	// Non-participant zero allocation listed first so it is rejected before any
+	// ledger entry is recorded for the legitimate deposit.
+	appStateUpdateCore := app.AppStateUpdateV1{
+		AppSessionID: appSessionID,
+		Intent:       app.AppStateUpdateIntentDeposit,
+		Version:      2,
+		Allocations: []app.AppAllocationV1{
+			{Participant: nonParticipant, Asset: asset, Amount: decimal.Zero},
+			{Participant: participant1, Asset: asset, Amount: depositAmount},
+		},
+	}
+	packedAppUpdate, _ := app.PackAppStateUpdateV1(appStateUpdateCore)
+	appSigBytes, _ := appWalletSigner.Sign(packedAppUpdate)
+	appSigHex := hexutil.Encode(appSigBytes)
+
+	appStateUpdate := rpc.AppStateUpdateV1{
+		AppSessionID: appSessionID,
+		Intent:       app.AppStateUpdateIntentDeposit,
+		Version:      "2",
+		Allocations: []rpc.AppAllocationV1{
+			{Participant: nonParticipant, Asset: asset, Amount: "0"},
+			{Participant: participant1, Asset: asset, Amount: depositAmount.String()},
+		},
+	}
+
+	mockStore.On("GetApp", "test-app").Return(&app.AppInfoV1{
+		App: app.AppV1{ID: "test-app", OwnerWallet: "0x0000000000000000000000000000000000000001"},
+	}, nil).Maybe()
+	mockStore.On("GetAppSession", appSessionID).Return(existingAppSession, nil).Once()
+	mockStore.On("LockUserState", participant1, asset).Return(decimal.Zero, nil).Once()
+	mockStore.On("CheckActiveChannel", participant1, asset).Return("0x03", core.ChannelStatusOpen, nil).Once()
+	mockStore.On("GetLastUserState", participant1, asset, false).Return(currentUserState, nil).Once()
+	mockStore.On("EnsureNoOngoingStateTransitions", participant1, asset).Return(nil).Once()
+	mockAssetStore.On("GetAssetDecimals", asset).Return(uint8(6), nil)
+	mockAssetStore.On("GetTokenDecimals", uint64(1), "0xTokenAddress").Return(uint8(6), nil).Maybe()
+	mockStore.On("GetParticipantAllocations", appSessionID).Return(
+		map[string]map[string]decimal.Decimal{}, nil,
+	).Once()
+	// No ledger entry should be recorded — rejection happens before it.
+	mockStore.On("RecordLedgerEntry", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	rpcState := toRPCState(*incomingUserState)
+	reqPayload := rpc.AppSessionsV1SubmitDepositStateRequest{
+		AppStateUpdate: appStateUpdate,
+		QuorumSigs:     []string{appSigHex},
+		UserState:      rpcState,
+	}
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, string(rpc.AppSessionsV1SubmitDepositStateMethod), payload),
+	}
+
+	handler.SubmitDepositState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.NotNil(t, respErr, "expected error for non-participant allocation")
+	assert.Contains(t, respErr.Error(), "non-participant")
+	mockStore.AssertNotCalled(t, "RecordLedgerEntry", nonParticipant, mock.Anything, mock.Anything, mock.Anything)
+}
+
+// TestSubmitDepositState_MissingDepositedAssetAllocation_Rejected verifies that an
+// existing nonzero allocation in the deposited asset cannot be omitted from the
+// signed update. Previously the completeness check skipped the deposited asset,
+// so such an allocation could silently vanish from the canonical snapshot.
+func TestSubmitDepositState_MissingDepositedAssetAllocation_Rejected(t *testing.T) {
+	mockStore := new(MockStore)
+	mockSigner := NewMockChannelSigner()
+	nodeAddress := mockSigner.PublicKey().Address().String()
+	mockAssetStore := new(MockAssetStore)
+	mockStatePacker := new(MockStatePacker)
+
+	handler := &Handler{
+		assetStore:    mockAssetStore,
+		actionGateway: &MockActionGateway{},
+		stateAdvancer: core.NewStateAdvancerV1(mockAssetStore),
+		statePacker:   mockStatePacker,
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockStore)
+		},
+		signer:             mockSigner,
+		nodeAddress:        nodeAddress,
+		appRegistryEnabled: true,
+		metrics:            metrics.NewNoopRuntimeMetricExporter(),
+		maxParticipants:    32,
+		maxSessionData:     1024,
+		maxSessionKeyIDs:   256,
+		maxSignedUpdates:   16,
+	}
+
+	userRawSigner := NewMockSigner()
+	channelWalletSigner, _ := core.NewChannelDefaultSigner(userRawSigner)
+	appWalletSigner, _ := app.NewAppSessionWalletSignerV1(userRawSigner)
+	participant1 := strings.ToLower(userRawSigner.PublicKey().Address().String())
+	participant2 := "0x2222222222222222222222222222222222222222"
+	asset := "USDC"
+	homeChannelID := "0xHomeChannel123"
+	appSessionID := "0xAppSession123"
+
+	existingAppSession := &app.AppSessionV1{
+		SessionID:     appSessionID,
+		ApplicationID: "test-app",
+		Participants: []app.AppParticipantV1{
+			{WalletAddress: participant1, SignatureWeight: 1},
+			{WalletAddress: participant2, SignatureWeight: 1},
+		},
+		Quorum:  1,
+		Nonce:   12345,
+		Status:  app.AppSessionStatusOpen,
+		Version: 1,
+	}
+
+	currentUserState := core.State{
+		ID:         core.GetStateID(participant1, asset, 1, 1),
+		Transition: core.Transition{Type: core.TransitionTypeVoid},
+		Asset:      asset, UserWallet: participant1, Epoch: 1, Version: 1,
+		HomeChannelID: &homeChannelID,
+		HomeLedger: core.Ledger{
+			TokenAddress: "0xTokenAddress", BlockchainID: 1,
+			UserBalance: decimal.NewFromInt(500), UserNetFlow: decimal.NewFromInt(500),
+		},
+	}
+
+	depositAmount := decimal.NewFromInt(100)
+	incomingUserState := currentUserState.NextState()
+	_, err := incomingUserState.ApplyCommitTransition(appSessionID, depositAmount)
+	require.NoError(t, err)
+
+	mockStatePacker.On("PackState", mock.Anything).Return([]byte("packed"), nil)
+	packedUserState, _ := mockStatePacker.PackState(*incomingUserState)
+	userSig, _ := channelWalletSigner.Sign(packedUserState)
+	userSigStr := userSig.String()
+	incomingUserState.UserSig = &userSigStr
+
+	// Incoming update carries only participant1's deposit and omits participant2's
+	// existing nonzero balance in the same (deposited) asset.
+	appStateUpdateCore := app.AppStateUpdateV1{
+		AppSessionID: appSessionID,
+		Intent:       app.AppStateUpdateIntentDeposit,
+		Version:      2,
+		Allocations: []app.AppAllocationV1{
+			{Participant: participant1, Asset: asset, Amount: depositAmount},
+		},
+	}
+	packedAppUpdate, _ := app.PackAppStateUpdateV1(appStateUpdateCore)
+	appSigBytes, _ := appWalletSigner.Sign(packedAppUpdate)
+	appSigHex := hexutil.Encode(appSigBytes)
+
+	appStateUpdate := rpc.AppStateUpdateV1{
+		AppSessionID: appSessionID,
+		Intent:       app.AppStateUpdateIntentDeposit,
+		Version:      "2",
+		Allocations: []rpc.AppAllocationV1{
+			{Participant: participant1, Asset: asset, Amount: depositAmount.String()},
+		},
+	}
+
+	mockStore.On("GetApp", "test-app").Return(&app.AppInfoV1{
+		App: app.AppV1{ID: "test-app", OwnerWallet: "0x0000000000000000000000000000000000000001"},
+	}, nil).Maybe()
+	mockStore.On("GetAppSession", appSessionID).Return(existingAppSession, nil).Once()
+	mockStore.On("LockUserState", participant1, asset).Return(decimal.Zero, nil).Once()
+	mockStore.On("CheckActiveChannel", participant1, asset).Return("0x03", core.ChannelStatusOpen, nil).Once()
+	mockStore.On("GetLastUserState", participant1, asset, false).Return(currentUserState, nil).Once()
+	mockStore.On("EnsureNoOngoingStateTransitions", participant1, asset).Return(nil).Once()
+	mockAssetStore.On("GetAssetDecimals", asset).Return(uint8(6), nil)
+	mockAssetStore.On("GetTokenDecimals", uint64(1), "0xTokenAddress").Return(uint8(6), nil).Maybe()
+	// participant2 already holds 50 USDC (the deposited asset) in the session.
+	mockStore.On("GetParticipantAllocations", appSessionID).Return(
+		map[string]map[string]decimal.Decimal{
+			participant2: {asset: decimal.NewFromInt(50)},
+		}, nil,
+	).Once()
+	mockStore.On("RecordLedgerEntry", participant1, appSessionID, asset, depositAmount).Return(nil).Maybe()
+
+	rpcState := toRPCState(*incomingUserState)
+	reqPayload := rpc.AppSessionsV1SubmitDepositStateRequest{
+		AppStateUpdate: appStateUpdate,
+		QuorumSigs:     []string{appSigHex},
+		UserState:      rpcState,
+	}
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, string(rpc.AppSessionsV1SubmitDepositStateMethod), payload),
+	}
+
+	handler.SubmitDepositState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.NotNil(t, respErr, "expected error for omitted deposited-asset allocation")
+	assert.Contains(t, respErr.Error(), "missing allocation")
+	mockStore.AssertNotCalled(t, "UpdateAppSession", mock.Anything)
+}

--- a/sdk/go/utils.go
+++ b/sdk/go/utils.go
@@ -163,6 +163,7 @@ func transformChannel(channel rpc.ChannelV1) (core.Channel, error) {
 		BlockchainID:          blockchainID,
 		TokenAddress:          channel.TokenAddress,
 		ChallengeDuration:     channel.ChallengeDuration,
+		ChallengeExpiresAt:    channel.ChallengeExpiresAt,
 		Nonce:                 nonce,
 		ApprovedSigValidators: channel.ApprovedSigValidators,
 		Status:                channelStatus,

--- a/sdk/go/utils_test.go
+++ b/sdk/go/utils_test.go
@@ -137,6 +137,7 @@ func TestTransformPaginationParams(t *testing.T) {
 }
 
 func TestTransformChannel(t *testing.T) {
+	challengeExpiresAt := time.Unix(1710000000, 0).UTC()
 	rpcChan := rpc.ChannelV1{
 		ChannelID:             "0xChannelID",
 		UserWallet:            "0xUserWallet",
@@ -144,6 +145,7 @@ func TestTransformChannel(t *testing.T) {
 		BlockchainID:          "137",
 		TokenAddress:          "0xToken",
 		ChallengeDuration:     100,
+		ChallengeExpiresAt:    &challengeExpiresAt,
 		Nonce:                 "1",
 		ApprovedSigValidators: "0x01",
 		Status:                "open",
@@ -156,6 +158,8 @@ func TestTransformChannel(t *testing.T) {
 	assert.Equal(t, core.ChannelStatusOpen, ch.Status)
 	assert.Equal(t, uint64(137), ch.BlockchainID)
 	assert.Equal(t, uint64(5), ch.StateVersion)
+	require.NotNil(t, ch.ChallengeExpiresAt)
+	assert.True(t, ch.ChallengeExpiresAt.Equal(challengeExpiresAt))
 
 	// Test error cases
 	rpcChan.BlockchainID = "invalid"


### PR DESCRIPTION
## What

Remediation for **MF3-L04** — `SubmitDepositState()` only partially validated `AppStateUpdate.Allocations`, so an accepted deposit update could carry a non-canonical or incomplete allocation set relative to the node's actual ledger.

Two gaps:
1) the participant check sat *inside* the amount-increase branch, so a non-participant could be included with a zero amount and bypass it;
2) the final completeness check skipped `asset == userState.Asset`, so existing nonzero allocations for the deposited asset could be omitted from the signed update.

Neither moves or erases funds (omitted balances aren't modified, zero allocations produce no ledger entries) — but the signed deposit state could diverge from the ledger, which is misleading for any client/app/verifier treating it as a full allocation snapshot.

## Changes

- Hoist the participant check to the top of the allocation loop so it runs regardless of amount — non-participant allocations are now rejected even at zero amount.
- Drop the deposited-asset skip in the completeness check. Every existing nonzero allocation must now be present in the update:
  - **deposited asset** — may only grow (the deposit itself; the increase is still validated and recorded in the forward loop), never shrink;
  - **all other assets** — must match the current state exactly (unchanged).

Valid deposit increases keep working; the signed allocation set becomes a complete, canonical snapshot.

## Tests

- `NonParticipantZeroAllocation_Rejected` — zero-amount non-participant allocation is rejected, no ledger entry recorded for it.
- `MissingDepositedAssetAllocation_Rejected` — omitting another participant's existing balance in the deposited asset is rejected, session is not updated.

All `app_session_v1` tests pass; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved participant validation during deposit state submission to reject invalid allocations earlier in processing
  * Strengthened balance verification to ensure all existing asset allocations are accounted for in updates
  * Enforced stricter requirements for deposited asset allocations to maintain non-decreasing amounts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->