### PR TITLE
MF3-L16: fix(rpc): escape error message in NewErrorPayload

### DIFF
--- a/pkg/rpc/error.go
+++ b/pkg/rpc/error.go
@@ -122,5 +122,13 @@ func (e Error) Error() string {
 //
 // The resulting Params will contain: {"error": "invalid address format"}
 func NewErrorPayload(errMsg string) Payload {
-	return Payload{errorParamKey: json.RawMessage(fmt.Sprintf(`"%s"`, errMsg))}
+	// json.Marshal escapes quotes, backslashes, and control characters so the
+	// resulting RawMessage is always valid JSON. Building the string by hand
+	// would corrupt the payload whenever errMsg contains JSON-special chars.
+	encoded, err := json.Marshal(errMsg)
+	if err != nil {
+		// Marshaling a Go string cannot fail; fall back to an empty JSON string.
+		encoded = json.RawMessage(`""`)
+	}
+	return Payload{errorParamKey: encoded}
 }

--- a/pkg/rpc/error_test.go
+++ b/pkg/rpc/error_test.go
@@ -1,0 +1,40 @@
+package rpc
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestNewErrorPayload(t *testing.T) {
+	cases := map[string]string{
+		"plain":          "invalid address format",
+		"embedded quote": `duplicate key value violates unique constraint "app_sessions_v1_pkey"`,
+		"backslash":      `path\to\thing`,
+		"newline":        "line1\nline2",
+		"control char":   "tab\there",
+		"leading quote":  `"quoted"`,
+		"empty":          "",
+	}
+
+	for name, msg := range cases {
+		t.Run(name, func(t *testing.T) {
+			payload := NewErrorPayload(msg)
+
+			// The stored value must be valid JSON that round-trips to the
+			// original string.
+			var got string
+			if err := json.Unmarshal(payload[errorParamKey], &got); err != nil {
+				t.Fatalf("stored value is not valid JSON: %v", err)
+			}
+			if got != msg {
+				t.Fatalf("round-trip mismatch: got %q, want %q", got, msg)
+			}
+
+			// The whole payload must marshal without error. This is the
+			// regression guard for the websocket-response marshal failure.
+			if _, err := json.Marshal(payload); err != nil {
+				t.Fatalf("payload failed to marshal: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## MF3-L16

### Problem
`NewErrorPayload()` built the error field by wrapping `errMsg` with `fmt.Sprintf(`"%s"`, errMsg)` and storing it as `json.RawMessage`. Since `json.RawMessage` is treated as already-encoded JSON, embedded quotes or other JSON-special characters in `errMsg` were not escaped during the later websocket response marshal.

A client-facing `rpc.Error` containing quotes — e.g. a duplicate-key error mentioning `"app_sessions_v1_pkey"` — produced invalid raw JSON. The websocket node then failed to marshal `ctx.Response` and returned the generic node error instead of the intended application-level error response.

### Fix
Encode `errMsg` with `json.Marshal()` in `NewErrorPayload()` and store the returned bytes. The standard encoder escapes quotes, backslashes, and control characters before the value is embedded in the final response. A defensive fallback to `""` is kept (marshaling a Go string cannot fail in practice).

### Tests
Added `pkg/rpc/error_test.go` covering embedded quotes, backslashes, newlines, control chars, leading quotes, and empty input. Each case asserts the stored value round-trips to the original string and that the whole payload marshals without error (regression guard for the websocket-marshal failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)