### PR TITLE
MF3-H03: fix(nitronode): skip unsupported NodeBalanceUpdated tokens instead of fatal

### DIFF
--- a/nitronode/store/memory/memory_store.go
+++ b/nitronode/store/memory/memory_store.go
@@ -238,7 +238,7 @@ func (ms *MemoryStoreV1) GetTokenDecimals(blockchainID uint64, tokenAddress stri
 
 	decimalsOnChain, ok := ms.tokenDecimals[blockchainID]
 	if !ok {
-		return 0, fmt.Errorf("blockchain with ID '%d' is not supported", blockchainID)
+		return 0, fmt.Errorf("blockchain with ID '%d' has no configured tokens: %w", blockchainID, core.ErrTokenNotSupported)
 	}
 	decimals, ok := decimalsOnChain[tokenAddress]
 	if !ok {
@@ -253,7 +253,7 @@ func (ms *MemoryStoreV1) GetTokenAsset(blockchainID uint64, tokenAddress string)
 
 	assetsOnChain, ok := ms.tokenAssets[blockchainID]
 	if !ok {
-		return "", fmt.Errorf("blockchain with ID '%d' is not supported", blockchainID)
+		return "", fmt.Errorf("blockchain with ID '%d' has no configured tokens: %w", blockchainID, core.ErrTokenNotSupported)
 	}
 	asset, ok := assetsOnChain[tokenAddress]
 	if !ok {

--- a/nitronode/store/memory/memory_store.go
+++ b/nitronode/store/memory/memory_store.go
@@ -242,7 +242,7 @@ func (ms *MemoryStoreV1) GetTokenDecimals(blockchainID uint64, tokenAddress stri
 	}
 	decimals, ok := decimalsOnChain[tokenAddress]
 	if !ok {
-		return 0, fmt.Errorf("token %s is not supported on blockchain with ID '%d'", tokenAddress, blockchainID)
+		return 0, fmt.Errorf("token %s is not supported on blockchain with ID '%d': %w", tokenAddress, blockchainID, core.ErrTokenNotSupported)
 	}
 	return decimals, nil
 }
@@ -257,7 +257,7 @@ func (ms *MemoryStoreV1) GetTokenAsset(blockchainID uint64, tokenAddress string)
 	}
 	asset, ok := assetsOnChain[tokenAddress]
 	if !ok {
-		return "", fmt.Errorf("token %s is not supported on blockchain with ID '%d'", tokenAddress, blockchainID)
+		return "", fmt.Errorf("token %s is not supported on blockchain with ID '%d': %w", tokenAddress, blockchainID, core.ErrTokenNotSupported)
 	}
 	return asset.Symbol, nil
 }

--- a/nitronode/store/memory/memory_store_test.go
+++ b/nitronode/store/memory/memory_store_test.go
@@ -1,0 +1,76 @@
+package memory
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/layer-3/nitrolite/pkg/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testBlockchainID        uint64 = 137
+	testEnabledNoTokensID   uint64 = 480 // ChannelHub-enabled chain with no configured tokens
+	testTokenAddress               = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+	testUnknownTokenAddress        = "0x000000000000000000000000000000000000dead"
+)
+
+func newTestStore() *MemoryStoreV1 {
+	return &MemoryStoreV1{
+		tokenAssets: map[uint64]map[string]core.Asset{
+			testBlockchainID: {testTokenAddress: {Symbol: "usdc"}},
+		},
+		tokenDecimals: map[uint64]map[string]uint8{
+			testBlockchainID: {testTokenAddress: 6},
+		},
+	}
+}
+
+func TestMemoryStoreV1_GetTokenAsset(t *testing.T) {
+	ms := newTestStore()
+
+	t.Run("configured token returns asset", func(t *testing.T) {
+		asset, err := ms.GetTokenAsset(testBlockchainID, testTokenAddress)
+		require.NoError(t, err)
+		assert.Equal(t, "usdc", asset)
+	})
+
+	t.Run("unknown token on configured chain wraps ErrTokenNotSupported", func(t *testing.T) {
+		_, err := ms.GetTokenAsset(testBlockchainID, testUnknownTokenAddress)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, core.ErrTokenNotSupported))
+	})
+
+	// MF3-H03 regression: a ChannelHub-enabled chain with no configured tokens
+	// must also surface ErrTokenNotSupported so the reactor skips the event
+	// instead of stopping the listener.
+	t.Run("chain with no configured tokens wraps ErrTokenNotSupported", func(t *testing.T) {
+		_, err := ms.GetTokenAsset(testEnabledNoTokensID, testTokenAddress)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, core.ErrTokenNotSupported))
+	})
+}
+
+func TestMemoryStoreV1_GetTokenDecimals(t *testing.T) {
+	ms := newTestStore()
+
+	t.Run("configured token returns decimals", func(t *testing.T) {
+		decimals, err := ms.GetTokenDecimals(testBlockchainID, testTokenAddress)
+		require.NoError(t, err)
+		assert.Equal(t, uint8(6), decimals)
+	})
+
+	t.Run("unknown token on configured chain wraps ErrTokenNotSupported", func(t *testing.T) {
+		_, err := ms.GetTokenDecimals(testBlockchainID, testUnknownTokenAddress)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, core.ErrTokenNotSupported))
+	})
+
+	// MF3-H03 regression: see GetTokenAsset counterpart above.
+	t.Run("chain with no configured tokens wraps ErrTokenNotSupported", func(t *testing.T) {
+		_, err := ms.GetTokenDecimals(testEnabledNoTokensID, testTokenAddress)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, core.ErrTokenNotSupported))
+	})
+}

--- a/pkg/blockchain/evm/channel_hub_reactor.go
+++ b/pkg/blockchain/evm/channel_hub_reactor.go
@@ -260,13 +260,7 @@ func (r *ChannelHubReactor) handleNodeBalanceUpdated(ctx context.Context, store 
 
 	asset, err := r.assetStore.GetTokenAsset(r.blockchainID, event.Token.String())
 	if err != nil {
-		if errors.Is(err, core.ErrTokenNotSupported) {
-			// A NodeBalanceUpdated event for an unconfigured token is not fatal:
-			// anyone can deposit an arbitrary ERC20 via depositToNode(). Skip the
-			// balance update but let HandleEvent record the event so it is not replayed.
-			log.FromContext(ctx).Warn("skipping NodeBalanceUpdated for unsupported token",
-				"token", event.Token.String(), "blockchainID", r.blockchainID,
-				"blockNumber", l.BlockNumber, "txHash", l.TxHash.String(), "logIndex", l.Index)
+		if r.skipIfUnsupportedToken(ctx, err, event.Token, l) {
 			return nil
 		}
 		return errors.Wrap(err, "failed to get token asset")
@@ -274,10 +268,7 @@ func (r *ChannelHubReactor) handleNodeBalanceUpdated(ctx context.Context, store 
 
 	decimals, err := r.assetStore.GetTokenDecimals(r.blockchainID, event.Token.String())
 	if err != nil {
-		if errors.Is(err, core.ErrTokenNotSupported) {
-			log.FromContext(ctx).Warn("skipping NodeBalanceUpdated for unsupported token",
-				"token", event.Token.String(), "blockchainID", r.blockchainID,
-				"blockNumber", l.BlockNumber, "txHash", l.TxHash.String(), "logIndex", l.Index)
+		if r.skipIfUnsupportedToken(ctx, err, event.Token, l) {
 			return nil
 		}
 		return errors.Wrap(err, "failed to get token decimals")
@@ -291,6 +282,26 @@ func (r *ChannelHubReactor) handleNodeBalanceUpdated(ctx context.Context, store 
 		Balance:      balance,
 	}
 	return r.eventHandler.HandleNodeBalanceUpdated(ctx, store, &ev)
+}
+
+// skipIfUnsupportedToken reports whether a NodeBalanceUpdated lookup error is an
+// unsupported-token error that should be skipped rather than treated as fatal.
+// Anyone can deposit an arbitrary ERC20 via depositToNode(), so an event for an
+// unconfigured token (or a chain with no configured tokens) must not stop the
+// listener. The caller returns nil so HandleEvent records the event and it is
+// not replayed.
+//
+// Note: this is a dedup record, not a replay queue. Once an event is recorded as
+// skipped, the balance change is NOT re-applied if the operator later configures
+// that token — a legitimate new asset requires a manual resync.
+func (r *ChannelHubReactor) skipIfUnsupportedToken(ctx context.Context, err error, token common.Address, l types.Log) bool {
+	if !errors.Is(err, core.ErrTokenNotSupported) {
+		return false
+	}
+	log.FromContext(ctx).Warn("skipping NodeBalanceUpdated for unsupported token",
+		"token", token.String(), "blockchainID", r.blockchainID,
+		"blockNumber", l.BlockNumber, "txHash", l.TxHash.String(), "logIndex", l.Index)
+	return true
 }
 
 func (r *ChannelHubReactor) handleHomeChannelCreated(ctx context.Context, store ChannelHubReactorStore, l types.Log) error {

--- a/pkg/blockchain/evm/channel_hub_reactor.go
+++ b/pkg/blockchain/evm/channel_hub_reactor.go
@@ -260,11 +260,26 @@ func (r *ChannelHubReactor) handleNodeBalanceUpdated(ctx context.Context, store 
 
 	asset, err := r.assetStore.GetTokenAsset(r.blockchainID, event.Token.String())
 	if err != nil {
+		if errors.Is(err, core.ErrTokenNotSupported) {
+			// A NodeBalanceUpdated event for an unconfigured token is not fatal:
+			// anyone can deposit an arbitrary ERC20 via depositToNode(). Skip the
+			// balance update but let HandleEvent record the event so it is not replayed.
+			log.FromContext(ctx).Warn("skipping NodeBalanceUpdated for unsupported token",
+				"token", event.Token.String(), "blockchainID", r.blockchainID,
+				"blockNumber", l.BlockNumber, "txHash", l.TxHash.String(), "logIndex", l.Index)
+			return nil
+		}
 		return errors.Wrap(err, "failed to get token asset")
 	}
 
 	decimals, err := r.assetStore.GetTokenDecimals(r.blockchainID, event.Token.String())
 	if err != nil {
+		if errors.Is(err, core.ErrTokenNotSupported) {
+			log.FromContext(ctx).Warn("skipping NodeBalanceUpdated for unsupported token",
+				"token", event.Token.String(), "blockchainID", r.blockchainID,
+				"blockNumber", l.BlockNumber, "txHash", l.TxHash.String(), "logIndex", l.Index)
+			return nil
+		}
 		return errors.Wrap(err, "failed to get token decimals")
 	}
 

--- a/pkg/blockchain/evm/channel_hub_reactor_test.go
+++ b/pkg/blockchain/evm/channel_hub_reactor_test.go
@@ -347,6 +347,34 @@ func TestChannelHubReactor_HandleNodeBalanceUpdated(t *testing.T) {
 		handler.AssertNotCalled(t, "HandleNodeBalanceUpdated", mock.Anything, mock.Anything, mock.Anything)
 		store.AssertExpectations(t)
 	})
+
+	// Mirror of the case above, but the unsupported-token error surfaces from the
+	// second lookup (GetTokenDecimals) rather than the first. Both guards must
+	// behave identically (MF3-H03), so cover them independently.
+	t.Run("unsupported token from decimals lookup is skipped and recorded", func(t *testing.T) {
+		store := new(mockChannelHubStore)
+		handler := new(mockChannelHubEventHandler)
+		assetStore := new(MockAssetStore)
+
+		assetStore.On("GetTokenAsset", blockchainID, tokenAddr.String()).Return("usdc", nil)
+		assetStore.On("GetTokenDecimals", blockchainID, tokenAddr.String()).
+			Return(uint8(0), fmt.Errorf("token %s is not supported: %w", tokenAddr.String(), core.ErrTokenNotSupported))
+
+		expectStoreContractEvent(store, "NodeBalanceUpdated", 200, blockchainID)
+
+		reactor := newReactor(blockchainID, nodeAddr.String(), handler, assetStore, store)
+
+		var processedSuccess bool
+		reactor.SetOnEventProcessed(func(_ uint64, success bool) {
+			processedSuccess = success
+		})
+
+		err := reactor.HandleEvent(context.Background(), logEntry)
+		require.NoError(t, err)
+		assert.True(t, processedSuccess)
+		handler.AssertNotCalled(t, "HandleNodeBalanceUpdated", mock.Anything, mock.Anything, mock.Anything)
+		store.AssertExpectations(t)
+	})
 }
 
 func TestChannelHubReactor_HandleHomeChannelCreated(t *testing.T) {

--- a/pkg/blockchain/evm/channel_hub_reactor_test.go
+++ b/pkg/blockchain/evm/channel_hub_reactor_test.go
@@ -2,6 +2,7 @@ package evm
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -316,6 +317,35 @@ func TestChannelHubReactor_HandleNodeBalanceUpdated(t *testing.T) {
 		err := reactor.HandleEvent(context.Background(), logEntry)
 		require.Error(t, err)
 		assert.False(t, processedSuccess)
+	})
+
+	t.Run("unsupported token is skipped and recorded", func(t *testing.T) {
+		store := new(mockChannelHubStore)
+		handler := new(mockChannelHubEventHandler)
+		assetStore := new(MockAssetStore)
+
+		// Unconfigured token: anyone can deposit an arbitrary ERC20 via
+		// depositToNode(). The event must not be fatal and must be recorded so
+		// it is not replayed on restart (MF3-H03).
+		assetStore.On("GetTokenAsset", blockchainID, tokenAddr.String()).
+			Return("", fmt.Errorf("token %s is not supported: %w", tokenAddr.String(), core.ErrTokenNotSupported))
+
+		// StoreContractEvent must still be called so the event is not replayed.
+		expectStoreContractEvent(store, "NodeBalanceUpdated", 200, blockchainID)
+
+		reactor := newReactor(blockchainID, nodeAddr.String(), handler, assetStore, store)
+
+		var processedSuccess bool
+		reactor.SetOnEventProcessed(func(_ uint64, success bool) {
+			processedSuccess = success
+		})
+
+		err := reactor.HandleEvent(context.Background(), logEntry)
+		require.NoError(t, err)
+		assert.True(t, processedSuccess)
+		// Balance update must not be applied for an unsupported token.
+		handler.AssertNotCalled(t, "HandleNodeBalanceUpdated", mock.Anything, mock.Anything, mock.Anything)
+		store.AssertExpectations(t)
 	})
 }
 

--- a/pkg/core/errors.go
+++ b/pkg/core/errors.go
@@ -1,0 +1,8 @@
+package core
+
+import "errors"
+
+// ErrTokenNotSupported indicates a token address is not configured in the node
+// asset store for the given blockchain. Callers can use errors.Is to distinguish
+// this deterministic "not configured" condition from genuine store failures.
+var ErrTokenNotSupported = errors.New("token not supported")


### PR DESCRIPTION
## Finding (MF3-H03)

`ChannelHubReactor.HandleEvent()` treated any handler error as fatal: it returned before `StoreContractEvent()`, so `Listener.processEvents()` unsubscribed and `main()` exited via `logger.Fatal()`.

`depositToNode()` accepts any ERC20 and emits `NodeBalanceUpdated`. `handleNodeBalanceUpdated()` required the token to be configured in the node asset store, so depositing an unconfigured ERC20 was a permissionless, low-cost way to stop nitronode event processing. Since the failing event was never recorded, it replayed on restart — recovery needed manual intervention or a config/code change.

## Fix

- New `core.ErrTokenNotSupported` sentinel, returned (wrapped) by the memory asset store's `GetTokenAsset`/`GetTokenDecimals` when a token is not configured.
- `handleNodeBalanceUpdated()` checks `errors.Is(err, core.ErrTokenNotSupported)`, logs a warning, skips the balance update, and returns `nil`. `HandleEvent()` then records the event via `StoreContractEvent()`, so it is not replayed, the listener stays subscribed, and the process does not die.
- Genuine store errors still propagate — only the deterministic "not configured" case is skipped (typed error, not a catch-all).

Out of scope (per finding's optional suggestion): broader listener-level error classification so handler failures don't all collapse to `logger.Fatal`. Can follow up separately.

## Tests

- New subtest `unsupported token is skipped and recorded`: asserts `HandleEvent` returns nil, `StoreContractEvent` is called, the balance handler is NOT called, and the processed callback reports success.
- `go test ./pkg/blockchain/evm/... ./nitronode/store/memory/...` and `go vet` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)