### PR TITLE
MF3-L18: fix(nitronode): lock transfer balances in deterministic order

### DIFF
--- a/nitronode/api/channel_v1/handler.go
+++ b/nitronode/api/channel_v1/handler.go
@@ -97,22 +97,16 @@ func (h *Handler) lockTransferBalances(tx Store, senderState core.State) (string
 // It reads the receiver's current state, applies a transfer_receive transition with the same
 // amount and tx hash, signs it with the node's key, and persists it.
 //
-// The receiver's (wallet, asset) balance row MUST already be locked by the caller
-// (via lockTransferBalances) before this is invoked — it does not take the lock itself.
-func (h *Handler) issueTransferReceiverState(ctx context.Context, tx Store, senderState core.State, applicationID string) (*core.State, error) {
+// receiverWallet must be the normalized receiver address returned by
+// lockTransferBalances, which the caller MUST invoke first — that call also
+// locks the receiver's (wallet, asset) row and rejects self-transfers, so this
+// function does neither itself.
+func (h *Handler) issueTransferReceiverState(ctx context.Context, tx Store, senderState core.State, receiverWallet, applicationID string) (*core.State, error) {
 	logger := log.FromContext(ctx)
 
 	incomingTransition := senderState.Transition
 	if incomingTransition.Type != core.TransitionTypeTransferSend {
 		return nil, rpc.Errorf("incoming state doesn't have 'transfer_send' transition")
-	}
-	receiverWallet, err := core.NormalizeHexAddress(incomingTransition.AccountID)
-	if err != nil {
-		return nil, rpc.Errorf("invalid receiver wallet address: %v", err)
-	}
-
-	if strings.EqualFold(senderState.UserWallet, receiverWallet) {
-		return nil, rpc.Errorf("sender and receiver wallets are the same")
 	}
 
 	logger = logger.

--- a/nitronode/api/channel_v1/handler.go
+++ b/nitronode/api/channel_v1/handler.go
@@ -59,9 +59,46 @@ func (h *Handler) getChannelSigValidator(tx Store, asset string) *core.ChannelSi
 	})
 }
 
+// lockTransferBalances normalizes the receiver address, rejects self-transfers,
+// and locks the sender's and receiver's (wallet, asset) balance rows in a
+// deterministic order (ascending lowercase wallet) to avoid database deadlocks
+// when two opposite-direction transfers run concurrently. It returns the
+// normalized receiver wallet.
+//
+// Callers MUST call this before issueTransferReceiverState for a TransferSend
+// transition — issueTransferReceiverState assumes the receiver row is already
+// locked and does not take the lock itself.
+func (h *Handler) lockTransferBalances(tx Store, senderState core.State) (string, error) {
+	receiverWallet, err := core.NormalizeHexAddress(senderState.Transition.AccountID)
+	if err != nil {
+		return "", rpc.Errorf("invalid receiver wallet address: %v", err)
+	}
+	if strings.EqualFold(senderState.UserWallet, receiverWallet) {
+		return "", rpc.Errorf("sender and receiver wallets are the same")
+	}
+
+	// Lock both rows in ascending lowercase-wallet order so concurrent
+	// opposite-direction transfers acquire the same locks in the same sequence.
+	// LockUserState lowercases internally, so the sort key matches the lock key.
+	first, second := senderState.UserWallet, receiverWallet
+	if strings.ToLower(first) > strings.ToLower(second) {
+		first, second = second, first
+	}
+	if _, err := tx.LockUserState(first, senderState.Asset); err != nil {
+		return "", rpc.Errorf("failed to lock user state: %v", err)
+	}
+	if _, err := tx.LockUserState(second, senderState.Asset); err != nil {
+		return "", rpc.Errorf("failed to lock user state: %v", err)
+	}
+	return receiverWallet, nil
+}
+
 // issueTransferReceiverState creates and stores a new state for the receiver of a transfer.
 // It reads the receiver's current state, applies a transfer_receive transition with the same
 // amount and tx hash, signs it with the node's key, and persists it.
+//
+// The receiver's (wallet, asset) balance row MUST already be locked by the caller
+// (via lockTransferBalances) before this is invoked — it does not take the lock itself.
 func (h *Handler) issueTransferReceiverState(ctx context.Context, tx Store, senderState core.State, applicationID string) (*core.State, error) {
 	logger := log.FromContext(ctx)
 
@@ -84,11 +121,6 @@ func (h *Handler) issueTransferReceiverState(ctx context.Context, tx Store, send
 		WithKV("asset", senderState.Asset)
 
 	logger.Debug("issuing transfer receiver state")
-
-	// Lock the receiver's state to prevent concurrent modifications
-	if _, err := tx.LockUserState(receiverWallet, senderState.Asset); err != nil {
-		return nil, rpc.Errorf("failed to lock receiver state: %v", err)
-	}
 
 	currentState, err := tx.GetLastUserState(receiverWallet, senderState.Asset, false)
 	if err != nil {

--- a/nitronode/api/channel_v1/lock_transfer_balances_test.go
+++ b/nitronode/api/channel_v1/lock_transfer_balances_test.go
@@ -1,0 +1,89 @@
+package channel_v1
+
+import (
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/layer-3/nitrolite/pkg/core"
+)
+
+// lockOrder returns the wallet arguments of every LockUserState call recorded on
+// the mock, in invocation order.
+func lockOrder(m *MockStore) []string {
+	var order []string
+	for _, call := range m.Calls {
+		if call.Method == "LockUserState" {
+			order = append(order, call.Arguments.String(0))
+		}
+	}
+	return order
+}
+
+func transferSenderState(sender, receiver, asset string) core.State {
+	return core.State{
+		UserWallet: sender,
+		Asset:      asset,
+		Transition: core.Transition{
+			Type:      core.TransitionTypeTransferSend,
+			AccountID: receiver,
+		},
+	}
+}
+
+// MF3-L18: both balance rows must be locked in a deterministic order (ascending
+// lowercase wallet) regardless of transfer direction, so two opposite-direction
+// transfers can't acquire row locks in opposite order and deadlock.
+func TestLockTransferBalances_DeterministicOrder(t *testing.T) {
+	const (
+		asset = "USDC"
+		low   = "0x1111111111111111111111111111111111111111"
+		high  = "0x2222222222222222222222222222222222222222"
+	)
+
+	t.Run("sender lower than receiver", func(t *testing.T) {
+		h := &Handler{}
+		tx := new(MockStore)
+		tx.On("LockUserState", mock.Anything, asset).Return(decimal.Zero, nil)
+
+		receiver, err := h.lockTransferBalances(tx, transferSenderState(low, high, asset))
+		require.NoError(t, err)
+		require.Equal(t, high, receiver)
+		require.Equal(t, []string{low, high}, lockOrder(tx))
+	})
+
+	t.Run("sender higher than receiver", func(t *testing.T) {
+		h := &Handler{}
+		tx := new(MockStore)
+		tx.On("LockUserState", mock.Anything, asset).Return(decimal.Zero, nil)
+
+		// Direction flipped: sender is the lexicographically larger wallet, but the
+		// locks must still be taken low-then-high — same sequence as the case above.
+		receiver, err := h.lockTransferBalances(tx, transferSenderState(high, low, asset))
+		require.NoError(t, err)
+		require.Equal(t, low, receiver)
+		require.Equal(t, []string{low, high}, lockOrder(tx))
+	})
+}
+
+func TestLockTransferBalances_RejectsSelfTransfer(t *testing.T) {
+	const wallet = "0x1111111111111111111111111111111111111111"
+	h := &Handler{}
+	tx := new(MockStore)
+
+	// Mixed case must still be caught as a self-transfer before any lock is taken.
+	_, err := h.lockTransferBalances(tx, transferSenderState(wallet, "0x1111111111111111111111111111111111111111", "USDC"))
+	require.Error(t, err)
+	require.Empty(t, lockOrder(tx), "no row should be locked for a self-transfer")
+}
+
+func TestLockTransferBalances_RejectsInvalidReceiver(t *testing.T) {
+	h := &Handler{}
+	tx := new(MockStore)
+
+	_, err := h.lockTransferBalances(tx, transferSenderState("0x1111111111111111111111111111111111111111", "not-an-address", "USDC"))
+	require.Error(t, err)
+	require.Empty(t, lockOrder(tx), "no row should be locked when the receiver address is invalid")
+}

--- a/nitronode/api/channel_v1/request_creation.go
+++ b/nitronode/api/channel_v1/request_creation.go
@@ -83,9 +83,16 @@ func (h *Handler) RequestCreation(c *rpc.Context) {
 
 	var nodeSig string
 	err = h.useStoreInTx(func(tx Store) error {
-		_, err := tx.LockUserState(incomingState.UserWallet, incomingState.Asset)
-		if err != nil {
-			return rpc.Errorf("failed to lock user state: %v", err)
+		if incomingState.Transition.Type == core.TransitionTypeTransferSend {
+			// Lock both sender and receiver balance rows up front in deterministic
+			// order so concurrent opposite-direction transfers can't deadlock.
+			if _, err := h.lockTransferBalances(tx, incomingState); err != nil {
+				return err
+			}
+		} else {
+			if _, err := tx.LockUserState(incomingState.UserWallet, incomingState.Asset); err != nil {
+				return rpc.Errorf("failed to lock user state: %v", err)
+			}
 		}
 
 		// Reject if any home channel for this (wallet, asset) is not fully closed on-chain.

--- a/nitronode/api/channel_v1/request_creation.go
+++ b/nitronode/api/channel_v1/request_creation.go
@@ -82,11 +82,13 @@ func (h *Handler) RequestCreation(c *rpc.Context) {
 	applicationID := rpc.GetApplicationID(c)
 
 	var nodeSig string
+	var receiverWallet string
 	err = h.useStoreInTx(func(tx Store) error {
 		if incomingState.Transition.Type == core.TransitionTypeTransferSend {
 			// Lock both sender and receiver balance rows up front in deterministic
 			// order so concurrent opposite-direction transfers can't deadlock.
-			if _, err := h.lockTransferBalances(tx, incomingState); err != nil {
+			receiverWallet, err = h.lockTransferBalances(tx, incomingState)
+			if err != nil {
 				return err
 			}
 		} else {
@@ -233,7 +235,7 @@ func (h *Handler) RequestCreation(c *rpc.Context) {
 
 				// We return Node's signature, the user is expected to submit this on blockchain.
 			case core.TransitionTypeTransferSend:
-				newReceiverState, err := h.issueTransferReceiverState(ctx, tx, incomingState, applicationID)
+				newReceiverState, err := h.issueTransferReceiverState(ctx, tx, incomingState, receiverWallet, applicationID)
 				if err != nil {
 					return rpc.Errorf("failed to issue receiver state: %v", err)
 				}

--- a/nitronode/api/channel_v1/submit_state.go
+++ b/nitronode/api/channel_v1/submit_state.go
@@ -38,11 +38,13 @@ func (h *Handler) SubmitState(c *rpc.Context) {
 
 	var nodeSig string
 	incomingTransition := incomingState.Transition
+	var receiverWallet string
 	err = h.useStoreInTx(func(tx Store) error {
 		if incomingTransition.Type == core.TransitionTypeTransferSend {
 			// Lock both sender and receiver balance rows up front in deterministic
 			// order so concurrent opposite-direction transfers can't deadlock.
-			if _, err := h.lockTransferBalances(tx, incomingState); err != nil {
+			receiverWallet, err = h.lockTransferBalances(tx, incomingState)
+			if err != nil {
 				return err
 			}
 		} else {
@@ -169,7 +171,7 @@ func (h *Handler) SubmitState(c *rpc.Context) {
 				}
 
 			case core.TransitionTypeTransferSend:
-				newReceiverState, err := h.issueTransferReceiverState(ctx, tx, incomingState, applicationID)
+				newReceiverState, err := h.issueTransferReceiverState(ctx, tx, incomingState, receiverWallet, applicationID)
 				if err != nil {
 					return rpc.Errorf("failed to issue receiver state: %v", err)
 				}

--- a/nitronode/api/channel_v1/submit_state.go
+++ b/nitronode/api/channel_v1/submit_state.go
@@ -39,9 +39,16 @@ func (h *Handler) SubmitState(c *rpc.Context) {
 	var nodeSig string
 	incomingTransition := incomingState.Transition
 	err = h.useStoreInTx(func(tx Store) error {
-		_, err := tx.LockUserState(incomingState.UserWallet, incomingState.Asset)
-		if err != nil {
-			return rpc.Errorf("failed to lock user state: %v", err)
+		if incomingTransition.Type == core.TransitionTypeTransferSend {
+			// Lock both sender and receiver balance rows up front in deterministic
+			// order so concurrent opposite-direction transfers can't deadlock.
+			if _, err := h.lockTransferBalances(tx, incomingState); err != nil {
+				return err
+			}
+		} else {
+			if _, err := tx.LockUserState(incomingState.UserWallet, incomingState.Asset); err != nil {
+				return rpc.Errorf("failed to lock user state: %v", err)
+			}
 		}
 
 		approvedSigValidators, channelStatus, err := tx.CheckActiveChannel(incomingState.UserWallet, incomingState.Asset)

--- a/nitronode/api/channel_v1/submit_state_test.go
+++ b/nitronode/api/channel_v1/submit_state_test.go
@@ -569,18 +569,17 @@ func TestSubmitState_TransferSend_SameWalletCaseInsensitive_Rejected(t *testing.
 	userSigStr := userSig.String()
 	incomingSenderState.UserSig = &userSigStr
 
-	// Mock expectations — should reach the issueTransferReceiverState check
-	mockAssetStore.On("GetAssetDecimals", asset).Return(uint8(6), nil)
-	mockTxStore.On("LockUserState", senderWallet, asset).Return(decimal.Zero, nil)
-	mockTxStore.On("CheckActiveChannel", senderWallet, asset).Return("0x03", core.ChannelStatusOpen, nil)
-	mockTxStore.On("GetLastUserState", senderWallet, asset, false).Return(currentSenderState, nil)
-	mockTxStore.On("EnsureNoOngoingStateTransitions", senderWallet, asset).Return(nil)
+	// Mock expectations. The self-transfer check now runs inside lockTransferBalances,
+	// before any balance row is locked or any state is stored, so none of the store
+	// methods below should be reached. Marked Maybe() to document that they are
+	// deliberately not expected.
+	mockAssetStore.On("GetAssetDecimals", asset).Return(uint8(6), nil).Maybe()
+	mockTxStore.On("LockUserState", mock.Anything, asset).Return(decimal.Zero, nil).Maybe()
+	mockTxStore.On("CheckActiveChannel", senderWallet, asset).Return("0x03", core.ChannelStatusOpen, nil).Maybe()
+	mockTxStore.On("GetLastUserState", senderWallet, asset, false).Return(currentSenderState, nil).Maybe()
+	mockTxStore.On("EnsureNoOngoingStateTransitions", senderWallet, asset).Return(nil).Maybe()
 	mockStatePacker.On("PackState", mock.Anything).Return(packedSenderState, nil).Maybe()
-
-	// Sender state is stored before the transition-specific logic
-	mockTxStore.On("StoreUserState", mock.MatchedBy(func(state core.State) bool {
-		return state.UserWallet == senderWallet && state.NodeSig != nil
-	}), mock.Anything).Return(nil)
+	mockTxStore.On("StoreUserState", mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	rpcState := toRPCState(*incomingSenderState)
 	reqPayload := rpc.ChannelsV1SubmitStateRequest{


### PR DESCRIPTION
## What

Fixes the MF3-L18 audit finding: balance-lock acquisition for `transfer_send` transitions happened in request-dependent order, so two opposite-direction transfers of the same asset could deadlock at the database layer.

`SubmitState` and `RequestCreation` locked the sender's `user_balances` row first, then `issueTransferReceiverState` locked the receiver's row later in the same tx. Concurrent A→B and B→A transfers could lock A-then-wait-B and B-then-wait-A — a cycle that Postgres breaks with `SQLSTATE 40P01`, aborting a valid transfer instead of resolving it deterministically. No balance corruption (the tx rolls back), but it's a liveness/UX problem under load.

## Change

- New `lockTransferBalances` helper: normalizes the receiver address, rejects self-transfers, and locks both `(wallet, asset)` rows in ascending lowercase-wallet order **up front** for any `TransferSend` transition. Same sequence regardless of direction → no lock cycle.
- Both handlers branch: `TransferSend` → `lockTransferBalances`; every other transition keeps the existing sender-only lock.
- `issueTransferReceiverState` no longer takes the receiver lock — it now documents that the caller must pre-lock the receiver row.

Mirrors the deterministic-ordering pattern already used in `app_session_v1` (sorted participants before locking).

### Side effect (improvement)

Self-transfer and invalid-receiver are now rejected *before* the sender lock and state store, rather than after. Less wasted work; behavior otherwise unchanged.

## Scope

Cross-subsystem ordering (channel transfers vs `app_session_v1` release locks) is a separate concern and intentionally out of scope here — different assets/rows.

## Tests

- New `lock_transfer_balances_test.go`: asserts both directions lock low→high, and that self-transfer / invalid-receiver take zero locks.
- Updated the self-transfer case in `submit_state_test.go` to reflect the earlier rejection point.
- `go build ./nitronode/...`, `go vet`, full `channel_v1` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)