### PR TITLE
Fix SDK MCP Hono audit failure

### DIFF
--- a/sdk/mcp/package-lock.json
+++ b/sdk/mcp/package-lock.json
@@ -1103,9 +1103,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"


### PR DESCRIPTION
## Summary

- Refresh `sdk/mcp/package-lock.json` so the MCP SDK dependency tree resolves `hono` 4.12.23 instead of vulnerable 4.12.18.
- Fix the `Publish SDK MCP` workflow failure in the `Audit production dependencies` step, where `npm audit --omit=dev --audit-level=moderate` reports Hono moderate advisories.

## Root cause

The PR #810 job failed because `sdk/mcp/package-lock.json` pinned production dependency `hono` at 4.12.18, which matches the vulnerable `<=4.12.20` advisory range. The package manifest already allows a patched Hono through `@modelcontextprotocol/sdk`; the lockfile needed to be refreshed.

## Validation

- `npm ci`
- `npm audit --omit=dev --audit-level=moderate`
- `npm run typecheck`
- `npm run build`
- `npm run verify:package -- pack.json`
- Local packed MCP server smoke test equivalent to the workflow smoke job
