### PR TITLE
release: v1.4.0 → main

### DIFF
--- a/faucet-app/chart/Chart.yaml
+++ b/faucet-app/chart/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v2
 description: Faucet App Helm chart
 name: faucet-app
 version: 1.0.0
-appVersion: "1.3.0"
+appVersion: "1.4.0"

--- a/nitronode/chart/Chart.yaml
+++ b/nitronode/chart/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v2
 description: Nitronode Helm chart
 name: nitronode
 version: 1.0.0
-appVersion: "1.3.0"
+appVersion: "1.4.0"

--- a/playground/chart/Chart.yaml
+++ b/playground/chart/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v2
 description: Nitrolite Playground Helm chart
 name: playground
 version: 1.0.0
-appVersion: "1.3.0"
+appVersion: "1.4.0"

--- a/sdk/mcp/package-lock.json
+++ b/sdk/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yellow-org/sdk-mcp",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yellow-org/sdk-mcp",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/sdk/mcp/package.json
+++ b/sdk/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yellow-org/sdk-mcp",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Unified MCP server for Yellow SDK and Nitrolite protocol context for AI agents and IDEs",
   "type": "module",
   "mcpName": "io.github.layer-3/yellow-sdk-mcp",

--- a/sdk/mcp/server.json
+++ b/sdk/mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.layer-3/yellow-sdk-mcp",
   "description": "MCP server exposing Yellow SDK and Nitrolite protocol reference material to AI agents and IDEs.",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "repository": {
     "url": "https://github.com/layer-3/nitrolite",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "@yellow-org/sdk-mcp",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "transport": {
         "type": "stdio"
       }

--- a/sdk/ts-compat/package-lock.json
+++ b/sdk/ts-compat/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@yellow-org/sdk-compat",
-    "version": "1.3.1",
+    "version": "1.4.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@yellow-org/sdk-compat",
-            "version": "1.3.1",
+            "version": "1.4.0",
             "license": "MIT",
             "dependencies": {
                 "decimal.js": "^10.4.3"
@@ -34,7 +34,7 @@
         },
         "../ts": {
             "name": "@yellow-org/sdk",
-            "version": "1.3.1",
+            "version": "1.4.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -59,7 +59,7 @@
                 "ethers": "6.16.0",
                 "glob": "^13.0.3",
                 "jest": "^30.2.0",
-                "prettier": "3.8.3",
+                "prettier": "3.8.4",
                 "rimraf": "^6.1.3",
                 "ts-jest": "^29.1.2",
                 "ts-node": "^10.9.2",

--- a/sdk/ts-compat/package.json
+++ b/sdk/ts-compat/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@yellow-org/sdk-compat",
-    "version": "1.3.1",
+    "version": "1.4.0",
     "description": "Curated migration layer preserving selected Nitrolite SDK v0.5.3 app-facing APIs over the v1 runtime.",
     "type": "module",
     "sideEffects": false,

--- a/sdk/ts/package-lock.json
+++ b/sdk/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@yellow-org/sdk",
-    "version": "1.3.1",
+    "version": "1.4.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@yellow-org/sdk",
-            "version": "1.3.1",
+            "version": "1.4.0",
             "license": "MIT",
             "dependencies": {
                 "abitype": "^1.2.3",

--- a/sdk/ts/package.json
+++ b/sdk/ts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@yellow-org/sdk",
-    "version": "1.3.1",
+    "version": "1.4.0",
     "description": "The Yellow SDK empowers developers to build high-performance, scalable web3 applications using state channels. It's designed to provide near-instant transactions and significantly improved user experiences by minimizing direct blockchain interactions.",
     "type": "module",
     "main": "dist/index.js",


### PR DESCRIPTION
## Release v1.4.0

### Highlights
- **Audit remediation — MF3 final round (#846):** security hardening across contracts, nitronode, SDK, and RPC.
  - Contract: reentrancy guard + event-handler monotonicity, reorg double-spend confirmation gate.
  - **Breaking:** removed app registry, action allowances, user staking, and rebalance feature; removed SDK locking client + app-registry ABI; RPC surface (`docs/api.yaml`) trimmed.
  - DoS/overflow fixes: pagination limit=0, uint8 quorum overflow, frame-layer rate limit, deposit-state enforcement.
- feat(nitronode): add USDC asset across 7 chains (#845)
- fix(go-sdk): preserve channel challenge expiry (#816)
- Fix SDK MCP Hono audit failure (#821)
- Dependency bumps (gomod, npm, ws).

### Versioning note
Minor bump (1.3.1 → 1.4.0). Note: removal of app-registry/staking/rebalance + RPC methods is a breaking change for downstream consumers — flagged here rather than a major bump per 1.x cadence.

### MCP
`mcp-v1.4.0` tag intentionally NOT pushed this release. `@yellow-org/sdk-mcp` published manually (npm + MCP registry), alongside manual `@yellow-org/sdk` + `@yellow-org/sdk-compat` publishes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 1.4.0 across multiple packages and Helm charts for faucet-app, nitronode, playground, and SDK components (mcp, ts-compat, ts).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->