### PR TITLE
MF3-I12, I13, I14: nitronode audit remediations

### DIFF
--- a/nitronode/api/channel_v1/submit_session_key_state.go
+++ b/nitronode/api/channel_v1/submit_session_key_state.go
@@ -2,6 +2,7 @@ package channel_v1
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -69,6 +70,13 @@ func (h *Handler) SubmitSessionKeyState(c *rpc.Context) {
 	}
 	if len(coreState.Assets) > h.maxSessionKeyIDs {
 		c.Fail(rpc.Errorf("invalid_session_key_state: assets array exceeds maximum length of %d", h.maxSessionKeyIDs), "")
+		return
+	}
+	// An empty assets list authorizes no usable asset, so it is only meaningful as a
+	// revocation/deactivation state (expires_at <= now). Rejecting it for a future
+	// expires_at prevents an active current version that authorizes nothing.
+	if len(coreState.Assets) == 0 && coreState.ExpiresAt.After(time.Now()) {
+		c.Fail(rpc.Errorf("invalid_session_key_state: assets must be non-empty unless expires_at is in the past"), "")
 		return
 	}
 	if err := h.validateSessionKeyAssets(coreState.Assets); err != nil {
@@ -190,15 +198,15 @@ func (h *Handler) validateSessionKeyAssets(assets []string) error {
 	for _, asset := range assets {
 		normalized := strings.ToLower(asset)
 		if asset != normalized {
-			return rpc.Errorf("non-canonical asset '%s', expected '%s'", asset, normalized)
+			return fmt.Errorf("non-canonical asset '%s', expected '%s'", asset, normalized)
 		}
 		if _, ok := seen[normalized]; ok {
-			return rpc.Errorf("duplicate asset '%s'", asset)
+			return fmt.Errorf("duplicate asset '%s'", asset)
 		}
 		seen[normalized] = struct{}{}
 
 		if _, err := h.memoryStore.GetAssetDecimals(normalized); err != nil {
-			return rpc.Errorf("unsupported asset '%s'", asset)
+			return fmt.Errorf("unsupported asset '%s'", asset)
 		}
 	}
 	return nil

--- a/nitronode/api/channel_v1/submit_session_key_state.go
+++ b/nitronode/api/channel_v1/submit_session_key_state.go
@@ -71,6 +71,10 @@ func (h *Handler) SubmitSessionKeyState(c *rpc.Context) {
 		c.Fail(rpc.Errorf("invalid_session_key_state: assets array exceeds maximum length of %d", h.maxSessionKeyIDs), "")
 		return
 	}
+	if err := h.validateSessionKeyAssets(coreState.Assets); err != nil {
+		c.Fail(rpc.Errorf("invalid_session_key_state: %v", err), "")
+		return
+	}
 	if coreState.UserSig == "" {
 		c.Fail(rpc.Errorf("invalid_session_key_state: user_sig is required"), "")
 		return
@@ -173,4 +177,29 @@ func (h *Handler) SubmitSessionKeyState(c *rpc.Context) {
 		"userAddress", coreState.UserAddress,
 		"sessionKey", coreState.SessionKey,
 		"version", coreState.Version)
+}
+
+// validateSessionKeyAssets rejects an assets list that contains a non-canonical asset, a
+// duplicate, or an asset the node does not support. Assets must already be lowercased because
+// they are persisted lowercased (StoreChannelSessionKeyState) and looked up lowercased
+// (ValidateChannelSessionKeyForAsset); rejecting a non-canonical asset keeps the user-signed
+// payload identical to what is stored. Empty assets lists are allowed; the per-asset checks
+// only run on entries.
+func (h *Handler) validateSessionKeyAssets(assets []string) error {
+	seen := make(map[string]struct{}, len(assets))
+	for _, asset := range assets {
+		normalized := strings.ToLower(asset)
+		if asset != normalized {
+			return rpc.Errorf("non-canonical asset '%s', expected '%s'", asset, normalized)
+		}
+		if _, ok := seen[normalized]; ok {
+			return rpc.Errorf("duplicate asset '%s'", asset)
+		}
+		seen[normalized] = struct{}{}
+
+		if _, err := h.memoryStore.GetAssetDecimals(normalized); err != nil {
+			return rpc.Errorf("unsupported asset '%s'", asset)
+		}
+	}
+	return nil
 }

--- a/nitronode/api/channel_v1/submit_session_key_state_test.go
+++ b/nitronode/api/channel_v1/submit_session_key_state_test.go
@@ -59,6 +59,14 @@ func buildSignedChannelSessionKeyStateReq(t *testing.T, userAddress, sessionKey 
 	return rpc.ChannelsV1SubmitSessionKeyStateRequest{State: state}
 }
 
+// allAssetsMemoryStore returns a MockMemoryStore that treats every asset as supported, so
+// validateSessionKeyAssets passes for arbitrary symbols in these tests.
+func allAssetsMemoryStore() *MockMemoryStore {
+	m := new(MockMemoryStore)
+	m.On("GetAssetDecimals", mock.AnythingOfType("string")).Return(uint8(6), nil)
+	return m
+}
+
 func TestChannelSubmitSessionKeyState_Success(t *testing.T) {
 	mockStore := new(MockStore)
 	userSigner := NewMockSigner()
@@ -70,12 +78,13 @@ func TestChannelSubmitSessionKeyState_Success(t *testing.T) {
 		useStoreInTx: func(handler StoreTxHandler) error {
 			return handler(mockStore)
 		},
+		memoryStore:      allAssetsMemoryStore(),
 		metrics:          metrics.NewNoopRuntimeMetricExporter(),
 		maxSessionKeyIDs: 10,
 	}
 
 	expiresAt := time.Now().Add(24 * time.Hour).Truncate(time.Second)
-	assets := []string{"USDC"}
+	assets := []string{"usdc"}
 
 	reqPayload := buildSignedChannelSessionKeyStateReq(t, userAddress, sessionKeyAddress, 1, assets, expiresAt, userSigner, sessionKeySigner)
 
@@ -104,6 +113,7 @@ func TestChannelSubmitSessionKeyState_AssetsExceedsMax(t *testing.T) {
 		useStoreInTx: func(handler StoreTxHandler) error {
 			return handler(mockStore)
 		},
+		memoryStore:      allAssetsMemoryStore(),
 		metrics:          metrics.NewNoopRuntimeMetricExporter(),
 		maxSessionKeyIDs: 2,
 	}
@@ -114,7 +124,7 @@ func TestChannelSubmitSessionKeyState_AssetsExceedsMax(t *testing.T) {
 			UserAddress: "0x1111111111111111111111111111111111111111",
 			SessionKey:  "0x3333333333333333333333333333333333333333",
 			Version:     "1",
-			Assets:      []string{"USDC", "ETH", "BTC"},
+			Assets:      []string{"usdc", "eth", "btc"},
 			ExpiresAt:   strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10),
 			UserSig:     "0xdeadbeef",
 		},
@@ -136,6 +146,125 @@ func TestChannelSubmitSessionKeyState_AssetsExceedsMax(t *testing.T) {
 	assert.Contains(t, respErr.Error(), "assets array exceeds maximum length of 2")
 }
 
+func TestChannelSubmitSessionKeyState_RejectsDuplicateAssets(t *testing.T) {
+	mockStore := new(MockStore)
+	handler := &Handler{
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockStore)
+		},
+		memoryStore:      allAssetsMemoryStore(),
+		metrics:          metrics.NewNoopRuntimeMetricExporter(),
+		maxSessionKeyIDs: 10,
+	}
+
+	// Two identical assets must be rejected as a duplicate.
+	reqPayload := rpc.ChannelsV1SubmitSessionKeyStateRequest{
+		State: rpc.ChannelSessionKeyStateV1{
+			UserAddress: "0x1111111111111111111111111111111111111111",
+			SessionKey:  "0x3333333333333333333333333333333333333333",
+			Version:     "1",
+			Assets:      []string{"usdc", "usdc"},
+			ExpiresAt:   strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10),
+			UserSig:     "0xdeadbeef",
+		},
+	}
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, rpc.ChannelsV1SubmitSessionKeyStateMethod.String(), payload),
+	}
+
+	handler.SubmitSessionKeyState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.NotNil(t, respErr)
+	assert.Contains(t, respErr.Error(), "duplicate asset")
+}
+
+func TestChannelSubmitSessionKeyState_RejectsNonCanonicalAsset(t *testing.T) {
+	mockStore := new(MockStore)
+	handler := &Handler{
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockStore)
+		},
+		memoryStore:      allAssetsMemoryStore(),
+		metrics:          metrics.NewNoopRuntimeMetricExporter(),
+		maxSessionKeyIDs: 10,
+	}
+
+	// Assets must be submitted lowercased; a non-canonical casing is rejected.
+	reqPayload := rpc.ChannelsV1SubmitSessionKeyStateRequest{
+		State: rpc.ChannelSessionKeyStateV1{
+			UserAddress: "0x1111111111111111111111111111111111111111",
+			SessionKey:  "0x3333333333333333333333333333333333333333",
+			Version:     "1",
+			Assets:      []string{"USDC"},
+			ExpiresAt:   strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10),
+			UserSig:     "0xdeadbeef",
+		},
+	}
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, rpc.ChannelsV1SubmitSessionKeyStateMethod.String(), payload),
+	}
+
+	handler.SubmitSessionKeyState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.NotNil(t, respErr)
+	assert.Contains(t, respErr.Error(), "non-canonical asset")
+}
+
+func TestChannelSubmitSessionKeyState_RejectsUnsupportedAsset(t *testing.T) {
+	mockStore := new(MockStore)
+	mockMemoryStore := new(MockMemoryStore)
+	mockMemoryStore.On("GetAssetDecimals", "foo").Return(uint8(0), fmt.Errorf("asset 'foo' is not supported"))
+	handler := &Handler{
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockStore)
+		},
+		memoryStore:      mockMemoryStore,
+		metrics:          metrics.NewNoopRuntimeMetricExporter(),
+		maxSessionKeyIDs: 10,
+	}
+
+	reqPayload := rpc.ChannelsV1SubmitSessionKeyStateRequest{
+		State: rpc.ChannelSessionKeyStateV1{
+			UserAddress: "0x1111111111111111111111111111111111111111",
+			SessionKey:  "0x3333333333333333333333333333333333333333",
+			Version:     "1",
+			Assets:      []string{"foo"},
+			ExpiresAt:   strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10),
+			UserSig:     "0xdeadbeef",
+		},
+	}
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, rpc.ChannelsV1SubmitSessionKeyStateMethod.String(), payload),
+	}
+
+	handler.SubmitSessionKeyState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.NotNil(t, respErr)
+	assert.Contains(t, respErr.Error(), "unsupported asset")
+	mockMemoryStore.AssertExpectations(t)
+}
+
 func TestChannelSubmitSessionKeyState_AtMaxLimit(t *testing.T) {
 	mockStore := new(MockStore)
 	userSigner := NewMockSigner()
@@ -147,13 +276,14 @@ func TestChannelSubmitSessionKeyState_AtMaxLimit(t *testing.T) {
 		useStoreInTx: func(handler StoreTxHandler) error {
 			return handler(mockStore)
 		},
+		memoryStore:      allAssetsMemoryStore(),
 		metrics:          metrics.NewNoopRuntimeMetricExporter(),
 		maxSessionKeyIDs: 2,
 	}
 
 	expiresAt := time.Now().Add(24 * time.Hour).Truncate(time.Second)
 	// Exactly at max (2) should pass validation
-	assets := []string{"USDC", "ETH"}
+	assets := []string{"usdc", "eth"}
 
 	reqPayload := buildSignedChannelSessionKeyStateReq(t, userAddress, sessionKeyAddress, 1, assets, expiresAt, userSigner, sessionKeySigner)
 
@@ -181,6 +311,7 @@ func TestChannelSubmitSessionKeyState_InvalidUserAddress(t *testing.T) {
 		useStoreInTx: func(handler StoreTxHandler) error {
 			return handler(mockStore)
 		},
+		memoryStore:      allAssetsMemoryStore(),
 		metrics:          metrics.NewNoopRuntimeMetricExporter(),
 		maxSessionKeyIDs: 10,
 	}
@@ -223,6 +354,7 @@ func TestChannelSubmitSessionKeyState_RevokeWithPastExpiresAt(t *testing.T) {
 		useStoreInTx: func(handler StoreTxHandler) error {
 			return handler(mockStore)
 		},
+		memoryStore:      allAssetsMemoryStore(),
 		metrics:          metrics.NewNoopRuntimeMetricExporter(),
 		maxSessionKeyIDs: 10,
 	}
@@ -230,7 +362,7 @@ func TestChannelSubmitSessionKeyState_RevokeWithPastExpiresAt(t *testing.T) {
 	// expires_at in the past expresses a revoke: the same monotonic version sequence
 	// is preserved, the auth path filters expires_at > now so the key is deactivated.
 	expiresAt := time.Now().Add(-time.Hour).Truncate(time.Second)
-	assets := []string{"USDC"}
+	assets := []string{"usdc"}
 
 	reqPayload := buildSignedChannelSessionKeyStateReq(t, userAddress, sessionKeyAddress, 1, assets, expiresAt, userSigner, sessionKeySigner)
 
@@ -267,13 +399,14 @@ func TestChannelSubmitSessionKeyState_RevokeExistingActiveKey(t *testing.T) {
 		useStoreInTx: func(handler StoreTxHandler) error {
 			return handler(mockStore)
 		},
+		memoryStore:           allAssetsMemoryStore(),
 		metrics:               metrics.NewNoopRuntimeMetricExporter(),
 		maxSessionKeyIDs:      10,
 		maxSessionKeysPerUser: 5,
 	}
 
 	expiresAt := time.Now().Add(-time.Hour).Truncate(time.Second)
-	assets := []string{"USDC"}
+	assets := []string{"usdc"}
 
 	reqPayload := buildSignedChannelSessionKeyStateReq(t, userAddress, sessionKeyAddress, 2, assets, expiresAt, userSigner, sessionKeySigner)
 
@@ -313,13 +446,14 @@ func TestChannelSubmitSessionKeyState_ReactivateAfterRevoke_BelowCapAllowed(t *t
 		useStoreInTx: func(handler StoreTxHandler) error {
 			return handler(mockStore)
 		},
+		memoryStore:           allAssetsMemoryStore(),
 		metrics:               metrics.NewNoopRuntimeMetricExporter(),
 		maxSessionKeyIDs:      10,
 		maxSessionKeysPerUser: 5,
 	}
 
 	expiresAt := time.Now().Add(24 * time.Hour).Truncate(time.Second)
-	assets := []string{"USDC"}
+	assets := []string{"usdc"}
 
 	reqPayload := buildSignedChannelSessionKeyStateReq(t, userAddress, sessionKeyAddress, 3, assets, expiresAt, userSigner, sessionKeySigner)
 
@@ -357,13 +491,14 @@ func TestChannelSubmitSessionKeyState_ReactivateAfterRevoke_AtCapRejected(t *tes
 		useStoreInTx: func(handler StoreTxHandler) error {
 			return handler(mockStore)
 		},
+		memoryStore:           allAssetsMemoryStore(),
 		metrics:               metrics.NewNoopRuntimeMetricExporter(),
 		maxSessionKeyIDs:      10,
 		maxSessionKeysPerUser: 3,
 	}
 
 	expiresAt := time.Now().Add(24 * time.Hour).Truncate(time.Second)
-	assets := []string{"USDC"}
+	assets := []string{"usdc"}
 
 	reqPayload := buildSignedChannelSessionKeyStateReq(t, userAddress, sessionKeyAddress, 3, assets, expiresAt, userSigner, sessionKeySigner)
 
@@ -395,6 +530,7 @@ func TestChannelSubmitSessionKeyState_RejectsNegativeExpiresAt(t *testing.T) {
 		useStoreInTx: func(handler StoreTxHandler) error {
 			return handler(mockStore)
 		},
+		memoryStore:      allAssetsMemoryStore(),
 		metrics:          metrics.NewNoopRuntimeMetricExporter(),
 		maxSessionKeyIDs: 10,
 	}
@@ -433,6 +569,7 @@ func TestChannelSubmitSessionKeyState_MissingUserSig(t *testing.T) {
 		useStoreInTx: func(handler StoreTxHandler) error {
 			return handler(mockStore)
 		},
+		memoryStore:      allAssetsMemoryStore(),
 		metrics:          metrics.NewNoopRuntimeMetricExporter(),
 		maxSessionKeyIDs: 10,
 	}
@@ -475,6 +612,7 @@ func TestChannelSubmitSessionKeyState_VersionMismatch(t *testing.T) {
 		useStoreInTx: func(handler StoreTxHandler) error {
 			return handler(mockStore)
 		},
+		memoryStore:      allAssetsMemoryStore(),
 		metrics:          metrics.NewNoopRuntimeMetricExporter(),
 		maxSessionKeyIDs: 10,
 	}
@@ -514,13 +652,14 @@ func TestChannelSubmitSessionKeyState_RejectsWhenAtUserCap(t *testing.T) {
 		useStoreInTx: func(handler StoreTxHandler) error {
 			return handler(mockStore)
 		},
+		memoryStore:           allAssetsMemoryStore(),
 		metrics:               metrics.NewNoopRuntimeMetricExporter(),
 		maxSessionKeyIDs:      10,
 		maxSessionKeysPerUser: 3,
 	}
 
 	expiresAt := time.Now().Add(24 * time.Hour).Truncate(time.Second)
-	reqPayload := buildSignedChannelSessionKeyStateReq(t, userAddress, sessionKeyAddress, 1, []string{"USDC"}, expiresAt, userSigner, sessionKeySigner)
+	reqPayload := buildSignedChannelSessionKeyStateReq(t, userAddress, sessionKeyAddress, 1, []string{"usdc"}, expiresAt, userSigner, sessionKeySigner)
 
 	mockStore.On("LockSessionKeyState", userAddress, sessionKeyAddress, database.SessionKeyKindChannel).Return(0, time.Time{}, nil)
 	mockStore.On("CountSessionKeysForUser", userAddress).Return(3, nil)
@@ -554,6 +693,7 @@ func TestChannelSubmitSessionKeyState_AllowsUpdateForExistingKeyAtCap(t *testing
 		useStoreInTx: func(handler StoreTxHandler) error {
 			return handler(mockStore)
 		},
+		memoryStore:           allAssetsMemoryStore(),
 		metrics:               metrics.NewNoopRuntimeMetricExporter(),
 		maxSessionKeyIDs:      10,
 		maxSessionKeysPerUser: 3,
@@ -561,7 +701,7 @@ func TestChannelSubmitSessionKeyState_AllowsUpdateForExistingKeyAtCap(t *testing
 
 	expiresAt := time.Now().Add(24 * time.Hour).Truncate(time.Second)
 	// Existing key at version 4: submit version 5. Cap must NOT block updates.
-	reqPayload := buildSignedChannelSessionKeyStateReq(t, userAddress, sessionKeyAddress, 5, []string{"USDC"}, expiresAt, userSigner, sessionKeySigner)
+	reqPayload := buildSignedChannelSessionKeyStateReq(t, userAddress, sessionKeyAddress, 5, []string{"usdc"}, expiresAt, userSigner, sessionKeySigner)
 
 	prevActiveExpiresAt := time.Now().Add(24 * time.Hour)
 	mockStore.On("LockSessionKeyState", userAddress, sessionKeyAddress, database.SessionKeyKindChannel).Return(4, prevActiveExpiresAt, nil)
@@ -595,6 +735,7 @@ func TestChannelSubmitSessionKeyState_SignatureMismatch(t *testing.T) {
 		useStoreInTx: func(handler StoreTxHandler) error {
 			return handler(mockStore)
 		},
+		memoryStore:      allAssetsMemoryStore(),
 		metrics:          metrics.NewNoopRuntimeMetricExporter(),
 		maxSessionKeyIDs: 10,
 	}
@@ -629,12 +770,13 @@ func TestChannelSubmitSessionKeyState_RejectsUserAddressEqualsSessionKey(t *test
 		useStoreInTx: func(handler StoreTxHandler) error {
 			return handler(mockStore)
 		},
+		memoryStore:      allAssetsMemoryStore(),
 		metrics:          metrics.NewNoopRuntimeMetricExporter(),
 		maxSessionKeyIDs: 10,
 	}
 
 	expiresAt := time.Now().Add(24 * time.Hour).Truncate(time.Second)
-	reqPayload := buildSignedChannelSessionKeyStateReq(t, userAddress, userAddress, 1, []string{"USDC"}, expiresAt, userSigner, userSigner)
+	reqPayload := buildSignedChannelSessionKeyStateReq(t, userAddress, userAddress, 1, []string{"usdc"}, expiresAt, userSigner, userSigner)
 
 	payload, err := rpc.NewPayload(reqPayload)
 	require.NoError(t, err)
@@ -663,13 +805,14 @@ func TestChannelSubmitSessionKeyState_RejectsMissingSessionKeySig(t *testing.T) 
 		useStoreInTx: func(handler StoreTxHandler) error {
 			return handler(mockStore)
 		},
+		memoryStore:      allAssetsMemoryStore(),
 		metrics:          metrics.NewNoopRuntimeMetricExporter(),
 		maxSessionKeyIDs: 10,
 	}
 
 	expiresAt := time.Now().Add(24 * time.Hour).Truncate(time.Second)
 	// keySigner=nil → SessionKeySig field stays empty.
-	reqPayload := buildSignedChannelSessionKeyStateReq(t, userAddress, sessionKeyAddress, 1, []string{"USDC"}, expiresAt, userSigner, nil)
+	reqPayload := buildSignedChannelSessionKeyStateReq(t, userAddress, sessionKeyAddress, 1, []string{"usdc"}, expiresAt, userSigner, nil)
 
 	payload, err := rpc.NewPayload(reqPayload)
 	require.NoError(t, err)
@@ -699,13 +842,14 @@ func TestChannelSubmitSessionKeyState_RejectsMismatchedSessionKeySig(t *testing.
 		useStoreInTx: func(handler StoreTxHandler) error {
 			return handler(mockStore)
 		},
+		memoryStore:      allAssetsMemoryStore(),
 		metrics:          metrics.NewNoopRuntimeMetricExporter(),
 		maxSessionKeyIDs: 10,
 	}
 
 	expiresAt := time.Now().Add(24 * time.Hour).Truncate(time.Second)
 	// SessionKeySig from a key that does not match the declared session_key.
-	reqPayload := buildSignedChannelSessionKeyStateReq(t, userAddress, sessionKeyAddress, 1, []string{"USDC"}, expiresAt, userSigner, otherSigner)
+	reqPayload := buildSignedChannelSessionKeyStateReq(t, userAddress, sessionKeyAddress, 1, []string{"usdc"}, expiresAt, userSigner, otherSigner)
 
 	payload, err := rpc.NewPayload(reqPayload)
 	require.NoError(t, err)
@@ -734,12 +878,13 @@ func TestChannelSubmitSessionKeyState_RejectsForeignOwner(t *testing.T) {
 		useStoreInTx: func(handler StoreTxHandler) error {
 			return handler(mockStore)
 		},
+		memoryStore:      allAssetsMemoryStore(),
 		metrics:          metrics.NewNoopRuntimeMetricExporter(),
 		maxSessionKeyIDs: 10,
 	}
 
 	expiresAt := time.Now().Add(24 * time.Hour).Truncate(time.Second)
-	reqPayload := buildSignedChannelSessionKeyStateReq(t, userAddress, sessionKeyAddress, 1, []string{"USDC"}, expiresAt, userSigner, sessionKeySigner)
+	reqPayload := buildSignedChannelSessionKeyStateReq(t, userAddress, sessionKeyAddress, 1, []string{"usdc"}, expiresAt, userSigner, sessionKeySigner)
 
 	mockStore.On("LockSessionKeyState", userAddress, sessionKeyAddress, database.SessionKeyKindChannel).
 		Return(0, time.Time{}, database.ErrSessionKeyNotAllowed)

--- a/nitronode/api/channel_v1/submit_session_key_state_test.go
+++ b/nitronode/api/channel_v1/submit_session_key_state_test.go
@@ -265,6 +265,91 @@ func TestChannelSubmitSessionKeyState_RejectsUnsupportedAsset(t *testing.T) {
 	mockMemoryStore.AssertExpectations(t)
 }
 
+// An empty assets list authorizes no usable asset, so it is only meaningful as a
+// revocation/deactivation state (expires_at <= now). Submitting an empty list with a future
+// expires_at must be rejected so it can never become an active current version that
+// authorizes nothing. The allowed past-expires_at companion is
+// TestChannelSubmitSessionKeyState_AllowsEmptyAssetsWithPastExpiresAt.
+func TestChannelSubmitSessionKeyState_RejectsEmptyAssetsWithFutureExpiresAt(t *testing.T) {
+	mockStore := new(MockStore)
+	handler := &Handler{
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockStore)
+		},
+		memoryStore:      allAssetsMemoryStore(),
+		metrics:          metrics.NewNoopRuntimeMetricExporter(),
+		maxSessionKeyIDs: 10,
+	}
+
+	reqPayload := rpc.ChannelsV1SubmitSessionKeyStateRequest{
+		State: rpc.ChannelSessionKeyStateV1{
+			UserAddress: "0x1111111111111111111111111111111111111111",
+			SessionKey:  "0x3333333333333333333333333333333333333333",
+			Version:     "1",
+			Assets:      []string{},
+			ExpiresAt:   strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10),
+			UserSig:     "0xdeadbeef",
+		},
+	}
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, rpc.ChannelsV1SubmitSessionKeyStateMethod.String(), payload),
+	}
+
+	handler.SubmitSessionKeyState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.NotNil(t, respErr)
+	assert.Contains(t, respErr.Error(), "assets must be non-empty unless expires_at is in the past")
+	// The submission is rejected before any store interaction.
+	mockStore.AssertNotCalled(t, "LockSessionKeyState", mock.Anything, mock.Anything, mock.Anything)
+}
+
+// An empty assets list with a past expires_at is the revocation/deactivation state and must
+// be accepted: it stores the version-sequenced state while authorizing no asset, and the
+// auth path filters expires_at > now so the key is inactive.
+func TestChannelSubmitSessionKeyState_AllowsEmptyAssetsWithPastExpiresAt(t *testing.T) {
+	mockStore := new(MockStore)
+	userSigner := NewMockSigner()
+	userAddress := strings.ToLower(userSigner.PublicKey().Address().String())
+	sessionKeySigner := NewMockSigner()
+	sessionKeyAddress := strings.ToLower(sessionKeySigner.PublicKey().Address().String())
+
+	handler := &Handler{
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockStore)
+		},
+		memoryStore:      allAssetsMemoryStore(),
+		metrics:          metrics.NewNoopRuntimeMetricExporter(),
+		maxSessionKeyIDs: 10,
+	}
+
+	expiresAt := time.Now().Add(-time.Hour).Truncate(time.Second)
+	reqPayload := buildSignedChannelSessionKeyStateReq(t, userAddress, sessionKeyAddress, 1, []string{}, expiresAt, userSigner, sessionKeySigner)
+
+	mockStore.On("LockSessionKeyState", userAddress, sessionKeyAddress, database.SessionKeyKindChannel).Return(0, time.Time{}, nil)
+	mockStore.On("StoreChannelSessionKeyState", mock.AnythingOfType("core.ChannelSessionKeyStateV1")).Return(nil)
+
+	payload, err := rpc.NewPayload(reqPayload)
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.NewRequest(1, rpc.ChannelsV1SubmitSessionKeyStateMethod.String(), payload),
+	}
+
+	handler.SubmitSessionKeyState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	require.Nil(t, ctx.Response.Error())
+	mockStore.AssertExpectations(t)
+}
+
 func TestChannelSubmitSessionKeyState_AtMaxLimit(t *testing.T) {
 	mockStore := new(MockStore)
 	userSigner := NewMockSigner()
@@ -579,7 +664,7 @@ func TestChannelSubmitSessionKeyState_MissingUserSig(t *testing.T) {
 			UserAddress: "0x1111111111111111111111111111111111111111",
 			SessionKey:  "0x3333333333333333333333333333333333333333",
 			Version:     "1",
-			Assets:      []string{},
+			Assets:      []string{"usdc"},
 			ExpiresAt:   strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10),
 			UserSig:     "",
 		},
@@ -620,7 +705,7 @@ func TestChannelSubmitSessionKeyState_VersionMismatch(t *testing.T) {
 	expiresAt := time.Now().Add(24 * time.Hour).Truncate(time.Second)
 
 	// Submit version 3 when latest is 0 (expects 1)
-	reqPayload := buildSignedChannelSessionKeyStateReq(t, userAddress, sessionKeyAddress, 3, []string{}, expiresAt, userSigner, sessionKeySigner)
+	reqPayload := buildSignedChannelSessionKeyStateReq(t, userAddress, sessionKeyAddress, 3, []string{"usdc"}, expiresAt, userSigner, sessionKeySigner)
 
 	mockStore.On("LockSessionKeyState", userAddress, sessionKeyAddress, database.SessionKeyKindChannel).Return(0, time.Time{}, nil)
 
@@ -743,7 +828,7 @@ func TestChannelSubmitSessionKeyState_SignatureMismatch(t *testing.T) {
 	expiresAt := time.Now().Add(24 * time.Hour).Truncate(time.Second)
 
 	// Sign with differentSigner but claim userAddress
-	reqPayload := buildSignedChannelSessionKeyStateReq(t, userAddress, sessionKeyAddress, 1, []string{}, expiresAt, differentSigner, sessionKeySigner)
+	reqPayload := buildSignedChannelSessionKeyStateReq(t, userAddress, sessionKeyAddress, 1, []string{"usdc"}, expiresAt, differentSigner, sessionKeySigner)
 
 	payload, err := rpc.NewPayload(reqPayload)
 	require.NoError(t, err)

--- a/nitronode/api/channel_v1/submit_state.go
+++ b/nitronode/api/channel_v1/submit_state.go
@@ -99,10 +99,12 @@ func (h *Handler) SubmitState(c *rpc.Context) {
 			// 	extraTransitions = nil // no extra transitions to reapply
 			// }
 		default:
-			// User has no previous state
+			// An active home channel always has its initial state stored atomically by
+			// request_creation. A nil state here means the channel row exists without its
+			// state — an invariant violation, not a first-submit. Fail closed rather than
+			// bootstrapping a synthetic Void state through the wrong endpoint.
 			if currentState == nil {
-				logger.Debug("no previous state found, issuing a void state")
-				currentState = core.NewVoidState(incomingState.Asset, incomingState.UserWallet)
+				return rpc.Errorf("active channel has no stored state")
 			}
 		}
 

--- a/nitronode/api/channel_v1/submit_state_test.go
+++ b/nitronode/api/channel_v1/submit_state_test.go
@@ -51,6 +51,83 @@ func TestSubmitState_InvalidUserWallet_Rejected(t *testing.T) {
 	mockTxStore.AssertNotCalled(t, "LockUserState", mock.Anything, mock.Anything)
 }
 
+func TestSubmitState_ActiveChannelMissingState_Rejected(t *testing.T) {
+	// An active home channel always has its initial state stored by request_creation.
+	// If CheckActiveChannel reports an active channel but GetLastUserState returns nil,
+	// SubmitState must fail closed rather than bootstrapping a synthetic Void state.
+	mockTxStore := new(MockStore)
+	mockMemoryStore := new(MockMemoryStore)
+	mockAssetStore := new(MockAssetStore)
+	mockSigner := NewMockSigner()
+	nodeSigner, _ := core.NewChannelDefaultSigner(mockSigner)
+	mockStatePacker := new(MockStatePacker)
+
+	handler := &Handler{
+		stateAdvancer: core.NewStateAdvancerV1(mockAssetStore),
+		statePacker:   mockStatePacker,
+		useStoreInTx: func(handler StoreTxHandler) error {
+			return handler(mockTxStore)
+		},
+		memoryStore:      mockMemoryStore,
+		nodeSigner:       nodeSigner,
+		nodeAddress:      mockSigner.PublicKey().Address().String(),
+		minChallenge:     uint32(3600),
+		metrics:          metrics.NewNoopRuntimeMetricExporter(),
+		maxSessionKeyIDs: 256,
+		actionGateway:    &MockActionGateway{},
+	}
+
+	userSigner := NewMockSigner()
+	senderWallet := userSigner.PublicKey().Address().String()
+	receiverWallet := "0x0987654321098765432109876543210987654321"
+	asset := "USDC"
+	homeChannelID := "0xHomeChannel123"
+
+	currentState := core.State{
+		ID:            core.GetStateID(senderWallet, asset, 1, 1),
+		Asset:         asset,
+		UserWallet:    senderWallet,
+		Epoch:         1,
+		Version:       1,
+		HomeChannelID: &homeChannelID,
+		HomeLedger: core.Ledger{
+			TokenAddress: "0xTokenAddress",
+			BlockchainID: 1,
+			UserBalance:  decimal.NewFromInt(500),
+			UserNetFlow:  decimal.NewFromInt(500),
+			NodeBalance:  decimal.NewFromInt(0),
+			NodeNetFlow:  decimal.NewFromInt(0),
+		},
+	}
+	incomingState := currentState.NextState()
+	_, err := incomingState.ApplyTransferSendTransition(receiverWallet, decimal.NewFromInt(100))
+	require.NoError(t, err)
+
+	// Reports an active channel, but no stored state exists for the (wallet, asset) slot.
+	mockTxStore.On("LockUserState", senderWallet, asset).Return(decimal.Zero, nil)
+	mockTxStore.On("CheckActiveChannel", senderWallet, asset).Return("0x03", core.ChannelStatusOpen, nil)
+	mockTxStore.On("GetLastUserState", senderWallet, asset, false).Return(nil, nil)
+
+	rpcState := toRPCState(*incomingState)
+	payload, err := rpc.NewPayload(rpc.ChannelsV1SubmitStateRequest{State: rpcState})
+	require.NoError(t, err)
+
+	ctx := &rpc.Context{
+		Context: context.Background(),
+		Request: rpc.Message{Method: "channels.v1.submit_state", Payload: payload},
+	}
+
+	handler.SubmitState(ctx)
+
+	require.NotNil(t, ctx.Response)
+	respErr := ctx.Response.Error()
+	require.NotNil(t, respErr)
+	assert.Contains(t, respErr.Error(), "active channel has no stored state")
+	// Failed before signing/persistence.
+	mockTxStore.AssertNotCalled(t, "StoreUserState", mock.Anything, mock.Anything)
+	mockTxStore.AssertExpectations(t)
+}
+
 func TestSubmitState_TransferSend_Success(t *testing.T) {
 	// Setup
 	mockTxStore := new(MockStore)

--- a/nitronode/store/database/blockchain_action_test.go
+++ b/nitronode/store/database/blockchain_action_test.go
@@ -34,7 +34,7 @@ func TestDBStore_ScheduleCheckpoint(t *testing.T) {
 				UserBalance: decimal.NewFromInt(1000),
 			},
 		}
-		require.NoError(t, store.StoreUserState(state, ""))
+		require.NoError(t, storeLocked(t, store, state, ""))
 
 		err := store.ScheduleCheckpoint(state.ID, 0)
 		require.NoError(t, err)
@@ -73,7 +73,7 @@ func TestDBStore_ScheduleInitiateEscrowWithdrawal(t *testing.T) {
 				UserBalance: decimal.NewFromInt(500),
 			},
 		}
-		require.NoError(t, store.StoreUserState(state, ""))
+		require.NoError(t, storeLocked(t, store, state, ""))
 
 		err := store.ScheduleInitiateEscrowWithdrawal(state.ID, 0)
 		require.NoError(t, err)
@@ -107,7 +107,7 @@ func TestDBStore_ScheduleFinalizeEscrowDeposit(t *testing.T) {
 				UserBalance: decimal.NewFromInt(100),
 			},
 		}
-		require.NoError(t, store.StoreUserState(state, ""))
+		require.NoError(t, storeLocked(t, store, state, ""))
 
 		err := store.ScheduleFinalizeEscrowDeposit(state.ID, 0)
 		require.NoError(t, err)
@@ -139,7 +139,7 @@ func TestDBStore_ScheduleFinalizeEscrowWithdrawal(t *testing.T) {
 				UserBalance: decimal.NewFromInt(200),
 			},
 		}
-		require.NoError(t, store.StoreUserState(state, ""))
+		require.NoError(t, storeLocked(t, store, state, ""))
 
 		err := store.ScheduleFinalizeEscrowWithdrawal(state.ID, 0)
 		require.NoError(t, err)
@@ -171,7 +171,7 @@ func TestDBStore_Fail(t *testing.T) {
 				UserBalance: decimal.NewFromInt(300),
 			},
 		}
-		require.NoError(t, store.StoreUserState(state, ""))
+		require.NoError(t, storeLocked(t, store, state, ""))
 		require.NoError(t, store.ScheduleCheckpoint(state.ID, 0))
 
 		var action BlockchainAction
@@ -211,7 +211,7 @@ func TestDBStore_FailNoRetry(t *testing.T) {
 				UserBalance: decimal.NewFromInt(400),
 			},
 		}
-		require.NoError(t, store.StoreUserState(state, ""))
+		require.NoError(t, storeLocked(t, store, state, ""))
 		require.NoError(t, store.ScheduleCheckpoint(state.ID, 0))
 
 		var action BlockchainAction
@@ -251,7 +251,7 @@ func TestDBStore_RecordAttempt(t *testing.T) {
 				UserBalance: decimal.NewFromInt(150),
 			},
 		}
-		require.NoError(t, store.StoreUserState(state, ""))
+		require.NoError(t, storeLocked(t, store, state, ""))
 		require.NoError(t, store.ScheduleCheckpoint(state.ID, 0))
 
 		var action BlockchainAction
@@ -291,7 +291,7 @@ func TestDBStore_Complete(t *testing.T) {
 				UserBalance: decimal.NewFromInt(600),
 			},
 		}
-		require.NoError(t, store.StoreUserState(state, ""))
+		require.NoError(t, storeLocked(t, store, state, ""))
 		require.NoError(t, store.ScheduleCheckpoint(state.ID, 0))
 
 		var action BlockchainAction
@@ -329,7 +329,7 @@ func TestDBStore_Complete(t *testing.T) {
 				UserBalance: decimal.NewFromInt(250),
 			},
 		}
-		require.NoError(t, store.StoreUserState(state, ""))
+		require.NoError(t, storeLocked(t, store, state, ""))
 		require.NoError(t, store.ScheduleCheckpoint(state.ID, 0))
 
 		var action BlockchainAction
@@ -390,9 +390,9 @@ func TestDBStore_GetActions(t *testing.T) {
 			HomeLedger: core.Ledger{UserBalance: decimal.NewFromInt(300)},
 		}
 
-		require.NoError(t, store.StoreUserState(state1, ""))
-		require.NoError(t, store.StoreUserState(state2, ""))
-		require.NoError(t, store.StoreUserState(state3, ""))
+		require.NoError(t, storeLocked(t, store, state1, ""))
+		require.NoError(t, storeLocked(t, store, state2, ""))
+		require.NoError(t, storeLocked(t, store, state3, ""))
 
 		require.NoError(t, store.ScheduleCheckpoint(state1.ID, 0))
 		require.NoError(t, store.ScheduleInitiateEscrowWithdrawal(state2.ID, 0))
@@ -425,7 +425,7 @@ func TestDBStore_GetActions(t *testing.T) {
 				Transition: core.Transition{},
 				HomeLedger: core.Ledger{UserBalance: decimal.NewFromInt(int64(100 * (i + 1)))},
 			}
-			require.NoError(t, store.StoreUserState(state, ""))
+			require.NoError(t, storeLocked(t, store, state, ""))
 			require.NoError(t, store.ScheduleCheckpoint(state.ID, 0))
 		}
 
@@ -471,9 +471,9 @@ func TestDBStore_GetActions(t *testing.T) {
 			HomeLedger: core.Ledger{UserBalance: decimal.NewFromInt(300)},
 		}
 
-		require.NoError(t, store.StoreUserState(state1, ""))
-		require.NoError(t, store.StoreUserState(state2, ""))
-		require.NoError(t, store.StoreUserState(state3, ""))
+		require.NoError(t, storeLocked(t, store, state1, ""))
+		require.NoError(t, storeLocked(t, store, state2, ""))
+		require.NoError(t, storeLocked(t, store, state3, ""))
 
 		require.NoError(t, store.ScheduleCheckpoint(state1.ID, 0))
 		require.NoError(t, store.ScheduleCheckpoint(state2.ID, 0))

--- a/nitronode/store/database/channel_test.go
+++ b/nitronode/store/database/channel_test.go
@@ -234,7 +234,7 @@ func TestDBStore_GetActiveHomeChannel(t *testing.T) {
 				NodeNetFlow: decimal.Zero,
 			},
 		}
-		require.NoError(t, store.StoreUserState(state, ""))
+		require.NoError(t, storeLocked(t, store, state, ""))
 
 		result, err := store.GetActiveHomeChannel("0xuser123", "USDC")
 		require.NoError(t, err)
@@ -295,7 +295,7 @@ func TestDBStore_GetActiveHomeChannel(t *testing.T) {
 				NodeNetFlow: decimal.Zero,
 			},
 		}
-		require.NoError(t, store.StoreUserState(state, ""))
+		require.NoError(t, storeLocked(t, store, state, ""))
 
 		result, err := store.GetActiveHomeChannel("0xuser123", "USDC")
 		require.NoError(t, err)
@@ -341,7 +341,7 @@ func TestDBStore_GetActiveHomeChannel(t *testing.T) {
 				NodeNetFlow: decimal.Zero,
 			},
 		}
-		require.NoError(t, store.StoreUserState(state, ""))
+		require.NoError(t, storeLocked(t, store, state, ""))
 
 		result, err := store.GetActiveHomeChannel("0xuser123", "USDC")
 		require.NoError(t, err)
@@ -369,7 +369,7 @@ func TestDBStore_GetActiveHomeChannel(t *testing.T) {
 				NodeNetFlow: decimal.Zero,
 			},
 		}
-		require.NoError(t, store.StoreUserState(state, ""))
+		require.NoError(t, storeLocked(t, store, state, ""))
 
 		result, err := store.GetActiveHomeChannel("0xuser123", "USDC")
 		require.NoError(t, err)
@@ -482,7 +482,7 @@ func TestDBStore_CheckActiveChannel(t *testing.T) {
 				NodeNetFlow: decimal.Zero,
 			},
 		}
-		require.NoError(t, store.StoreUserState(state, ""))
+		require.NoError(t, storeLocked(t, store, state, ""))
 
 		approvedSigValidators, status, err := store.CheckActiveChannel("0xuser123", "USDC")
 		require.NoError(t, err)
@@ -542,7 +542,7 @@ func TestDBStore_CheckActiveChannel(t *testing.T) {
 				NodeNetFlow: decimal.Zero,
 			},
 		}
-		require.NoError(t, store.StoreUserState(state, ""))
+		require.NoError(t, storeLocked(t, store, state, ""))
 
 		approvedSigValidators, status, err := store.CheckActiveChannel("0xuser123", "USDC")
 		require.NoError(t, err)
@@ -589,7 +589,7 @@ func TestDBStore_CheckActiveChannel(t *testing.T) {
 				NodeNetFlow: decimal.Zero,
 			},
 		}
-		require.NoError(t, store.StoreUserState(state, ""))
+		require.NoError(t, storeLocked(t, store, state, ""))
 
 		// Check for different asset
 		approvedSigValidators, status, err := store.CheckActiveChannel("0xuser123", "ETH")

--- a/nitronode/store/database/db_store_test.go
+++ b/nitronode/store/database/db_store_test.go
@@ -35,10 +35,6 @@ func TestDBStore_GetUserBalances(t *testing.T) {
 			},
 		}
 
-		// Lock user state before storing (ensures row exists in user_balances)
-		_, err := store.LockUserState("0xuser123", "USDC")
-		require.NoError(t, err)
-
 		require.NoError(t, storeLocked(t, store, state, ""))
 
 		balances, err := store.GetUserBalances("0xuser123")
@@ -90,12 +86,6 @@ func TestDBStore_GetUserBalances(t *testing.T) {
 				NodeNetFlow: decimal.Zero,
 			},
 		}
-
-		// Lock user states before storing (ensures rows exist in user_balances)
-		_, err := store.LockUserState("0xuser123", "USDC")
-		require.NoError(t, err)
-		_, err = store.LockUserState("0xuser123", "ETH")
-		require.NoError(t, err)
 
 		require.NoError(t, storeLocked(t, store, state1, ""))
 		require.NoError(t, storeLocked(t, store, state2, ""))
@@ -163,10 +153,6 @@ func TestDBStore_GetUserBalances(t *testing.T) {
 			},
 		}
 
-		// Lock user state before storing (ensures row exists in user_balances)
-		_, err := store.LockUserState("0xuser123", "USDC")
-		require.NoError(t, err)
-
 		require.NoError(t, storeLocked(t, store, state1, ""))
 		require.NoError(t, storeLocked(t, store, state2, ""))
 
@@ -218,10 +204,6 @@ func TestDBStore_GetUserBalances(t *testing.T) {
 				NodeNetFlow: decimal.Zero,
 			},
 		}
-
-		// Lock user state before storing (ensures row exists in user_balances)
-		_, err := store.LockUserState("0xuser123", "USDC")
-		require.NoError(t, err)
 
 		require.NoError(t, storeLocked(t, store, state1, ""))
 		require.NoError(t, storeLocked(t, store, state2, ""))
@@ -302,13 +284,9 @@ func TestDBStore_EnsureNoOngoingStateTransitions(t *testing.T) {
 			NodeSig: &nodeSig,
 		}
 
-		// Lock user state before storing
-		_, err := store.LockUserState("0xuser123", "USDC")
-		require.NoError(t, err)
-
 		require.NoError(t, storeLocked(t, store, state, ""))
 
-		err = store.EnsureNoOngoingStateTransitions("0xuser123", "USDC")
+		err := store.EnsureNoOngoingStateTransitions("0xuser123", "USDC")
 		require.NoError(t, err)
 	})
 
@@ -358,13 +336,9 @@ func TestDBStore_EnsureNoOngoingStateTransitions(t *testing.T) {
 			NodeSig: &nodeSig,
 		}
 
-		// Lock user state before storing
-		_, err := store.LockUserState("0xuser123", "USDC")
-		require.NoError(t, err)
-
 		require.NoError(t, storeLocked(t, store, state, ""))
 
-		err = store.EnsureNoOngoingStateTransitions("0xuser123", "USDC")
+		err := store.EnsureNoOngoingStateTransitions("0xuser123", "USDC")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "home deposit is still ongoing")
 	})
@@ -438,13 +412,9 @@ func TestDBStore_EnsureNoOngoingStateTransitions(t *testing.T) {
 			NodeSig: &nodeSig,
 		}
 
-		// Lock user state before storing
-		_, err := store.LockUserState("0xuser123", "USDC")
-		require.NoError(t, err)
-
 		require.NoError(t, storeLocked(t, store, state, ""))
 
-		err = store.EnsureNoOngoingStateTransitions("0xuser123", "USDC")
+		err := store.EnsureNoOngoingStateTransitions("0xuser123", "USDC")
 		require.NoError(t, err)
 	})
 
@@ -517,13 +487,9 @@ func TestDBStore_EnsureNoOngoingStateTransitions(t *testing.T) {
 			NodeSig: &nodeSig,
 		}
 
-		// Lock user state before storing
-		_, err := store.LockUserState("0xuser123", "USDC")
-		require.NoError(t, err)
-
 		require.NoError(t, storeLocked(t, store, state, ""))
 
-		err = store.EnsureNoOngoingStateTransitions("0xuser123", "USDC")
+		err := store.EnsureNoOngoingStateTransitions("0xuser123", "USDC")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "mutual lock is still ongoing")
 	})
@@ -582,13 +548,9 @@ func TestDBStore_EnsureNoOngoingStateTransitions(t *testing.T) {
 			NodeSig: &nodeSig,
 		}
 
-		// Lock user state before storing
-		_, err := store.LockUserState("0xuser123", "USDC")
-		require.NoError(t, err)
-
 		require.NoError(t, storeLocked(t, store, state, ""))
 
-		err = store.EnsureNoOngoingStateTransitions("0xuser123", "USDC")
+		err := store.EnsureNoOngoingStateTransitions("0xuser123", "USDC")
 		require.NoError(t, err)
 	})
 
@@ -635,14 +597,10 @@ func TestDBStore_EnsureNoOngoingStateTransitions(t *testing.T) {
 			// No signatures
 		}
 
-		// Lock user state before storing
-		_, err := store.LockUserState("0xuser123", "USDC")
-		require.NoError(t, err)
-
 		require.NoError(t, storeLocked(t, store, state, ""))
 
 		// Should not error because there's no signed state
-		err = store.EnsureNoOngoingStateTransitions("0xuser123", "USDC")
+		err := store.EnsureNoOngoingStateTransitions("0xuser123", "USDC")
 		require.NoError(t, err)
 	})
 
@@ -717,8 +675,6 @@ func TestDBStore_EnsureNoOngoingStateTransitions(t *testing.T) {
 
 	storeState := func(t *testing.T, store DatabaseStore, state core.State) {
 		t.Helper()
-		_, err := store.LockUserState(wallet, asset)
-		require.NoError(t, err)
 		require.NoError(t, storeLocked(t, store, state, ""))
 	}
 
@@ -882,9 +838,6 @@ func TestDBStore_UpdateStateSigsIfMissing(t *testing.T) {
 		// Node-only state at version 2; gate would normally skip this row and find
 		// nothing else, returning nil. To exercise the wedge, also seed an older
 		// bilateral state at version 1.
-		_, err := store.LockUserState("0xuser123", "USDC")
-		require.NoError(t, err)
-
 		bilateralUserSig := "0xprior"
 		bilateralNodeSig := "0xpriornode"
 		bilateral := core.State{
@@ -929,7 +882,7 @@ func TestDBStore_UpdateStateSigsIfMissing(t *testing.T) {
 		require.NoError(t, storeLocked(t, store, nodeOnly, ""))
 
 		// Pre-backfill: gate sees bilateral row at version 1, channel.state_version is 2 → mismatch.
-		err = store.EnsureNoOngoingStateTransitions("0xuser123", "USDC")
+		err := store.EnsureNoOngoingStateTransitions("0xuser123", "USDC")
 		require.Error(t, err)
 
 		// Backfill the user signature recovered from the on-chain event.
@@ -970,9 +923,6 @@ func TestDBStore_UpdateStateSigsIfMissing(t *testing.T) {
 			StateVersion:      1,
 		}
 		require.NoError(t, store.CreateChannel(channel))
-
-		_, err := store.LockUserState("0xuser123", "USDC")
-		require.NoError(t, err)
 
 		state := core.State{
 			ID:            "state1",
@@ -1045,8 +995,6 @@ func TestDBStore_UpdateStateSigsIfMissing(t *testing.T) {
 			StateVersion:      1,
 		}))
 
-		_, err := store.LockUserState("0xuser123", "USDC")
-		require.NoError(t, err)
 		userSig := "0xusersigonly"
 		state := core.State{
 			ID:            "state-user-only",
@@ -1128,8 +1076,6 @@ func TestDBStore_SumNetTransitionAmountAfterVersion(t *testing.T) {
 			nodeSig := "0xnodesig"
 			s.NodeSig = &nodeSig
 		}
-		_, err := store.LockUserState(wallet, asset)
-		require.NoError(t, err)
 		require.NoError(t, storeLocked(t, store, s, ""))
 	}
 
@@ -1316,8 +1262,6 @@ func TestDBStore_HasSignedFinalize(t *testing.T) {
 			nodeSig := "0xnodesig"
 			s.NodeSig = &nodeSig
 		}
-		_, err := store.LockUserState(wallet, asset)
-		require.NoError(t, err)
 		require.NoError(t, storeLocked(t, store, s, ""))
 	}
 
@@ -1435,8 +1379,6 @@ func TestDBStore_EnsureNoOngoingEscrowOperation(t *testing.T) {
 
 	storeState := func(t *testing.T, store DatabaseStore, state core.State) {
 		t.Helper()
-		_, err := store.LockUserState(wallet, asset)
-		require.NoError(t, err)
 		require.NoError(t, storeLocked(t, store, state, ""))
 	}
 

--- a/nitronode/store/database/db_store_test.go
+++ b/nitronode/store/database/db_store_test.go
@@ -39,7 +39,7 @@ func TestDBStore_GetUserBalances(t *testing.T) {
 		_, err := store.LockUserState("0xuser123", "USDC")
 		require.NoError(t, err)
 
-		require.NoError(t, store.StoreUserState(state, ""))
+		require.NoError(t, storeLocked(t, store, state, ""))
 
 		balances, err := store.GetUserBalances("0xuser123")
 		require.NoError(t, err)
@@ -97,8 +97,8 @@ func TestDBStore_GetUserBalances(t *testing.T) {
 		_, err = store.LockUserState("0xuser123", "ETH")
 		require.NoError(t, err)
 
-		require.NoError(t, store.StoreUserState(state1, ""))
-		require.NoError(t, store.StoreUserState(state2, ""))
+		require.NoError(t, storeLocked(t, store, state1, ""))
+		require.NoError(t, storeLocked(t, store, state2, ""))
 
 		balances, err := store.GetUserBalances("0xuser123")
 		require.NoError(t, err)
@@ -167,8 +167,8 @@ func TestDBStore_GetUserBalances(t *testing.T) {
 		_, err := store.LockUserState("0xuser123", "USDC")
 		require.NoError(t, err)
 
-		require.NoError(t, store.StoreUserState(state1, ""))
-		require.NoError(t, store.StoreUserState(state2, ""))
+		require.NoError(t, storeLocked(t, store, state1, ""))
+		require.NoError(t, storeLocked(t, store, state2, ""))
 
 		balances, err := store.GetUserBalances("0xuser123")
 		require.NoError(t, err)
@@ -223,8 +223,8 @@ func TestDBStore_GetUserBalances(t *testing.T) {
 		_, err := store.LockUserState("0xuser123", "USDC")
 		require.NoError(t, err)
 
-		require.NoError(t, store.StoreUserState(state1, ""))
-		require.NoError(t, store.StoreUserState(state2, ""))
+		require.NoError(t, storeLocked(t, store, state1, ""))
+		require.NoError(t, storeLocked(t, store, state2, ""))
 
 		balances, err := store.GetUserBalances("0xuser123")
 		require.NoError(t, err)
@@ -306,7 +306,7 @@ func TestDBStore_EnsureNoOngoingStateTransitions(t *testing.T) {
 		_, err := store.LockUserState("0xuser123", "USDC")
 		require.NoError(t, err)
 
-		require.NoError(t, store.StoreUserState(state, ""))
+		require.NoError(t, storeLocked(t, store, state, ""))
 
 		err = store.EnsureNoOngoingStateTransitions("0xuser123", "USDC")
 		require.NoError(t, err)
@@ -362,7 +362,7 @@ func TestDBStore_EnsureNoOngoingStateTransitions(t *testing.T) {
 		_, err := store.LockUserState("0xuser123", "USDC")
 		require.NoError(t, err)
 
-		require.NoError(t, store.StoreUserState(state, ""))
+		require.NoError(t, storeLocked(t, store, state, ""))
 
 		err = store.EnsureNoOngoingStateTransitions("0xuser123", "USDC")
 		assert.Error(t, err)
@@ -442,7 +442,7 @@ func TestDBStore_EnsureNoOngoingStateTransitions(t *testing.T) {
 		_, err := store.LockUserState("0xuser123", "USDC")
 		require.NoError(t, err)
 
-		require.NoError(t, store.StoreUserState(state, ""))
+		require.NoError(t, storeLocked(t, store, state, ""))
 
 		err = store.EnsureNoOngoingStateTransitions("0xuser123", "USDC")
 		require.NoError(t, err)
@@ -521,7 +521,7 @@ func TestDBStore_EnsureNoOngoingStateTransitions(t *testing.T) {
 		_, err := store.LockUserState("0xuser123", "USDC")
 		require.NoError(t, err)
 
-		require.NoError(t, store.StoreUserState(state, ""))
+		require.NoError(t, storeLocked(t, store, state, ""))
 
 		err = store.EnsureNoOngoingStateTransitions("0xuser123", "USDC")
 		assert.Error(t, err)
@@ -586,7 +586,7 @@ func TestDBStore_EnsureNoOngoingStateTransitions(t *testing.T) {
 		_, err := store.LockUserState("0xuser123", "USDC")
 		require.NoError(t, err)
 
-		require.NoError(t, store.StoreUserState(state, ""))
+		require.NoError(t, storeLocked(t, store, state, ""))
 
 		err = store.EnsureNoOngoingStateTransitions("0xuser123", "USDC")
 		require.NoError(t, err)
@@ -639,7 +639,7 @@ func TestDBStore_EnsureNoOngoingStateTransitions(t *testing.T) {
 		_, err := store.LockUserState("0xuser123", "USDC")
 		require.NoError(t, err)
 
-		require.NoError(t, store.StoreUserState(state, ""))
+		require.NoError(t, storeLocked(t, store, state, ""))
 
 		// Should not error because there's no signed state
 		err = store.EnsureNoOngoingStateTransitions("0xuser123", "USDC")
@@ -719,7 +719,7 @@ func TestDBStore_EnsureNoOngoingStateTransitions(t *testing.T) {
 		t.Helper()
 		_, err := store.LockUserState(wallet, asset)
 		require.NoError(t, err)
-		require.NoError(t, store.StoreUserState(state, ""))
+		require.NoError(t, storeLocked(t, store, state, ""))
 	}
 
 	t.Run("HomeDeposit - home channel missing from DB - block", func(t *testing.T) {
@@ -906,7 +906,7 @@ func TestDBStore_UpdateStateSigsIfMissing(t *testing.T) {
 			UserSig: &bilateralUserSig,
 			NodeSig: &bilateralNodeSig,
 		}
-		require.NoError(t, store.StoreUserState(bilateral, ""))
+		require.NoError(t, storeLocked(t, store, bilateral, ""))
 
 		nodeOnly := core.State{
 			ID:            "state2",
@@ -926,7 +926,7 @@ func TestDBStore_UpdateStateSigsIfMissing(t *testing.T) {
 			},
 			NodeSig: &nodeSig,
 		}
-		require.NoError(t, store.StoreUserState(nodeOnly, ""))
+		require.NoError(t, storeLocked(t, store, nodeOnly, ""))
 
 		// Pre-backfill: gate sees bilateral row at version 1, channel.state_version is 2 → mismatch.
 		err = store.EnsureNoOngoingStateTransitions("0xuser123", "USDC")
@@ -993,7 +993,7 @@ func TestDBStore_UpdateStateSigsIfMissing(t *testing.T) {
 			UserSig: &userSig,
 			NodeSig: &nodeSig,
 		}
-		require.NoError(t, store.StoreUserState(state, ""))
+		require.NoError(t, storeLocked(t, store, state, ""))
 
 		// Replayed event would carry a different (or any) sig; existing one must not be overwritten.
 		require.NoError(t, store.UpdateStateSigsIfMissing(homeChannelID, 1, "0xshould-not-overwrite", "0xshould-not-overwrite-node"))
@@ -1064,7 +1064,7 @@ func TestDBStore_UpdateStateSigsIfMissing(t *testing.T) {
 			},
 			UserSig: &userSig,
 		}
-		require.NoError(t, store.StoreUserState(state, ""))
+		require.NoError(t, storeLocked(t, store, state, ""))
 
 		require.NoError(t, store.UpdateStateSigsIfMissing(homeChannelID, 1, "0xshould-not-overwrite-user", "0xrecoverednode"))
 
@@ -1130,7 +1130,7 @@ func TestDBStore_SumNetTransitionAmountAfterVersion(t *testing.T) {
 		}
 		_, err := store.LockUserState(wallet, asset)
 		require.NoError(t, err)
-		require.NoError(t, store.StoreUserState(s, ""))
+		require.NoError(t, storeLocked(t, store, s, ""))
 	}
 
 	t.Run("Scenario 3 - dust during challenge (unsigned receive only)", func(t *testing.T) {
@@ -1318,7 +1318,7 @@ func TestDBStore_HasSignedFinalize(t *testing.T) {
 		}
 		_, err := store.LockUserState(wallet, asset)
 		require.NoError(t, err)
-		require.NoError(t, store.StoreUserState(s, ""))
+		require.NoError(t, storeLocked(t, store, s, ""))
 	}
 
 	t.Run("True when node-signed Finalize exists", func(t *testing.T) {
@@ -1437,7 +1437,7 @@ func TestDBStore_EnsureNoOngoingEscrowOperation(t *testing.T) {
 		t.Helper()
 		_, err := store.LockUserState(wallet, asset)
 		require.NoError(t, err)
-		require.NoError(t, store.StoreUserState(state, ""))
+		require.NoError(t, storeLocked(t, store, state, ""))
 	}
 
 	t.Run("No previous state - allow", func(t *testing.T) {

--- a/nitronode/store/database/state.go
+++ b/nitronode/store/database/state.go
@@ -153,16 +153,22 @@ func (s *DBStore) StoreUserState(state core.State, applicationID string) error {
 	wallet := strings.ToLower(state.UserWallet)
 	balance := dbState.HomeUserBalance
 
-	err = s.db.Model(&UserBalance{}).
+	res := s.db.Model(&UserBalance{}).
 		Where("user_wallet = ? AND asset = ?", wallet, state.Asset).
 		Updates(map[string]interface{}{
 			"balance":            balance,
 			"home_blockchain_id": state.HomeLedger.BlockchainID,
 			"updated_at":         time.Now(),
-		}).Error
+		})
 
-	if err != nil {
-		return fmt.Errorf("failed to update user balance: %w", err)
+	if res.Error != nil {
+		return fmt.Errorf("failed to update user balance: %w", res.Error)
+	}
+	// The balance row must already exist (callers invoke LockUserState first, which
+	// inserts it). A zero-row update means the lock-before-store invariant was violated,
+	// so fail the transaction instead of leaving channel_states and user_balances divergent.
+	if res.RowsAffected != 1 {
+		return fmt.Errorf("failed to update user balance: expected 1 row affected, got %d (missing LockUserState?)", res.RowsAffected)
 	}
 
 	return nil

--- a/nitronode/store/database/state_test.go
+++ b/nitronode/store/database/state_test.go
@@ -14,6 +14,17 @@ func TestState_TableName(t *testing.T) {
 	assert.Equal(t, "channel_states", state.TableName())
 }
 
+// storeLocked mirrors the production invariant for tests: callers lock the user balance row
+// (which creates it if absent) before storing a state. StoreUserState requires the balance
+// row to exist, so tests that exercise it as a setup primitive must establish it the same way.
+func storeLocked(t *testing.T, store DatabaseStore, state core.State, applicationID string) error {
+	t.Helper()
+	if _, err := store.LockUserState(state.UserWallet, state.Asset); err != nil {
+		return err
+	}
+	return store.StoreUserState(state, applicationID)
+}
+
 func TestDBStore_StoreUserState_ApplicationID(t *testing.T) {
 	newState := func(id string) core.State {
 		homeChannelID := "0xhomechannel123"
@@ -46,7 +57,7 @@ func TestDBStore_StoreUserState_ApplicationID(t *testing.T) {
 		_, err := store.LockUserState("0xuserapp", "USDC")
 		require.NoError(t, err)
 
-		require.NoError(t, store.StoreUserState(newState("state-app"), "my-app"))
+		require.NoError(t, storeLocked(t, store, newState("state-app"), "my-app"))
 
 		var dbState State
 		require.NoError(t, db.Where("id = ?", "state-app").First(&dbState).Error)
@@ -62,7 +73,7 @@ func TestDBStore_StoreUserState_ApplicationID(t *testing.T) {
 		_, err := store.LockUserState("0xuserapp", "USDC")
 		require.NoError(t, err)
 
-		require.NoError(t, store.StoreUserState(newState("state-noapp"), ""))
+		require.NoError(t, storeLocked(t, store, newState("state-noapp"), ""))
 
 		var dbState State
 		require.NoError(t, db.Where("id = ?", "state-noapp").First(&dbState).Error)
@@ -103,7 +114,7 @@ func TestDBStore_StoreUserState(t *testing.T) {
 			NodeSig: &nodeSig,
 		}
 
-		err := store.StoreUserState(state, "")
+		err := storeLocked(t, store, state, "")
 		require.NoError(t, err)
 
 		// Verify state was stored
@@ -163,7 +174,7 @@ func TestDBStore_StoreUserState(t *testing.T) {
 			NodeSig: &nodeSig,
 		}
 
-		err := store.StoreUserState(state, "")
+		err := storeLocked(t, store, state, "")
 		require.NoError(t, err)
 
 		// Verify state was stored
@@ -200,12 +211,43 @@ func TestDBStore_StoreUserState(t *testing.T) {
 			},
 		}
 
-		err := store.StoreUserState(state, "")
+		err := storeLocked(t, store, state, "")
 		require.NoError(t, err)
 
 		// Try to store again with same ID
-		err = store.StoreUserState(state, "")
+		err = storeLocked(t, store, state, "")
 		assert.Error(t, err)
+	})
+
+	t.Run("Error - No locked balance row", func(t *testing.T) {
+		db, cleanup := SetupTestDB(t)
+		defer cleanup()
+
+		store := NewDBStore(db)
+
+		homeChannelID := "0xhomechannel123"
+		state := core.State{
+			ID:            "state-nolock",
+			Asset:         "USDC",
+			UserWallet:    "0xuser123",
+			Epoch:         1,
+			Version:       1,
+			HomeChannelID: &homeChannelID,
+			Transition:    core.Transition{},
+			HomeLedger: core.Ledger{
+				UserBalance: decimal.NewFromInt(1000),
+				UserNetFlow: decimal.Zero,
+				NodeBalance: decimal.Zero,
+				NodeNetFlow: decimal.Zero,
+			},
+		}
+
+		// No LockUserState first: the user_balances row does not exist, so the balance
+		// update matches zero rows and StoreUserState must error. Callers wrap this in a
+		// transaction, so the error rolls back the orphaned state row.
+		err := store.StoreUserState(state, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected 1 row affected")
 	})
 }
 
@@ -263,8 +305,8 @@ func TestDBStore_GetLastUserState(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, store.StoreUserState(state1, ""))
-		require.NoError(t, store.StoreUserState(state2, ""))
+		require.NoError(t, storeLocked(t, store, state1, ""))
+		require.NoError(t, storeLocked(t, store, state2, ""))
 
 		// Get last state
 		result, err := store.GetLastUserState("0xuser123", "USDC", false)
@@ -334,8 +376,8 @@ func TestDBStore_GetLastUserState(t *testing.T) {
 			NodeSig: &nodeSig,
 		}
 
-		require.NoError(t, store.StoreUserState(state1, ""))
-		require.NoError(t, store.StoreUserState(state2, ""))
+		require.NoError(t, storeLocked(t, store, state1, ""))
+		require.NoError(t, storeLocked(t, store, state2, ""))
 
 		// Get last signed state should return state2
 		result, err := store.GetLastUserState("0xuser123", "USDC", true)
@@ -411,8 +453,8 @@ func TestDBStore_GetLastUserState(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, store.StoreUserState(state1, ""))
-		require.NoError(t, store.StoreUserState(state2, ""))
+		require.NoError(t, storeLocked(t, store, state1, ""))
+		require.NoError(t, storeLocked(t, store, state2, ""))
 
 		// Get last state - should prioritize higher epoch
 		result, err := store.GetLastUserState("0xuser123", "USDC", false)
@@ -463,7 +505,7 @@ func TestDBStore_GetLastStateByChannelID(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, store.StoreUserState(state, ""))
+		require.NoError(t, storeLocked(t, store, state, ""))
 
 		result, err := store.GetLastStateByChannelID(homeChannelID, false)
 		require.NoError(t, err)
@@ -530,7 +572,7 @@ func TestDBStore_GetLastStateByChannelID(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, store.StoreUserState(state, ""))
+		require.NoError(t, storeLocked(t, store, state, ""))
 
 		result, err := store.GetLastStateByChannelID(escrowChannelID, false)
 		require.NoError(t, err)
@@ -601,8 +643,8 @@ func TestDBStore_GetLastStateByChannelID(t *testing.T) {
 			NodeSig: &nodeSig,
 		}
 
-		require.NoError(t, store.StoreUserState(state1, ""))
-		require.NoError(t, store.StoreUserState(state2, ""))
+		require.NoError(t, storeLocked(t, store, state1, ""))
+		require.NoError(t, storeLocked(t, store, state2, ""))
 
 		result, err := store.GetLastStateByChannelID(homeChannelID, true)
 		require.NoError(t, err)
@@ -679,8 +721,8 @@ func TestDBStore_GetStateByChannelIDAndVersion(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, store.StoreUserState(state1, ""))
-		require.NoError(t, store.StoreUserState(state2, ""))
+		require.NoError(t, storeLocked(t, store, state1, ""))
+		require.NoError(t, storeLocked(t, store, state2, ""))
 
 		// Get version 1
 		result, err := store.GetStateByChannelIDAndVersion(homeChannelID, 1)
@@ -757,7 +799,7 @@ func TestDBStore_GetStateByChannelIDAndVersion(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, store.StoreUserState(state, ""))
+		require.NoError(t, storeLocked(t, store, state, ""))
 
 		result, err := store.GetStateByChannelIDAndVersion(escrowChannelID, 5)
 		require.NoError(t, err)
@@ -806,7 +848,7 @@ func TestDBStore_GetStateByChannelIDAndVersion(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, store.StoreUserState(state, ""))
+		require.NoError(t, storeLocked(t, store, state, ""))
 
 		result, err := store.GetStateByChannelIDAndVersion(homeChannelID, 999)
 		require.NoError(t, err)

--- a/nitronode/store/database/state_test.go
+++ b/nitronode/store/database/state_test.go
@@ -54,8 +54,6 @@ func TestDBStore_StoreUserState_ApplicationID(t *testing.T) {
 		defer cleanup()
 
 		store := NewDBStore(db)
-		_, err := store.LockUserState("0xuserapp", "USDC")
-		require.NoError(t, err)
 
 		require.NoError(t, storeLocked(t, store, newState("state-app"), "my-app"))
 
@@ -70,8 +68,6 @@ func TestDBStore_StoreUserState_ApplicationID(t *testing.T) {
 		defer cleanup()
 
 		store := NewDBStore(db)
-		_, err := store.LockUserState("0xuserapp", "USDC")
-		require.NoError(t, err)
 
 		require.NoError(t, storeLocked(t, store, newState("state-noapp"), ""))
 

--- a/nitronode/store/database/test/postgres_integration_test.go
+++ b/nitronode/store/database/test/postgres_integration_test.go
@@ -16,6 +16,16 @@ import (
 	"gorm.io/gorm"
 )
 
+// storeLocked mirrors the production invariant: callers lock the user balance row (creating
+// it if absent) before storing a state. StoreUserState requires the balance row to exist.
+func storeLocked(t *testing.T, store database.DatabaseStore, state core.State, applicationID string) error {
+	t.Helper()
+	if _, err := store.LockUserState(state.UserWallet, state.Asset); err != nil {
+		return err
+	}
+	return store.StoreUserState(state, applicationID)
+}
+
 // PostgreSQL connection string should be provided via environment variable
 // Example: POSTGRES_DSN="host=localhost user=postgres password=postgres dbname=nitrolite_test port=5432 sslmode=disable"
 func getPostgresDB(t *testing.T) *gorm.DB {
@@ -113,7 +123,7 @@ func TestPostgres_StateOperations(t *testing.T) {
 			},
 		}
 
-		err := store.StoreUserState(state, "")
+		err := storeLocked(t, store, state, "")
 		require.NoError(t, err)
 
 		retrieved, err := store.GetLastUserState(wallet, asset, false)
@@ -169,9 +179,9 @@ func TestPostgres_StateOperations(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, store.StoreUserState(state1, ""))
-		require.NoError(t, store.StoreUserState(state2, ""))
-		require.NoError(t, store.StoreUserState(state3, ""))
+		require.NoError(t, storeLocked(t, store, state1, ""))
+		require.NoError(t, storeLocked(t, store, state2, ""))
+		require.NoError(t, storeLocked(t, store, state3, ""))
 
 		retrieved, err := store.GetLastUserState(wallet2, asset, false)
 		require.NoError(t, err)
@@ -446,8 +456,8 @@ func TestPostgres_UserBalances(t *testing.T) {
 		_, err = store.LockUserState(wallet, "ETH")
 		require.NoError(t, err)
 
-		require.NoError(t, store.StoreUserState(state1, ""))
-		require.NoError(t, store.StoreUserState(state2, ""))
+		require.NoError(t, storeLocked(t, store, state1, ""))
+		require.NoError(t, storeLocked(t, store, state2, ""))
 
 		balances, err := store.GetUserBalances(wallet)
 		require.NoError(t, err)
@@ -496,7 +506,7 @@ func TestPostgres_DecimalPrecision(t *testing.T) {
 			},
 		}
 
-		err := store.StoreUserState(state, "")
+		err := storeLocked(t, store, state, "")
 		require.NoError(t, err)
 
 		retrieved, err := store.GetLastUserState(wallet, "USDC", false)
@@ -524,7 +534,7 @@ func TestPostgres_DecimalPrecision(t *testing.T) {
 			},
 		}
 
-		err := store.StoreUserState(state, "")
+		err := storeLocked(t, store, state, "")
 		require.NoError(t, err)
 
 		retrieved, err := store.GetLastUserState(wallet, "ETH", false)


### PR DESCRIPTION
Remediates three audit findings in nitronode. All informational/defense-in-depth — no exploit in the current healthy flow; each hardens an implicit invariant to fail closed.

## MF3-I12 — channel session-key asset validation
`SubmitSessionKeyState` for channel session keys only length-checked `coreState.Assets`. Now, per asset, `validateSessionKeyAssets` rejects:
- **non-canonical** (`asset != strings.ToLower(asset)`) — assets are part of the user-signed metadata hash, so the node rejects rather than rewrites, keeping the signed payload identical to what is stored;
- **duplicates** (after normalization);
- **unsupported** (`GetAssetDecimals` errors).

An empty assets list is accepted only as a revocation/deactivation state: it is rejected when `expires_at` is in the future (it would leave an active current version authorizing no usable asset) and allowed only when `expires_at <= now`. All checks run before signature validation/storage.

## MF3-I13 — reject submit_state on a stateless active channel
`SubmitState`'s default branch silently bootstrapped a synthetic `Void` state when no stored state existed for an active home channel. An active channel always has its initial state stored atomically by `request_creation`, so a nil state is an invariant violation, not a first-submit. Now fails closed with `active channel has no stored state`. The `NewVoidState` fallback stays in the channel-creation path.

## MF3-I14 — assert user_balances update affects one row
`StoreUserState` checked only the GORM `Error` from the `user_balances` `Updates()` and ignored `RowsAffected`. A caller that stored a state without first calling `LockUserState` would silently match zero rows, leaving `channel_states` and the cached balance divergent without failing the transaction. Now requires exactly one affected row. Tests that used `StoreUserState` without locking are updated to lock-first via a `storeLocked` helper, plus a negative test for the new error.

All production call sites already lock-before-store / store-initial-state, so no behavior change in the healthy flow.
