### PR TITLE
MF3-L11: fix unbounded responseSinks growth on marshal failure

### DIFF
--- a/pkg/rpc/dialer.go
+++ b/pkg/rpc/dialer.go
@@ -284,6 +284,13 @@ func (d *WebsocketDialer) Call(ctx context.Context, req *Message) (*Message, err
 		return nil, ErrNilRequest
 	}
 
+	// Marshal the request before registering a response sink so a marshal
+	// failure cannot leak entries in responseSinks.
+	reqJSON, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrMarshalingRequest, err)
+	}
+
 	// Check connection and register response channel atomically
 	d.mu.Lock()
 	if d.dialCtx == nil || d.dialCtx.ctx.Err() != nil {
@@ -295,12 +302,6 @@ func (d *WebsocketDialer) Call(ctx context.Context, req *Message) (*Message, err
 	responseSink := make(chan *Message, 1) // Buffered to prevent blocking in readMessages
 	d.responseSinks[req.RequestID] = responseSink
 	d.mu.Unlock()
-
-	// Marshal the request
-	reqJSON, err := json.Marshal(req)
-	if err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrMarshalingRequest, err)
-	}
 
 	// Send the request (WebSocket writes must be serialized)
 	d.writeMu.Lock()

--- a/pkg/rpc/dialer_internal_test.go
+++ b/pkg/rpc/dialer_internal_test.go
@@ -1,0 +1,37 @@
+package rpc
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWebsocketDialer_Call_MarshalFailureNoSinkLeak verifies that a request
+// which fails to marshal does not leave a dangling entry in responseSinks.
+// Regression test: marshalling must happen before the response sink is
+// registered, otherwise repeated malformed calls grow the map unboundedly.
+func TestWebsocketDialer_Call_MarshalFailureNoSinkLeak(t *testing.T) {
+	t.Parallel()
+
+	d := NewWebsocketDialer(DefaultWebsocketDialerConfig)
+
+	// Malformed raw JSON in the payload makes json.Marshal fail.
+	badPayload := Payload{"bad": json.RawMessage("{invalid")}
+
+	const calls = 100
+	for i := uint64(1); i <= calls; i++ {
+		req := NewRequest(i, "noop", badPayload)
+		_, err := d.Call(context.Background(), &req)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrMarshalingRequest), "expected ErrMarshalingRequest, got %v", err)
+	}
+
+	d.mu.RLock()
+	pending := len(d.responseSinks)
+	d.mu.RUnlock()
+	assert.Equal(t, 0, pending, "marshal failures must not leak response sinks")
+}


### PR DESCRIPTION
## Finding (MF3-L11)

`WebsocketDialer.Call` registered the response sink **before** marshalling the request. If marshalling failed (malformed raw JSON in the payload), the function returned `ErrMarshalingRequest` without removing the sink. Repeated direct calls to the low-level `WebsocketDialer.Call` API with malformed payloads and unique request IDs could grow `responseSinks` unboundedly, degrading or crashing the calling process.

SDK methods are not affected — they build payloads via `NewPayload` before reaching `Call`.

## Fix

Move `json.Marshal` ahead of the connection check and sink registration in `Call`. A marshal failure now returns before any sink is registered, so nothing can leak.

## Test

`pkg/rpc/dialer_internal_test.go` — white-box test (no server needed, since marshalling now precedes the connection check):
- 100 calls with malformed `json.RawMessage` payloads and unique request IDs
- asserts each returns `ErrMarshalingRequest`
- asserts `responseSinks` is empty afterward

The test locks in the reordering: with the old order a disconnected dialer returned `ErrNotConnected` before reaching the marshal, so it would fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)