### PR TITLE
fix(go-sdk): preserve channel challenge expiry

### DIFF
--- a/sdk/go/utils.go
+++ b/sdk/go/utils.go
@@ -163,6 +163,7 @@ func transformChannel(channel rpc.ChannelV1) (core.Channel, error) {
 		BlockchainID:          blockchainID,
 		TokenAddress:          channel.TokenAddress,
 		ChallengeDuration:     channel.ChallengeDuration,
+		ChallengeExpiresAt:    channel.ChallengeExpiresAt,
 		Nonce:                 nonce,
 		ApprovedSigValidators: channel.ApprovedSigValidators,
 		Status:                channelStatus,

--- a/sdk/go/utils_test.go
+++ b/sdk/go/utils_test.go
@@ -137,6 +137,7 @@ func TestTransformPaginationParams(t *testing.T) {
 }
 
 func TestTransformChannel(t *testing.T) {
+	challengeExpiresAt := time.Unix(1710000000, 0).UTC()
 	rpcChan := rpc.ChannelV1{
 		ChannelID:             "0xChannelID",
 		UserWallet:            "0xUserWallet",
@@ -144,6 +145,7 @@ func TestTransformChannel(t *testing.T) {
 		BlockchainID:          "137",
 		TokenAddress:          "0xToken",
 		ChallengeDuration:     100,
+		ChallengeExpiresAt:    &challengeExpiresAt,
 		Nonce:                 "1",
 		ApprovedSigValidators: "0x01",
 		Status:                "open",
@@ -156,6 +158,8 @@ func TestTransformChannel(t *testing.T) {
 	assert.Equal(t, core.ChannelStatusOpen, ch.Status)
 	assert.Equal(t, uint64(137), ch.BlockchainID)
 	assert.Equal(t, uint64(5), ch.StateVersion)
+	require.NotNil(t, ch.ChallengeExpiresAt)
+	assert.True(t, ch.ChallengeExpiresAt.Equal(challengeExpiresAt))
 
 	// Test error cases
 	rpcChan.BlockchainID = "invalid"


### PR DESCRIPTION
## Summary
Fixes the Go SDK channel transform so `ChallengeExpiresAt` from RPC `ChannelV1` is preserved on the returned core `Channel`.

## Context
Auditor note: https://yellownetworkgroup.slack.com/archives/C0AHWMC0BRT/p1780517217044149

## Changes
- Copy `ChallengeExpiresAt` in `transformChannel`.
- Add regression coverage in `TestTransformChannel`.

## Checks
- `git diff --check -- sdk/go/utils.go sdk/go/utils_test.go`
- `go test ./sdk/go ./pkg/core ./pkg/rpc`
- `go test ./...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Channels now properly expose the challenge expiration timestamp field in the SDK response.

* **Tests**
  * Updated channel transformation test to validate the newly exposed timestamp field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->