### PR TITLE
MF3-L10: reject missing last user state in submit_deposit_state

### DIFF
--- a/nitronode/api/app_session_v1/submit_deposit_state.go
+++ b/nitronode/api/app_session_v1/submit_deposit_state.go
@@ -122,16 +122,19 @@ func (h *Handler) SubmitDepositState(c *rpc.Context) {
 			return rpc.Errorf("missing user signature on user state")
 		}
 
+		// An active home channel (confirmed by CheckActiveChannel above) always has a
+		// persisted latest state; deposit is not an initialization path. A nil result here
+		// means the local state materialization is inconsistent, so reject instead of
+		// synthesizing a void state and validating against history that was never persisted.
 		currentState, err := tx.GetLastUserState(userState.UserWallet, userState.Asset, false)
 		if err != nil {
 			return rpc.Errorf("failed to get last user state: %v", err)
 		}
 		if currentState == nil {
-			currentState = core.NewVoidState(userState.Asset, userState.UserWallet)
-		} else {
-			if err := tx.EnsureNoOngoingStateTransitions(userState.UserWallet, userState.Asset); err != nil {
-				return rpc.Errorf("ongoing state transitions check failed: %v", err)
-			}
+			return rpc.Errorf("last user state not found")
+		}
+		if err := tx.EnsureNoOngoingStateTransitions(userState.UserWallet, userState.Asset); err != nil {
+			return rpc.Errorf("ongoing state transitions check failed: %v", err)
 		}
 
 		if err := h.stateAdvancer.ValidateAdvancement(*currentState, userState); err != nil {

--- a/nitronode/api/app_session_v1/submit_deposit_state_test.go
+++ b/nitronode/api/app_session_v1/submit_deposit_state_test.go
@@ -275,6 +275,110 @@ func TestSubmitDepositState_Success(t *testing.T) {
 	mockStore.AssertExpectations(t)
 }
 
+func TestSubmitDepositState_MissingLastUserState_Rejected(t *testing.T) {
+	// An active home channel always has a persisted latest state; if GetLastUserState
+	// returns nil despite CheckActiveChannel succeeding, the handler must reject with a
+	// clean "last user state not found" rather than synthesizing a void state.
+	mockStore := new(MockStore)
+	mockStatePacker := new(MockStatePacker)
+
+	handler := &Handler{
+		statePacker: mockStatePacker,
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockStore)
+		},
+		appRegistryEnabled: false,
+		metrics:            metrics.NewNoopRuntimeMetricExporter(),
+		maxParticipants:    32,
+		maxSessionData:     1024,
+	}
+
+	userRawSigner := NewMockSigner()
+	participant1 := strings.ToLower(userRawSigner.PublicKey().Address().String())
+	participant2 := "0x2222222222222222222222222222222222222222"
+	asset := "USDC"
+	homeChannelID := "0xHomeChannel123"
+	depositAmount := decimal.NewFromInt(100)
+	appSessionID := "0xAppSession123"
+
+	existingAppSession := &app.AppSessionV1{
+		SessionID:     appSessionID,
+		ApplicationID: "test-app",
+		Participants: []app.AppParticipantV1{
+			{WalletAddress: participant1, SignatureWeight: 1},
+			{WalletAddress: participant2, SignatureWeight: 1},
+		},
+		Quorum:    1,
+		Nonce:     12345,
+		Status:    app.AppSessionStatusOpen,
+		Version:   1,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	// Build an incoming commit state referencing the app session.
+	baseState := core.State{
+		ID:            core.GetStateID(participant1, asset, 1, 1),
+		Transition:    core.Transition{Type: core.TransitionTypeVoid},
+		Asset:         asset,
+		UserWallet:    participant1,
+		Epoch:         1,
+		Version:       1,
+		HomeChannelID: &homeChannelID,
+		HomeLedger: core.Ledger{
+			TokenAddress: "0xTokenAddress",
+			BlockchainID: 1,
+			UserBalance:  decimal.NewFromInt(500),
+			UserNetFlow:  decimal.NewFromInt(500),
+		},
+	}
+	incomingUserState := baseState.NextState()
+	_, err := incomingUserState.ApplyCommitTransition(appSessionID, depositAmount)
+	require.NoError(t, err)
+	// Signature is never verified: the handler rejects before signature validation.
+	dummySig := "0x01"
+	incomingUserState.UserSig = &dummySig
+
+	mockStore.On("GetAppSession", appSessionID).Return(existingAppSession, nil).Once()
+	mockStore.On("LockUserState", participant1, asset).Return(decimal.Zero, nil).Once()
+	mockStore.On("CheckActiveChannel", participant1, asset).Return("0x03", core.ChannelStatusOpen, nil).Once()
+	mockStore.On("GetLastUserState", participant1, asset, false).Return(nil, nil).Once()
+
+	appStateUpdate := rpc.AppStateUpdateV1{
+		AppSessionID: appSessionID,
+		Intent:       app.AppStateUpdateIntentDeposit,
+		Version:      "2",
+		Allocations: []rpc.AppAllocationV1{
+			{Participant: participant1, Asset: asset, Amount: depositAmount.String()},
+		},
+	}
+
+	reqPayload := rpc.AppSessionsV1SubmitDepositStateRequest{
+		AppStateUpdate: appStateUpdate,
+		QuorumSigs:     []string{"0xdeadbeef"},
+		UserState:      toRPCState(*incomingUserState),
+	}
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, string(rpc.AppSessionsV1SubmitDepositStateMethod), payload),
+	}
+
+	handler.SubmitDepositState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.NotNil(t, respErr)
+	assert.Contains(t, respErr.Error(), "last user state not found")
+
+	// Must reject without advancing past the missing-state check.
+	mockStore.AssertNotCalled(t, "EnsureNoOngoingStateTransitions", mock.Anything, mock.Anything)
+	mockStore.AssertNotCalled(t, "StoreUserState", mock.Anything, mock.Anything)
+	mockStore.AssertExpectations(t)
+}
+
 func TestSubmitDepositState_InvalidTransitionType(t *testing.T) {
 	// Setup
 	mockStore := new(MockStore)


### PR DESCRIPTION
## Summary

`SubmitDepositState()` synthesized `core.NewVoidState()` when `GetLastUserState()` returned `nil` and continued validation. But deposit is **not** a channel initialization path: after `CheckActiveChannel()` confirms an active `Void`/`Open` home channel, the `channel_states` row for `(user_wallet, asset)` is guaranteed to exist (home channels are created atomically with their first state in `request_creation.go`).

A `nil` result there means the local-state materialization is inconsistent. Continuing from a synthetic void state evaluates a `Commit` against state history that was never persisted, yielding a misleading downstream validation error instead of a clean missing-state rejection.

## Changes

- Replace the `NewVoidState()` fallback with an explicit `last user state not found` rejection.
- `EnsureNoOngoingStateTransitions` now runs unconditionally — `currentState` is guaranteed non-nil past the guard.
- Add `TestSubmitDepositState_MissingLastUserState_Rejected`: active channel passes but `GetLastUserState` returns nil → clean rejection, no advancement past the guard.

## Impact

Hardening / fail-fast. The void path was unreachable under correct operation (no exploit, no incorrect accept) — worst prior consequence was a confusing error on DB inconsistency.

## Testing

- `go test ./nitronode/api/app_session_v1/` — pass
- `go vet ./nitronode/api/app_session_v1/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)