### PR TITLE
fix(nitronode): remediate MF3-I* audit findings

### DIFF
--- a/nitronode/api/app_session_v1/README.md
+++ b/nitronode/api/app_session_v1/README.md
@@ -715,7 +715,7 @@ ORDER BY created_at DESC;
 - `app_session_ids` entries must be lowercase strings (non-lowercase values are rejected before signature verification)
 - Version must be sequential (latest_version + 1)
 - Signature must recover to `user_address`
-- The per-user cap (`NITRONODE_MAX_SESSION_KEYS_PER_USER`, default 100) is enforced whenever the submit transitions the slot from inactive to active: a brand-new key (no prior state) or a reactivation (previous latest state's `expires_at` was already in the past). Rotation/update against a still-active key, and revocation submits, are not subject to the cap.
+- The per-user cap (`NITRONODE_MAX_SESSION_KEYS_PER_USER`, default 100) is enforced whenever the submit transitions the slot from inactive to active: a brand-new key (no prior state) or a reactivation (previous latest state's `expires_at` was already in the past). Rotation/update against a still-active key, and revocation submits, are not subject to the cap. A value `<= 0` disables the cap entirely (unlimited session keys per user).
 
 **Concurrency**: A `SELECT ... FOR UPDATE` is taken on a per-(user, session_key, kind) pointer row in `current_session_key_states_v1` so concurrent submits for the same key serialize and report a clean "expected version" error instead of racing on the history table's UNIQUE constraint.
 

--- a/nitronode/api/app_session_v1/get_app_sessions.go
+++ b/nitronode/api/app_session_v1/get_app_sessions.go
@@ -23,6 +23,14 @@ func (h *Handler) GetAppSessions(c *rpc.Context) {
 		return
 	}
 
+	// A provided app_session_id must be a well-formed hash. Rejecting it here
+	// stops an empty or malformed id from silently falling through to an
+	// unfiltered list (the store skips the id filter when it is empty).
+	if req.AppSessionID != nil && !core.IsValidHash(*req.AppSessionID) {
+		c.Fail(rpc.Errorf("invalid app_session_id"), "")
+		return
+	}
+
 	if req.Participant != nil {
 		normalizedParticipant, err := core.NormalizeHexAddress(*req.Participant)
 		if err != nil {

--- a/nitronode/api/app_session_v1/get_app_sessions_test.go
+++ b/nitronode/api/app_session_v1/get_app_sessions_test.go
@@ -160,7 +160,7 @@ func TestGetAppSessions_SuccessWithAppSessionID(t *testing.T) {
 	}
 
 	// Test data
-	sessionID := "session1"
+	sessionID := "0x3333333333333333333333333333333333333333333333333333333333333333"
 	participant := "0x1234567890123456789012345678901234567890"
 
 	sessions := []app.AppSessionV1{
@@ -189,7 +189,7 @@ func TestGetAppSessions_SuccessWithAppSessionID(t *testing.T) {
 
 	// Mock expectations
 	mockStore.On("GetAppSessions", &sessionID, (*string)(nil), app.AppSessionStatusVoid, &core.PaginationParams{}).Return(sessions, metadata, nil)
-	mockStore.On("GetParticipantAllocations", "session1").Return(map[string]map[string]decimal.Decimal{}, nil)
+	mockStore.On("GetParticipantAllocations", sessionID).Return(map[string]map[string]decimal.Decimal{}, nil)
 
 	// Create RPC request
 	reqPayload := rpc.AppSessionsV1GetAppSessionsRequest{
@@ -269,6 +269,45 @@ func TestGetAppSessions_MissingRequiredParams(t *testing.T) {
 
 	// Verify no store calls were made
 	mockStore.AssertExpectations(t)
+}
+
+func TestGetAppSessions_InvalidAppSessionID(t *testing.T) {
+	mockStore := new(MockStore)
+	mockSigner := NewMockChannelSigner()
+	mockAssetStore := new(MockAssetStore)
+
+	handler := &Handler{
+		useStoreInTx: func(fn StoreTxHandler) error {
+			return fn(mockStore)
+		},
+		signer:        mockSigner,
+		nodeAddress:   mockSigner.PublicKey().Address().String(),
+		stateAdvancer: core.NewStateAdvancerV1(mockAssetStore),
+		statePacker:   new(MockStatePacker),
+		metrics:       metrics.NewNoopRuntimeMetricExporter(),
+	}
+
+	// An empty or malformed app_session_id must be rejected, not silently
+	// dropped into an unfiltered list.
+	for _, id := range []string{"", "0xabc", "session1"} {
+		invalidID := id
+		reqPayload := rpc.AppSessionsV1GetAppSessionsRequest{AppSessionID: &invalidID}
+		payload, err := rpc.NewPayload(reqPayload)
+		require.NoError(t, err)
+
+		ctx := &rpc.Context{
+			Context: context.Background(),
+			Request: rpc.Message{Method: "app_sessions.v1.get_app_sessions", Payload: payload},
+		}
+
+		handler.GetAppSessions(ctx)
+
+		require.NotNil(t, ctx.Response.Error(), "id %q should be rejected", id)
+		assert.Contains(t, ctx.Response.Error().Error(), "invalid app_session_id")
+	}
+
+	// A malformed id must never reach the store.
+	mockStore.AssertNotCalled(t, "GetAppSessions")
 }
 
 func TestGetAppSessions_WithStatusFilter(t *testing.T) {

--- a/nitronode/api/app_session_v1/get_last_key_states.go
+++ b/nitronode/api/app_session_v1/get_last_key_states.go
@@ -2,6 +2,7 @@ package app_session_v1
 
 import (
 	"github.com/layer-3/nitrolite/pkg/app"
+	"github.com/layer-3/nitrolite/pkg/core"
 	"github.com/layer-3/nitrolite/pkg/log"
 	"github.com/layer-3/nitrolite/pkg/rpc"
 )
@@ -23,7 +24,7 @@ func (h *Handler) GetLastKeyStates(c *rpc.Context) {
 		return
 	}
 
-	var limit, offset uint32
+	var paginationParams core.PaginationParams
 	if req.Pagination != nil {
 		// The endpoint orders rows by (created_at DESC, id ASC) for stable pagination;
 		// callers cannot override this, so any sort value is rejected rather than silently
@@ -33,14 +34,14 @@ func (h *Handler) GetLastKeyStates(c *rpc.Context) {
 			c.Fail(rpc.Errorf("invalid_pagination: sort is not supported by get_last_key_states"), "")
 			return
 		}
-		if req.Pagination.Limit != nil {
-			limit = *req.Pagination.Limit
-		}
-		if req.Pagination.Offset != nil {
-			offset = *req.Pagination.Offset
-		}
+		paginationParams.Offset = req.Pagination.Offset
+		paginationParams.Limit = req.Pagination.Limit
 	}
-	if limit == 0 || limit > rpc.GetLastKeyStatesPageLimit {
+	// GetOffsetAndLimit caps the limit and clamps the offset so the later
+	// int(offset) conversion in the store never wraps negative. An explicit
+	// limit of 0 still falls back to the page limit.
+	offset, limit := paginationParams.GetOffsetAndLimit(rpc.GetLastKeyStatesPageLimit, rpc.GetLastKeyStatesPageLimit)
+	if limit == 0 {
 		limit = rpc.GetLastKeyStatesPageLimit
 	}
 

--- a/nitronode/api/app_session_v1/submit_session_key_state.go
+++ b/nitronode/api/app_session_v1/submit_session_key_state.go
@@ -105,6 +105,9 @@ func (h *Handler) SubmitSessionKeyState(c *rpc.Context) {
 
 	// Validate version and store the session key state
 	now := time.Now()
+	// revoked is true only when this submit transitions an active key to inactive,
+	// so the revocation log is not emitted for inactive-to-inactive updates.
+	var revoked bool
 	err = h.useStoreInTx(func(tx Store) error {
 		// Lock the (user, session_key, app_session) pointer row for the duration of the tx so
 		// that concurrent submits for the same (user, session_key) serialize cleanly and report
@@ -142,6 +145,7 @@ func (h *Handler) SubmitSessionKeyState(c *rpc.Context) {
 		// (pg_advisory_xact_lock(hashtext(user_address))) before counting.
 		prevActive := latestVersion > 0 && latestExpiresAt.After(now)
 		submittedActive := coreState.ExpiresAt.After(now)
+		revoked = prevActive && !submittedActive
 		if !prevActive && submittedActive && h.maxSessionKeysPerUser > 0 {
 			count, err := tx.CountSessionKeysForUser(coreState.UserAddress)
 			if err != nil {
@@ -174,7 +178,7 @@ func (h *Handler) SubmitSessionKeyState(c *rpc.Context) {
 	}
 
 	c.Succeed(c.Request.Method, payload)
-	if !coreState.ExpiresAt.After(now) {
+	if revoked {
 		logger.Info("session key revoked",
 			"userAddress", coreState.UserAddress,
 			"sessionKey", coreState.SessionKey,

--- a/nitronode/api/channel_v1/get_channels.go
+++ b/nitronode/api/channel_v1/get_channels.go
@@ -78,20 +78,19 @@ func (h *Handler) GetChannels(c *rpc.Context) {
 	const defaultLimit uint32 = 100
 	const maxLimit uint32 = 1000
 
-	var limit, offset uint32
+	var paginationParams core.PaginationParams
 	if req.Pagination != nil {
-		if req.Pagination.Limit != nil {
-			limit = *req.Pagination.Limit
-		}
-		if req.Pagination.Offset != nil {
-			offset = *req.Pagination.Offset
-		}
+		paginationParams.Offset = req.Pagination.Offset
+		paginationParams.Limit = req.Pagination.Limit
+		paginationParams.Sort = req.Pagination.Sort
 	}
+	// GetOffsetAndLimit caps the limit at maxLimit and clamps the offset so the
+	// later int(offset) conversion in the store never wraps negative. An explicit
+	// limit of 0 still falls back to the default so the page-count math below
+	// never divides by zero.
+	offset, limit := paginationParams.GetOffsetAndLimit(defaultLimit, maxLimit)
 	if limit == 0 {
 		limit = defaultLimit
-	}
-	if limit > maxLimit {
-		limit = maxLimit
 	}
 
 	var channels []core.Channel

--- a/nitronode/api/channel_v1/get_escrow_channel.go
+++ b/nitronode/api/channel_v1/get_escrow_channel.go
@@ -18,6 +18,11 @@ func (h *Handler) GetEscrowChannel(c *rpc.Context) {
 		return
 	}
 
+	if !core.IsValidHash(req.EscrowChannelID) {
+		c.Fail(rpc.Errorf("invalid escrow_channel_id"), "")
+		return
+	}
+
 	var channel *core.Channel
 	err := h.useStoreInTx(func(tx Store) error {
 		var err error

--- a/nitronode/api/channel_v1/get_escrow_channel_test.go
+++ b/nitronode/api/channel_v1/get_escrow_channel_test.go
@@ -42,7 +42,7 @@ func TestGetEscrowChannel_Success(t *testing.T) {
 
 	// Test data
 	userWallet := "0x1234567890123456789012345678901234567890"
-	escrowChannelID := "0xEscrowChannel456"
+	escrowChannelID := "0x1111111111111111111111111111111111111111111111111111111111111111"
 
 	escrowChannel := core.Channel{
 		ChannelID:         escrowChannelID,
@@ -120,7 +120,7 @@ func TestGetEscrowChannel_NotFound(t *testing.T) {
 		actionGateway:    &MockActionGateway{},
 	}
 
-	escrowChannelID := "0xMissingEscrowChannel"
+	escrowChannelID := "0x2222222222222222222222222222222222222222222222222222222222222222"
 	mockTxStore.On("GetChannelByID", escrowChannelID).Return(nil, nil)
 
 	reqPayload := rpc.ChannelsV1GetEscrowChannelRequest{EscrowChannelID: escrowChannelID}
@@ -144,4 +144,44 @@ func TestGetEscrowChannel_NotFound(t *testing.T) {
 	assert.Nil(t, response.Channel)
 
 	mockTxStore.AssertExpectations(t)
+}
+
+func TestGetEscrowChannel_InvalidID(t *testing.T) {
+	mockTxStore := new(MockStore)
+	mockAssetStore := new(MockAssetStore)
+	mockSigner := NewMockSigner()
+	nodeSigner, _ := core.NewChannelDefaultSigner(mockSigner)
+
+	handler := &Handler{
+		stateAdvancer: core.NewStateAdvancerV1(mockAssetStore),
+		statePacker:   new(MockStatePacker),
+		useStoreInTx: func(h StoreTxHandler) error {
+			return h(mockTxStore)
+		},
+		nodeSigner:       nodeSigner,
+		nodeAddress:      mockSigner.PublicKey().Address().String(),
+		minChallenge:     3600,
+		metrics:          metrics.NewNoopRuntimeMetricExporter(),
+		maxSessionKeyIDs: 256,
+		actionGateway:    &MockActionGateway{},
+	}
+
+	for _, id := range []string{"", "0xabc", "not-a-hash"} {
+		reqPayload := rpc.ChannelsV1GetEscrowChannelRequest{EscrowChannelID: id}
+		payload, err := rpc.NewPayload(reqPayload)
+		require.NoError(t, err)
+
+		ctx := &rpc.Context{
+			Context: context.Background(),
+			Request: rpc.Message{Method: "channels.v1.get_escrow_channel", Payload: payload},
+		}
+
+		handler.GetEscrowChannel(ctx)
+
+		require.NotNil(t, ctx.Response.Error(), "id %q should be rejected", id)
+		assert.Contains(t, ctx.Response.Error().Error(), "invalid escrow_channel_id")
+	}
+
+	// A malformed id must never reach the store.
+	mockTxStore.AssertNotCalled(t, "GetChannelByID")
 }

--- a/nitronode/api/channel_v1/get_last_key_states.go
+++ b/nitronode/api/channel_v1/get_last_key_states.go
@@ -23,7 +23,7 @@ func (h *Handler) GetLastKeyStates(c *rpc.Context) {
 		return
 	}
 
-	var limit, offset uint32
+	var paginationParams core.PaginationParams
 	if req.Pagination != nil {
 		// The endpoint orders rows by (created_at DESC, id ASC) for stable pagination;
 		// callers cannot override this, so any sort value is rejected rather than silently
@@ -33,14 +33,14 @@ func (h *Handler) GetLastKeyStates(c *rpc.Context) {
 			c.Fail(rpc.Errorf("invalid_pagination: sort is not supported by get_last_key_states"), "")
 			return
 		}
-		if req.Pagination.Limit != nil {
-			limit = *req.Pagination.Limit
-		}
-		if req.Pagination.Offset != nil {
-			offset = *req.Pagination.Offset
-		}
+		paginationParams.Offset = req.Pagination.Offset
+		paginationParams.Limit = req.Pagination.Limit
 	}
-	if limit == 0 || limit > rpc.GetLastKeyStatesPageLimit {
+	// GetOffsetAndLimit caps the limit and clamps the offset so the later
+	// int(offset) conversion in the store never wraps negative. An explicit
+	// limit of 0 still falls back to the page limit.
+	offset, limit := paginationParams.GetOffsetAndLimit(rpc.GetLastKeyStatesPageLimit, rpc.GetLastKeyStatesPageLimit)
+	if limit == 0 {
 		limit = rpc.GetLastKeyStatesPageLimit
 	}
 

--- a/nitronode/api/channel_v1/submit_session_key_state.go
+++ b/nitronode/api/channel_v1/submit_session_key_state.go
@@ -88,6 +88,9 @@ func (h *Handler) SubmitSessionKeyState(c *rpc.Context) {
 
 	// Validate version and store the session key state
 	now := time.Now()
+	// revoked is true only when this submit transitions an active key to inactive,
+	// so the revocation log is not emitted for inactive-to-inactive updates.
+	var revoked bool
 	err = h.useStoreInTx(func(tx Store) error {
 		// Lock the (user, session_key, channel) pointer row for the duration of the tx so that
 		// concurrent submits for the same (user, session_key) serialize cleanly and report a
@@ -125,6 +128,7 @@ func (h *Handler) SubmitSessionKeyState(c *rpc.Context) {
 		// (pg_advisory_xact_lock(hashtext(user_address))) before counting.
 		prevActive := latestVersion > 0 && latestExpiresAt.After(now)
 		submittedActive := coreState.ExpiresAt.After(now)
+		revoked = prevActive && !submittedActive
 		if !prevActive && submittedActive && h.maxSessionKeysPerUser > 0 {
 			count, err := tx.CountSessionKeysForUser(coreState.UserAddress)
 			if err != nil {
@@ -157,7 +161,7 @@ func (h *Handler) SubmitSessionKeyState(c *rpc.Context) {
 	}
 
 	c.Succeed(c.Request.Method, payload)
-	if !coreState.ExpiresAt.After(now) {
+	if revoked {
 		logger.Info("channel session key revoked",
 			"userAddress", coreState.UserAddress,
 			"sessionKey", coreState.SessionKey,

--- a/nitronode/api/channel_v1/submit_state.go
+++ b/nitronode/api/channel_v1/submit_state.go
@@ -121,7 +121,7 @@ func (h *Handler) SubmitState(c *rpc.Context) {
 
 		// Validate user's signature
 		if incomingState.UserSig == nil {
-			return rpc.Errorf("missing incoming state user signature: %v", err)
+			return rpc.Errorf("missing incoming state user signature")
 		}
 		userSigBytes, err := hexutil.Decode(*incomingState.UserSig)
 		if err != nil {

--- a/nitronode/runtime.go
+++ b/nitronode/runtime.go
@@ -103,11 +103,11 @@ type SignerConfig struct {
 
 // ValidationLimits defines configurable upper bounds for dynamic-length request fields.
 type ValidationLimits struct {
-	MaxParticipants       int `yaml:"max_participants" env:"NITRONODE_MAX_PARTICIPANTS" env-default:"32"`
-	MaxSessionDataLen     int `yaml:"max_session_data_len" env:"NITRONODE_MAX_SESSION_DATA_LEN" env-default:"1024"`
-	MaxAppMetadataLen     int `yaml:"max_app_metadata_len" env:"NITRONODE_MAX_APP_METADATA_LEN" env-default:"1024"`
-	MaxSessionKeyIDs      int `yaml:"max_session_key_ids" env:"NITRONODE_MAX_SESSION_KEY_IDS" env-default:"10"`
-	MaxSignedUpdates      int `yaml:"max_signed_updates" env:"NITRONODE_MAX_SIGNED_UPDATES" env-default:"0"`
+	MaxParticipants   int `yaml:"max_participants" env:"NITRONODE_MAX_PARTICIPANTS" env-default:"32"`
+	MaxSessionDataLen int `yaml:"max_session_data_len" env:"NITRONODE_MAX_SESSION_DATA_LEN" env-default:"1024"`
+	MaxAppMetadataLen int `yaml:"max_app_metadata_len" env:"NITRONODE_MAX_APP_METADATA_LEN" env-default:"1024"`
+	MaxSessionKeyIDs  int `yaml:"max_session_key_ids" env:"NITRONODE_MAX_SESSION_KEY_IDS" env-default:"10"`
+	MaxSignedUpdates  int `yaml:"max_signed_updates" env:"NITRONODE_MAX_SIGNED_UPDATES" env-default:"0"`
 	// MaxSessionKeysPerUser is a soft per-user cap on active session keys, a DoS/storage
 	// bound enforced when a submit activates a key (new registration or reactivation).
 	// A value <= 0 disables the cap entirely (unlimited). Default 100.

--- a/nitronode/runtime.go
+++ b/nitronode/runtime.go
@@ -108,6 +108,9 @@ type ValidationLimits struct {
 	MaxAppMetadataLen     int `yaml:"max_app_metadata_len" env:"NITRONODE_MAX_APP_METADATA_LEN" env-default:"1024"`
 	MaxSessionKeyIDs      int `yaml:"max_session_key_ids" env:"NITRONODE_MAX_SESSION_KEY_IDS" env-default:"10"`
 	MaxSignedUpdates      int `yaml:"max_signed_updates" env:"NITRONODE_MAX_SIGNED_UPDATES" env-default:"0"`
+	// MaxSessionKeysPerUser is a soft per-user cap on active session keys, a DoS/storage
+	// bound enforced when a submit activates a key (new registration or reactivation).
+	// A value <= 0 disables the cap entirely (unlimited). Default 100.
 	MaxSessionKeysPerUser int `yaml:"max_session_keys_per_user" env:"NITRONODE_MAX_SESSION_KEYS_PER_USER" env-default:"100"`
 }
 

--- a/nitronode/store/database/app.go
+++ b/nitronode/store/database/app.go
@@ -76,7 +76,7 @@ func (s *DBStore) GetApps(appID *string, ownerWallet *string, pagination *core.P
 
 	offset, limit := pagination.GetOffsetAndLimit(DefaultLimit, MaxLimit)
 
-	query = query.Order("created_at DESC").Offset(int(offset)).Limit(int(limit))
+	query = query.Order("created_at DESC").Offset(core.SafeOffset(offset)).Limit(int(limit))
 
 	var dbApps []AppV1
 	if err := query.Find(&dbApps).Error; err != nil {

--- a/nitronode/store/database/app_session.go
+++ b/nitronode/store/database/app_session.go
@@ -116,7 +116,7 @@ func (s *DBStore) GetAppSessions(appSessionID *string, participant *string, stat
 
 	offset, limit := pagination.GetOffsetAndLimit(DefaultLimit, MaxLimit)
 
-	query = query.Preload("Participants").Order("created_at DESC").Offset(int(offset)).Limit(int(limit))
+	query = query.Preload("Participants").Order("created_at DESC").Offset(core.SafeOffset(offset)).Limit(int(limit))
 
 	var dbSessions []AppSessionV1
 	if err := query.Find(&dbSessions).Error; err != nil {

--- a/nitronode/store/database/app_session_key_state.go
+++ b/nitronode/store/database/app_session_key_state.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/layer-3/nitrolite/pkg/app"
+	"github.com/layer-3/nitrolite/pkg/core"
 	"gorm.io/gorm"
 )
 
@@ -139,7 +140,7 @@ func (s *DBStore) GetLastAppSessionKeyStates(wallet string, sessionKey *string, 
 		Preload("AppSessionIDs").
 		Order("app_session_key_states_v1.created_at DESC, app_session_key_states_v1.id ASC").
 		Limit(int(limit)).
-		Offset(int(offset))
+		Offset(core.SafeOffset(offset))
 	if sessionKey != nil && *sessionKey != "" {
 		query = query.Where("c.session_key = ?", strings.ToLower(*sessionKey))
 	}

--- a/nitronode/store/database/channel.go
+++ b/nitronode/store/database/channel.go
@@ -225,14 +225,17 @@ func (s *DBStore) GetChannelsCountByLabels() ([]ChannelCount, error) {
 	return results, nil
 }
 
-// UpdateChannel persists changes to a channel's metadata (status, version, etc).
+// UpdateChannel persists changes to a channel's mutable lifecycle fields
+// (status, state_version, challenge_expires_at). Immutable configuration fields
+// are not touched here — see CreateChannel.
 func (s *DBStore) UpdateChannel(channel core.Channel) error {
+	// Only mutable lifecycle fields are persisted here. Immutable identity and
+	// configuration fields (blockchain_id, token, nonce, ...) are set once in
+	// CreateChannel and intentionally excluded so a partial or stale core.Channel
+	// passed by a caller cannot corrupt a channel's metadata.
 	updates := map[string]interface{}{
 		"status":               channel.Status,
 		"state_version":        channel.StateVersion,
-		"blockchain_id":        channel.BlockchainID,
-		"token":                strings.ToLower(channel.TokenAddress),
-		"nonce":                channel.Nonce,
 		"challenge_expires_at": channel.ChallengeExpiresAt,
 		"updated_at":           time.Now(),
 	}

--- a/nitronode/store/database/channel.go
+++ b/nitronode/store/database/channel.go
@@ -189,7 +189,7 @@ func (s *DBStore) GetUserChannels(wallet string, status *core.ChannelStatus, ass
 	}
 
 	var dbChannels []Channel
-	if err := query.Order("created_at DESC").Limit(int(limit)).Offset(int(offset)).Find(&dbChannels).Error; err != nil {
+	if err := query.Order("created_at DESC").Limit(int(limit)).Offset(core.SafeOffset(offset)).Find(&dbChannels).Error; err != nil {
 		return nil, 0, fmt.Errorf("failed to get user channels: %w", err)
 	}
 

--- a/nitronode/store/database/channel_session_key_state.go
+++ b/nitronode/store/database/channel_session_key_state.go
@@ -120,7 +120,7 @@ func (s *DBStore) GetLastChannelSessionKeyStates(wallet string, sessionKey *stri
 		Preload("Assets").
 		Order("channel_session_key_states_v1.created_at DESC, channel_session_key_states_v1.id ASC").
 		Limit(int(limit)).
-		Offset(int(offset))
+		Offset(core.SafeOffset(offset))
 	if sessionKey != nil && *sessionKey != "" {
 		query = query.Where("c.session_key = ?", strings.ToLower(*sessionKey))
 	}

--- a/nitronode/store/database/channel_test.go
+++ b/nitronode/store/database/channel_test.go
@@ -441,7 +441,6 @@ func TestDBStore_GetNotClosedHomeChannel(t *testing.T) {
 	})
 }
 
-
 func TestDBStore_CheckActiveChannel(t *testing.T) {
 	t.Run("Success - Has open channel", func(t *testing.T) {
 		db, cleanup := SetupTestDB(t)

--- a/nitronode/store/database/channel_test.go
+++ b/nitronode/store/database/channel_test.go
@@ -712,7 +712,7 @@ func TestDBStore_UpdateChannel(t *testing.T) {
 		assert.NotNil(t, result.ChallengeExpiresAt)
 	})
 
-	t.Run("Success - Update blockchain and token", func(t *testing.T) {
+	t.Run("Immutable config fields are not modified", func(t *testing.T) {
 		db, cleanup := SetupTestDB(t)
 		defer cleanup()
 
@@ -732,20 +732,26 @@ func TestDBStore_UpdateChannel(t *testing.T) {
 		}
 		require.NoError(t, store.CreateChannel(channel))
 
-		// Update blockchain and token
+		// A caller mutating immutable identity/config fields must not corrupt the
+		// stored channel — UpdateChannel persists only mutable lifecycle fields.
 		channel.BlockchainID = 137
 		channel.TokenAddress = "0xnewtoken456"
+		channel.Nonce = 999
+		channel.StateVersion = 5
 
 		err := store.UpdateChannel(channel)
 		require.NoError(t, err)
 
-		// Verify update
 		result, err := store.GetChannelByID("0xhomechannel123")
 		require.NoError(t, err)
 		require.NotNil(t, result)
 
-		assert.Equal(t, uint64(137), result.BlockchainID)
-		assert.Equal(t, "0xnewtoken456", result.TokenAddress)
+		// Immutable fields keep their CreateChannel values.
+		assert.Equal(t, uint64(1), result.BlockchainID)
+		assert.Equal(t, "0xtoken123", result.TokenAddress)
+		assert.Equal(t, uint64(1), result.Nonce)
+		// Mutable lifecycle field is updated.
+		assert.Equal(t, uint64(5), result.StateVersion)
 	})
 
 	t.Run("Error - Update non-existent channel", func(t *testing.T) {

--- a/nitronode/store/database/transaction.go
+++ b/nitronode/store/database/transaction.go
@@ -106,7 +106,7 @@ func (s *DBStore) GetUserTransactions(accountID string, asset *string, txType *c
 
 	offset, limit := paginate.GetOffsetAndLimit(DefaultLimit, MaxLimit)
 
-	query = query.Order("created_at DESC").Offset(int(offset)).Limit(int(limit))
+	query = query.Order("created_at DESC").Offset(core.SafeOffset(offset)).Limit(int(limit))
 
 	var dbTransactions []Transaction
 	if err := query.Find(&dbTransactions).Error; err != nil {

--- a/nitronode/store/memory/asset_config.go
+++ b/nitronode/store/memory/asset_config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -95,6 +96,13 @@ func LoadAssets(configDirPath string) (AssetsConfig, error) {
 // Note: This method modifies token fields during validation but changes are not persisted
 // back to the original slice due to Go's value semantics in range loops.
 func verifyAssetsConfig(cfg *AssetsConfig) error {
+	// seenSymbols maps a canonical (lowercased) symbol to the index of the first
+	// enabled asset that declared it. Downstream logic matches asset symbols
+	// case-sensitively in some places (the in-memory supported-asset registry)
+	// and case-insensitively in others (the persistence layer), so allowing both
+	// "usdt" and "USDT" would make asset handling ambiguous. Fail closed instead.
+	seenSymbols := make(map[string]int)
+
 	for i, asset := range cfg.Assets {
 		if asset.Disabled {
 			continue
@@ -103,6 +111,12 @@ func verifyAssetsConfig(cfg *AssetsConfig) error {
 		if asset.Symbol == "" {
 			return fmt.Errorf("missing asset symbol for asset[%d]", i)
 		}
+		canonicalSymbol := strings.ToLower(asset.Symbol)
+		if prev, dup := seenSymbols[canonicalSymbol]; dup {
+			return fmt.Errorf("duplicate asset symbol '%s' (asset[%d]) conflicts with '%s' (asset[%d]) on a case-insensitive basis",
+				asset.Symbol, i, cfg.Assets[prev].Symbol, prev)
+		}
+		seenSymbols[canonicalSymbol] = i
 		if asset.Name == "" {
 			cfg.Assets[i].Name = asset.Symbol
 		}

--- a/nitronode/store/memory/asset_config_test.go
+++ b/nitronode/store/memory/asset_config_test.go
@@ -122,6 +122,64 @@ func TestAssetsConfig_verifyVariables(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	// Test case-insensitive duplicate asset symbol (should fail)
+	t.Run("case-insensitive duplicate asset symbol", func(t *testing.T) {
+		cfg := AssetsConfig{
+			Assets: []AssetConfig{
+				{
+					Name:                  "Tether USD",
+					Symbol:                "usdt",
+					SuggestedBlockchainID: 1,
+				},
+				{
+					Name:                  "Tether USD",
+					Symbol:                "USDT",
+					SuggestedBlockchainID: 137,
+				},
+			},
+		}
+		err := verifyAssetsConfig(&cfg)
+		require.Error(t, err)
+		assert.Equal(t, "duplicate asset symbol 'USDT' (asset[1]) conflicts with 'usdt' (asset[0]) on a case-insensitive basis", err.Error())
+	})
+
+	// Test exact duplicate asset symbol (should fail)
+	t.Run("exact duplicate asset symbol", func(t *testing.T) {
+		cfg := AssetsConfig{
+			Assets: []AssetConfig{
+				{Symbol: "usdt", SuggestedBlockchainID: 1},
+				{Symbol: "usdt", SuggestedBlockchainID: 137},
+			},
+		}
+		err := verifyAssetsConfig(&cfg)
+		require.Error(t, err)
+		assert.Equal(t, "duplicate asset symbol 'usdt' (asset[1]) conflicts with 'usdt' (asset[0]) on a case-insensitive basis", err.Error())
+	})
+
+	// Test distinct asset symbols (should pass)
+	t.Run("distinct asset symbols", func(t *testing.T) {
+		cfg := AssetsConfig{
+			Assets: []AssetConfig{
+				{Symbol: "usdt", SuggestedBlockchainID: 1},
+				{Symbol: "usdc", SuggestedBlockchainID: 1},
+			},
+		}
+		err := verifyAssetsConfig(&cfg)
+		require.NoError(t, err)
+	})
+
+	// Test duplicate symbol where one asset is disabled (should pass — disabled assets are skipped)
+	t.Run("duplicate symbol with disabled asset", func(t *testing.T) {
+		cfg := AssetsConfig{
+			Assets: []AssetConfig{
+				{Symbol: "usdt", SuggestedBlockchainID: 1},
+				{Symbol: "USDT", Disabled: true},
+			},
+		}
+		err := verifyAssetsConfig(&cfg)
+		require.NoError(t, err)
+	})
+
 	// Test custom symbol for token (inherits from asset when empty)
 	t.Run("custom symbol for token", func(t *testing.T) {
 		cfg := AssetsConfig{

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -879,12 +879,12 @@ func NewTransactionFromTransition(senderState *State, receiverState *State, tran
 		toAccount = transition.AccountID
 
 	case TransitionTypeRelease:
-		txType = TransactionTypeRelease
-		fromAccount = transition.AccountID
-		toAccount = receiverState.UserWallet
 		if receiverState == nil {
 			return nil, fmt.Errorf("receiver state must not be nil for 'release' transition")
 		}
+		txType = TransactionTypeRelease
+		fromAccount = transition.AccountID
+		toAccount = receiverState.UserWallet
 
 	case TransitionTypeMutualLock:
 		if senderState.EscrowChannelID == nil || senderState.HomeChannelID == nil {

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -1226,6 +1227,12 @@ func (p *PaginationParams) GetOffsetAndLimit(defaultLimit, maxLimit uint32) (off
 			limit = min(*p.Limit, maxLimit)
 		}
 	}
+
+	// Callers convert offset to int before handing it to GORM's Offset(). On a
+	// 32-bit target int(offset) wraps to a negative value for large uint32s,
+	// which GORM treats as "no offset" and silently returns the first page.
+	// Clamp to MaxInt32 so the conversion is always a non-negative int.
+	offset = min(offset, math.MaxInt32)
 
 	return offset, limit
 }

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -1202,8 +1202,8 @@ type EscrowWithdrawalDataResponse struct {
 
 // BalanceEntry represents a balance entry for an asset
 type BalanceEntry struct {
-	Asset   string          `json:"asset"`   // Asset symbol
-	Balance decimal.Decimal `json:"balance"` // Balance amount
+	Asset    string          `json:"asset"`    // Asset symbol
+	Balance  decimal.Decimal `json:"balance"`  // Balance amount
 	Enforced decimal.Decimal `json:"enforced"` // On-chain enforced balance
 }
 

--- a/pkg/core/types_test.go
+++ b/pkg/core/types_test.go
@@ -568,6 +568,12 @@ func TestNewTransactionFromTransition(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "receiver state must not be nil")
 
+	// Release error: nil receiverState must return an error, not panic
+	transition = Transition{Type: TransitionTypeRelease, Amount: decimal.NewFromInt(10), AccountID: "REC"}
+	_, err = NewTransactionFromTransition(senderState, nil, transition)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "receiver state must not be nil for 'release' transition")
+
 	// Invalid
 	transition = Transition{Type: 255}
 	_, err = NewTransactionFromTransition(senderState, nil, transition)

--- a/pkg/core/types_test.go
+++ b/pkg/core/types_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"math"
 	"math/big"
 	"testing"
 
@@ -597,4 +598,11 @@ func TestPaginationParams_GetOffsetAndLimit(t *testing.T) {
 	lim = 200
 	o, l = p.GetOffsetAndLimit(10, 100)
 	assert.Equal(t, uint32(100), l) // Capped at max
+
+	// Offset is clamped to MaxInt32 so int(offset) never wraps negative on 32-bit.
+	bigOff := uint32(math.MaxUint32)
+	p = &PaginationParams{Offset: &bigOff}
+	o, _ = p.GetOffsetAndLimit(10, 100)
+	assert.Equal(t, uint32(math.MaxInt32), o)
+	assert.GreaterOrEqual(t, int(o), 0)
 }

--- a/pkg/core/utils.go
+++ b/pkg/core/utils.go
@@ -3,6 +3,7 @@ package core
 import (
 	"fmt"
 	"math/big"
+	"regexp"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -11,6 +12,16 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/shopspring/decimal"
 )
+
+// HashRegex matches a 32-byte hash rendered as a 0x-prefixed hex string, the
+// canonical form of channel IDs and app session IDs (both Keccak256 hashes).
+// Case-insensitive, since callers may submit checksummed or lowercased hex.
+var HashRegex = regexp.MustCompile(`^0x[0-9a-fA-F]{64}$`)
+
+// IsValidHash reports whether s is a well-formed 32-byte hash (see HashRegex).
+func IsValidHash(s string) bool {
+	return HashRegex.MatchString(s)
+}
 
 // maxInt256 = 2^255 - 1, the largest value representable as Solidity int256.
 var maxInt256 = new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 255), big.NewInt(1))

--- a/pkg/core/utils.go
+++ b/pkg/core/utils.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"math"
 	"math/big"
 	"regexp"
 	"strings"
@@ -21,6 +22,16 @@ var HashRegex = regexp.MustCompile(`^0x[0-9a-fA-F]{64}$`)
 // IsValidHash reports whether s is a well-formed 32-byte hash (see HashRegex).
 func IsValidHash(s string) bool {
 	return HashRegex.MatchString(s)
+}
+
+// SafeOffset converts a uint32 pagination offset to a non-negative int suitable
+// for GORM's Offset(). A raw int(offset) wraps to a negative value on a 32-bit
+// target for large uint32s, which GORM treats as "no offset" and silently
+// returns the first page. Clamping to MaxInt32 keeps the conversion safe even
+// when a caller reaches the store without routing through
+// PaginationParams.GetOffsetAndLimit.
+func SafeOffset(offset uint32) int {
+	return int(min(offset, math.MaxInt32))
 }
 
 // maxInt256 = 2^255 - 1, the largest value representable as Solidity int256.

--- a/pkg/core/utils_test.go
+++ b/pkg/core/utils_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"math"
 	"math/big"
 	"testing"
 
@@ -652,6 +653,29 @@ func TestGenerateChannelMetadata(t *testing.T) {
 	})
 }
 
+func TestSafeOffset(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		offset uint32
+		want   int
+	}{
+		{"zero", 0, 0},
+		{"small", 42, 42},
+		{"max_int32", math.MaxInt32, math.MaxInt32},
+		{"above_max_int32_clamped", math.MaxInt32 + 1, math.MaxInt32},
+		{"max_uint32_clamped", math.MaxUint32, math.MaxInt32},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := SafeOffset(tt.offset)
+			assert.Equal(t, tt.want, got)
+			assert.GreaterOrEqual(t, got, 0, "offset must never be negative")
+		})
+	}
+}
+
 func TestTransitionToIntent_OperateIntents(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -843,10 +867,10 @@ func TestIsValidHash(t *testing.T) {
 	invalid := []string{
 		"",
 		"0xabc",
-		"1111111111111111111111111111111111111111111111111111111111111111", // missing 0x
-		"0x111111111111111111111111111111111111111111111111111111111111111",  // 63 hex
+		"1111111111111111111111111111111111111111111111111111111111111111",    // missing 0x
+		"0x111111111111111111111111111111111111111111111111111111111111111",   // 63 hex
 		"0x11111111111111111111111111111111111111111111111111111111111111111", // 65 hex
-		"0xzz11111111111111111111111111111111111111111111111111111111111111", // non-hex
+		"0xzz11111111111111111111111111111111111111111111111111111111111111",  // non-hex
 	}
 	for _, s := range invalid {
 		assert.False(t, IsValidHash(s), "expected %q to be invalid", s)

--- a/pkg/core/utils_test.go
+++ b/pkg/core/utils_test.go
@@ -830,3 +830,25 @@ func TestDecimalToInt256(t *testing.T) {
 		assert.Contains(t, err.Error(), "below int256 min")
 	})
 }
+
+func TestIsValidHash(t *testing.T) {
+	valid := []string{
+		"0x1111111111111111111111111111111111111111111111111111111111111111",
+		"0xabcdefABCDEF0000000000000000000000000000000000000000000000000000",
+	}
+	for _, s := range valid {
+		assert.True(t, IsValidHash(s), "expected %q to be valid", s)
+	}
+
+	invalid := []string{
+		"",
+		"0xabc",
+		"1111111111111111111111111111111111111111111111111111111111111111", // missing 0x
+		"0x111111111111111111111111111111111111111111111111111111111111111",  // 63 hex
+		"0x11111111111111111111111111111111111111111111111111111111111111111", // 65 hex
+		"0xzz11111111111111111111111111111111111111111111111111111111111111", // non-hex
+	}
+	for _, s := range invalid {
+		assert.False(t, IsValidHash(s), "expected %q to be invalid", s)
+	}
+}


### PR DESCRIPTION
Remediates the MF3-I* batch of audit findings (informational severity). Each finding is its own commit so they can be reviewed independently.

## Findings

**MF3-I01 — `MAX_SESSION_KEYS_PER_USER=0` silently disables the per-user cap**
The cap is skipped whenever `maxSessionKeysPerUser <= 0`, but that wasn't documented and `0` could be read as "invalid" or "zero keys allowed". Documented `<= 0` as the unlimited mode on the config field and in the app-session submit README. Kept it as a documented behavior rather than a startup-reject, since that matches the existing `WsBytesPerSec` "<0 to disable" / `MaxSignedUpdates` `0` conventions and avoids breaking anyone already running `0`.

**MF3-I02 — duplicate asset symbols accepted case-insensitively**
`verifyAssetsConfig()` accepted both `usdt` and `USDT`, which is ambiguous because the in-memory registry matches symbols case-sensitively while the persistence layer lowercases them. Now tracks enabled symbols by their lowercased form and fails startup on a case-insensitive (or exact) duplicate. Disabled assets are skipped; request-time exact-symbol semantics are unchanged.

**MF3-I03 — stale `err` in missing-user-signature error**
The missing-`user_sig` guard formatted an `err` that is always `nil` at that point, polluting the message with `<nil>`. Dropped the format arg.

**MF3-I04 — nil-deref in `NewTransactionFromTransition` release branch**
The `release` case dereferenced `receiverState.UserWallet` before the nil check, so a nil receiver state panicked instead of returning an error. Moved the nil check ahead of any field access. No RPC path passes nil today, but the helper is now safe regardless of caller. Added a regression test.

**MF3-I05 — pagination offset can wrap negative on 32-bit**
`GetOffsetAndLimit` returned a caller-controlled `uint32` offset that every store query converts via `int(offset)` before GORM's `Offset()`; on a 32-bit target a large offset wraps negative and GORM treats it as "no offset", silently returning the first page. Clamped offset to `MaxInt32` in `GetOffsetAndLimit`, then routed the handlers that still computed offset/limit by hand through the same helper so the clamp is enforced everywhere (`channels.v1.get_channels`, `channels.v1.get_last_key_states`, `app_sessions.v1.get_last_key_states`). An explicit `limit: 0` still falls back to the endpoint default so page-count math never divides by zero.

**MF3-I07 — session-key revocation mislogged**
Both `SubmitSessionKeyState` handlers logged a revocation whenever the submitted `expires_at` was not in the future, ignoring whether the previous state was active — so inactive-to-inactive updates (and already-expired new versions) were logged as revocations. Now gated on the real transition: `revoked := prevActive && !submittedActive`.

**MF3-I08 — unvalidated channel / app-session IDs**
`GetAppSessions` accepted a non-nil but empty `app_session_id`, which the store treated as "no filter", silently returning an unfiltered paginated list instead of honoring the documented either-id-or-participant contract. Added `core.HashRegex` + `core.IsValidHash` (a `0x`-prefixed 32-byte hash — the canonical form of channel and app-session IDs), mirroring `app.IsValidApplicationID`, and reject malformed IDs at the RPC boundary in `GetAppSessions` and `GetEscrowChannel`. `HomeChannelID` is left as-is — it has no bare-id read endpoint and is already verified by exact derivation match or existence lookup.

**MF3-I09 — `UpdateChannel` rewrites immutable config**
`UpdateChannel` rewrote immutable config (`blockchain_id`, `token`, `nonce`) on every lifecycle update, widening the blast radius if a future caller passes a partial/stale `core.Channel`. Restricted it to mutable lifecycle fields (`status`, `state_version`, `challenge_expires_at`, `updated_at`); immutable config is set once in `CreateChannel`.

## Test plan

- `go build ./...`
- `go test ./pkg/core/... ./nitronode/store/database/... ./nitronode/api/channel_v1/... ./nitronode/api/app_session_v1/... ./nitronode/event_handlers/...`
- `go vet ./...` on touched packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session-key revocation logging now only fires when a key actually transitions from active to inactive
  * Error message for missing state signature corrected
  * Prevented a potential crash when handling a specific transaction case

* **New Features**
  * Validation added for session and channel identifiers to reject malformed IDs

* **Improvements**
  * Centralized, more consistent pagination and safer offset handling across endpoints
  * Asset symbol validation now treats duplicates as case-insensitive
  * Channel updates no longer modify immutable configuration fields

* **Documentation**
  * Clarified per-user active session-key cap semantics and disabling behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->