### PR TITLE
Add Yellow Settlement Room agent skill

### DIFF
--- a/agent-skills/yellow-settlement-room/LICENSE
+++ b/agent-skills/yellow-settlement-room/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Yellow
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/agent-skills/yellow-settlement-room/SKILL.md
+++ b/agent-skills/yellow-settlement-room/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: yellow-settlement-room
+description: Yellow Network Protocol app sessions for AI agents - a shared room where several agents pool funds, reallocate off-chain at machine speed, and settle one final split. Use for multiparty settlement among agents. Covers connecting, the funded-account prerequisite, creating a session with participants + weights + quorum, deposit, operate, withdraw, close, and the trust boundary. Grounded in the official @yellow-org/sdk lifecycle example.
+---
+
+# Yellow Settlement Room
+
+Use this skill when several AI agents need to hold funds together and settle one outcome: open a shared session, each agent's balance is tracked inside it, they reallocate between themselves off-chain with no gas per step, and they co-sign the final split.
+
+**The session holds N agents, not two.** A payment rail moves value from one payer to one payee; a swarm of agents settling over a rail needs a separate escrow per pair. One session settles all of them at once: one object, one deposit per agent, one final allocation. That is the shape to reach for when more than two agents have a stake in the same outcome.
+
+This skill covers the **app-session (virtual) layer** only. Every method here operates on funds that are *already in a participant's account balance at Yellow*. Getting funds there is a one-time on-chain step - see `## Prerequisite`. This skill never funds accounts; check a participant's balance first with `client.getBalances(wallet)`, and if it is short, stop and report it.
+
+Package: `@yellow-org/sdk` (v1). A complete runnable reference is the official example at `github.com/layer-3/docs`, `examples/nitrolite-v1-lifecycle`; the flow below matches it exactly, generalised from two participants to N. For method lookups, the docs MCP: `npx -y @yellow-org/sdk-mcp@^1`.
+
+## Core Model
+
+```text
+Each agent has a FUNDED account at Yellow (prerequisite, on-chain, one-time)
+  -> agents open one app session: N participants, signature weights, quorum
+  -> each agent deposits channel funds into the session
+  -> agents reallocate between themselves (operate), each update co-signed to quorum
+  -> withdraw / close: the final split releases back to channels, withdrawable on-chain
+```
+
+The session is an off-chain ledger hosted by the Yellow node. Its guarantee is signature-based: **no agent's allocation changes without signatures meeting the quorum.** It is not a trustless escrow; read `## Trust Boundary` before sizing exposure.
+
+## Design Rules
+
+- **Never fund accounts from this skill.** Funding happens once, on-chain, before a session. Check each participant's balance first with `client.getBalances(wallet)`; if it is short, stop and report the shortfall. Do not attempt `deposit`, `approveToken`, or `transfer` to self-fund.
+- **Never call an allocation "locked on-chain and enforceable."** Funds are committed out of a channel and governed by quorum, so no counterparty agent can take them - but releasing them still needs the node to co-sign. State both halves.
+- **Default to equal weights and unanimous quorum.** Only give a subset of agents combined weight >= quorum when that subset is intentionally trusted. See `## Weights and Quorum`.
+
+## Prerequisite: a funded account per participant
+
+Each participant must already hold a funded account balance at Yellow for the asset. (An account is backed by an on-chain state channel, but you can treat it as the participant's balance.) That balance is the ceiling on what they can commit and the maximum they can lose. Check it before doing anything:
+
+```ts
+const balances = await client.getBalances(wallet);   // account balances at Yellow, per asset
+```
+
+Funding is a one-time on-chain operation, done once before any session and out of scope here. The funding calls, for reference, are:
+
+```ts
+await client.setHomeBlockchain(asset, chainId);
+await client.approveToken(chainId, asset, amount);
+await client.deposit(chainId, asset, amount);
+await client.checkpoint(asset);              // finalizes the deposit on-chain
+```
+
+For the exact funding sequence and any Node-specific transaction setup, see the quickstart at `docs.yellow.org/nitrolite/build/getting-started/quickstart` and the official `nitrolite-v1-lifecycle` example.
+
+## Connect
+
+```ts
+import { Client, createSigners, withBlockchainRPC } from '@yellow-org/sdk';
+
+const signers = createSigners(privateKey);       // 0x-prefixed 32-byte hex
+const client = await Client.create(
+  wsURL,                                          // sandbox: wss://nitronode-sandbox.yellow.org/v1/ws
+  signers.stateSigner, signers.txSigner,
+  withBlockchainRPC(chainId, rpcURL),
+);
+```
+
+There is no login handshake; authorization is per-call, from the signatures inside each payload. Each participant runs its own client.
+
+## Open the session
+
+```ts
+import {
+  AppSessionWalletSignerV1, EthereumMsgSigner,
+  packCreateAppSessionRequestV1, type AppDefinitionV1,
+} from '@yellow-org/sdk';
+
+// One session signer per participant. This is a plain wallet signer (type 0xa1).
+// Session keys exist as an optional friction-reducer for repeat approvals; they
+// are not required and are omitted here.
+const signerA = new AppSessionWalletSignerV1(new EthereumMsgSigner(pkA));
+const signerB = new AppSessionWalletSignerV1(new EthereumMsgSigner(pkB));
+const signerC = new AppSessionWalletSignerV1(new EthereumMsgSigner(pkC));
+
+const definition: AppDefinitionV1 = {
+  applicationId: appId,                           // ^[a-z0-9_-]{1,66}$
+  participants: [
+    { walletAddress: addrA, signatureWeight: 1 },
+    { walletAddress: addrB, signatureWeight: 1 },
+    { walletAddress: addrC, signatureWeight: 1 },
+  ],
+  quorum: 3,                                       // = sum of weights -> unanimous (the safe default)
+  nonce: BigInt(Date.now()) * 1_000_000n + BigInt(Math.floor(Math.random() * 1_000_000)),
+};
+
+const createPayload = packCreateAppSessionRequestV1(definition, sessionData);
+const created = await client.createAppSession(definition, sessionData, [
+  await signerA.signMessage(createPayload),
+  await signerB.signMessage(createPayload),
+  await signerC.signMessage(createPayload),       // creation must itself meet quorum
+]);
+// created.appSessionId, created.version, created.status
+```
+
+The participant set is **immutable after creation**; no agent can be added later. Creation must meet quorum, so every participant that makes up the quorum co-signs the create request. Optionally `client.registerApp(appId, meta, true)` first; some nodes disable the registry (`apps.v1 group is disabled`) - continue without it.
+
+## Read the live state
+
+```ts
+const { sessions } = await client.getAppSessions({ appSessionId });
+const session = sessions[0];    // session.version, session.isClosed, session.allocations
+```
+
+Read this immediately before signing any update: `version` must be exactly `session.version + 1n`.
+
+## Deposit, operate, withdraw, close
+
+All updates share one shape; `intent` is a **number**, not a string.
+
+```ts
+import { AppStateUpdateIntent, packAppStateUpdateV1, type AppStateUpdateV1 } from '@yellow-org/sdk';
+import Decimal from 'decimal.js';
+
+// DEPOSIT (own endpoint): commit channel funds into the session.
+const deposit: AppStateUpdateV1 = {
+  appSessionId, intent: AppStateUpdateIntent.Deposit, version: session.version + 1n,
+  allocations: [
+    { participant: addrA, asset, amount: new Decimal('10') },
+    { participant: addrB, asset, amount: new Decimal('0') },
+    { participant: addrC, asset, amount: new Decimal('0') },
+  ],
+  sessionData: JSON.stringify({ intent: 'fund' }),
+};
+const dp = packAppStateUpdateV1(deposit);
+await client.submitAppSessionDeposit(
+  deposit, [await signerA.signMessage(dp), await signerB.signMessage(dp), await signerC.signMessage(dp)],
+  asset, new Decimal('10'),                        // amount must equal the deposit allocation total
+);
+```
+
+```ts
+// OPERATE: reallocate between participants. Per-asset totals must stay CONSTANT,
+// and every non-zero allocation must be restated (not a delta).
+const operate: AppStateUpdateV1 = {
+  appSessionId, intent: AppStateUpdateIntent.Operate, version: /* live */ session.version + 1n,
+  allocations: [
+    { participant: addrA, asset, amount: new Decimal('4') },
+    { participant: addrB, asset, amount: new Decimal('4') },
+    { participant: addrC, asset, amount: new Decimal('2') },
+  ],
+  sessionData: JSON.stringify({ round: 'payout' }),
+};
+const op = packAppStateUpdateV1(operate);
+await client.submitAppState(operate, [ /* signatures summing to quorum */
+  await signerA.signMessage(op), await signerB.signMessage(op), await signerC.signMessage(op),
+]);
+```
+
+`Withdraw` (intent 2) may only decrease allocations and releases to channels. `Close` (intent 3) must restate the current allocation exactly, releases everything, and is terminal - never close while work or a review is outstanding. Both use `submitAppState` the same way.
+
+**Each participant collects its own signatures.** Pass one per signer until summed weight meets quorum; the protocol has no transport for gathering them across agents. Duplicate signers count once.
+
+## Weights and Quorum
+
+`signatureWeight` per participant, `quorum` = the weight threshold a state needs to be valid.
+
+- **Equal weights, quorum = sum** -> unanimous. The safe default. Use it unless you have a specific reason not to.
+- A subset of agents whose weights sum to >= quorum can settle **without** the others. That is a feature for a trusted operator (e.g. a client that funds and controls a swarm) and a hazard between adversaries: in a client/orchestrator/worker room at 1/1/1 quorum 2, the orchestrator and worker together can sign a split that pays the worker and zeroes the client. A single scalar quorum cannot protect every party's balance at N > 2. If the parties mutually distrust, give each depositor a blocking stake, or keep them in separate sessions.
+
+State which regime a session is in when you design it.
+
+## Trust Boundary
+
+State this before any agent puts value at risk. Do not soften it.
+
+- **No agent in the session can take another's allocation.** Every change needs signatures meeting quorum. This is the real, strong guarantee.
+- **The Yellow node is trusted for liveness and honest relay.** Sessions are off-chain; funds become enforceable on-chain only once released back to a channel as a node-co-signed state. If the node will not co-sign, there is no on-chain path out of the session. Yellow's own docs state the protocol is not fully trust-minimized. This is weaker than an on-chain escrow and stronger than a spending-allowance delegation (where the payer can drain the account at any time). Say which you rely on.
+- **A session has no dispute mechanism, challenge, or timeout of its own.** If quorum is never reached, funds stay in the session. Cooperative settlement is the supported path today.
+- **The deposit is the exposure ceiling.** A participant can lose at most what it committed into the session.
+
+## Composes with
+
+- **GenLayer** for subjective disputes: a session cannot judge whether work was acceptable; a jury can. The intended composition is verdict-informed cooperative settlement (parties agree up front to sign the allocation a verdict dictates). Adjudicator-enforced settlement against a non-cooperative party is roadmap, not shipped - do not place already-contested funds in a session.
+- **Alkahest** (`vendored/arkhai/alkahest-user`) for a bilateral, one-shot deal that needs trustless on-chain escrow with a reclaim timeout. Reach for a settlement room when the deal is *multiparty and many-update*, which a single bilateral escrow cannot express.
+
+## Failure Cases
+
+- Version race: `version` must be exactly `session.version + 1n`. Concurrent signers collide and one update fails cleanly (the node serializes). Re-read the live version, re-collect signatures, retry. Most common friction in a busy room.
+- Quorum never reached: permanent deadlock, no timeout. Prevent by design (cooperative weights); for adversarial bilateral deals use Alkahest.
+- Unfunded participant: `submitAppSessionDeposit` fails if the account is not funded (on the sandbox the node error reads `no channel state to advance`). This is the prerequisite, not a bug - check `getBalances(wallet)` first and report a shortfall.
+- `Operate` that drops a non-zero allocation or whose per-asset total drifts: rejected.
+- `Close` while work or a review is outstanding: terminal and unrecoverable.
+- Node fails to co-sign a release: surface as a stuck session; do not retry silently or report success.
+
+## Output Checklist
+
+1. Which agents are in the session, and whether they cooperate or mutually distrust.
+2. Participant set with weights and quorum, and the arithmetic showing no coalition can rob a party.
+3. Each participant's funded balance confirmed via `getBalances(wallet)`, and its deposit as the max it can lose.
+4. The happy path: open, deposit, operate, (withdraw), close - and the disagreement path, or an explicit statement that the room deadlocks.
+5. The trust disclosure from `## Trust Boundary`, in plain language, before any value moves.
+
+## References
+
+- `references/agent-lifecycle.md` - the full multiparty flow as runnable code, matching the official `nitrolite-v1-lifecycle` example.

--- a/agent-skills/yellow-settlement-room/references/agent-lifecycle.md
+++ b/agent-skills/yellow-settlement-room/references/agent-lifecycle.md
@@ -1,0 +1,169 @@
+# Multiparty Settlement Room — Runnable Lifecycle
+
+Real code, real method names, grounded in the official `@yellow-org/sdk` example at `github.com/layer-3/docs`, `examples/nitrolite-v1-lifecycle`. That example runs a two-party lifecycle against the Yellow sandbox; the flow below is the same API generalised to three participants. Nothing here is invented - every method appears in the official example.
+
+## Setup
+
+ESM project, Node 20+.
+
+```jsonc
+// package.json
+{ "type": "module",
+  "dependencies": { "@yellow-org/sdk": "^1", "decimal.js": "^10", "viem": "^2" } }
+```
+
+Environment per participant: a funded user wallet (Sepolia gas + the test asset), an RPC URL, and the Nitronode WS URL (`wss://nitronode-sandbox.yellow.org/v1/ws` for sandbox).
+
+## 0. Prerequisite: each participant's account must be funded
+
+App sessions operate on funds already in a participant's account balance at Yellow (an account is backed by an on-chain channel; treat it as the participant's balance). Funding is done once per participant and is a hard prerequisite - `submitAppSessionDeposit` fails without it. The funding calls, from the official example:
+
+```ts
+await client.setHomeBlockchain(asset, chainId);
+await client.approveToken(chainId, asset, amount);
+const depositState = await client.deposit(chainId, asset, amount);
+const txHash = await client.checkpoint(asset);        // finalizes on-chain
+```
+
+For the exact funding sequence and any Node-specific transaction setup, follow the official `nitrolite-v1-lifecycle` example and the quickstart.
+
+**This skill assumes that prerequisite is already met.** It never funds accounts. Check a participant's balance first:
+
+```ts
+const balances = await client.getBalances(wallet);    // account balances at Yellow, per asset
+// if the asset balance is below what this agent must deposit, stop and report it.
+```
+
+## 1. Connect (one client per participant)
+
+```ts
+import { Client, createSigners, withBlockchainRPC } from '@yellow-org/sdk';
+
+async function connect(pk: `0x${string}`, wsURL: string, chainId: bigint, rpcURL: string) {
+  const s = createSigners(pk);
+  return Client.create(wsURL, s.stateSigner, s.txSigner, withBlockchainRPC(chainId, rpcURL));
+}
+```
+
+## 2. Open a three-party room
+
+```ts
+import {
+  AppSessionWalletSignerV1, EthereumMsgSigner,
+  packCreateAppSessionRequestV1, type AppDefinitionV1,
+} from '@yellow-org/sdk';
+
+// One session signer per participant - a plain wallet signer (type 0xa1).
+const sign = {
+  A: new AppSessionWalletSignerV1(new EthereumMsgSigner(pkA)),
+  B: new AppSessionWalletSignerV1(new EthereumMsgSigner(pkB)),
+  C: new AppSessionWalletSignerV1(new EthereumMsgSigner(pkC)),
+};
+
+const definition: AppDefinitionV1 = {
+  applicationId: `room-${Date.now().toString(36)}`,   // ^[a-z0-9_-]{1,66}$
+  participants: [
+    { walletAddress: addrA, signatureWeight: 1 },
+    { walletAddress: addrB, signatureWeight: 1 },
+    { walletAddress: addrC, signatureWeight: 1 },
+  ],
+  quorum: 3,                                            // unanimous: the safe default
+  nonce: BigInt(Date.now()) * 1_000_000n + BigInt(Math.floor(Math.random() * 1_000_000)),
+};
+
+const sessionData = JSON.stringify({ intent: 'init' });
+const createPayload = packCreateAppSessionRequestV1(definition, sessionData);
+const created = await clientA.createAppSession(definition, sessionData, [
+  await sign.A.signMessage(createPayload),
+  await sign.B.signMessage(createPayload),
+  await sign.C.signMessage(createPayload),             // creation must meet quorum
+]);
+const appSessionId = created.appSessionId;
+```
+
+## 3. Read live state (before every update)
+
+```ts
+async function getSession(client, appSessionId: string) {
+  const { sessions } = await client.getAppSessions({ appSessionId });
+  const s = sessions[0];
+  if (!s) throw new Error('session not found');
+  return s;   // s.version, s.isClosed, s.allocations
+}
+```
+
+## 4. Deposit funds into the room
+
+```ts
+import { AppStateUpdateIntent, packAppStateUpdateV1, type AppStateUpdateV1 } from '@yellow-org/sdk';
+import Decimal from 'decimal.js';
+
+let session = await getSession(clientA, appSessionId);
+const clientBudget = new Decimal('10');
+
+const deposit: AppStateUpdateV1 = {
+  appSessionId, intent: AppStateUpdateIntent.Deposit, version: session.version + 1n,
+  allocations: [
+    { participant: addrA, asset, amount: clientBudget },
+    { participant: addrB, asset, amount: new Decimal('0') },
+    { participant: addrC, asset, amount: new Decimal('0') },
+  ],
+  sessionData: JSON.stringify({ intent: 'fund' }),
+};
+const dp = packAppStateUpdateV1(deposit);
+await clientA.submitAppSessionDeposit(
+  deposit,
+  [await sign.A.signMessage(dp), await sign.B.signMessage(dp), await sign.C.signMessage(dp)],
+  asset, clientBudget,                                  // amount == deposit allocation total
+);
+```
+
+## 5. Operate: reallocate among the three, off-chain
+
+The client pays two providers out of the pooled budget. Per-asset totals stay constant; every non-zero allocation is restated.
+
+```ts
+session = await getSession(clientA, appSessionId);      // re-read for live version
+const payout: AppStateUpdateV1 = {
+  appSessionId, intent: AppStateUpdateIntent.Operate, version: session.version + 1n,
+  allocations: [
+    { participant: addrA, asset, amount: new Decimal('4') },   // client keeps 4
+    { participant: addrB, asset, amount: new Decimal('4') },   // provider B earns 4
+    { participant: addrC, asset, amount: new Decimal('2') },   // provider C earns 2
+  ],
+  sessionData: JSON.stringify({ round: 'final-split' }),
+};
+const op = packAppStateUpdateV1(payout);
+await clientA.submitAppState(payout, [
+  await sign.A.signMessage(op), await sign.B.signMessage(op), await sign.C.signMessage(op),
+]);
+```
+
+Repeat `operate` as many times as the work has milestones - all off-chain, no gas per step. That repetition, among N parties, is the capability a bilateral rail cannot express.
+
+## 6. Close: release the final split
+
+```ts
+session = await getSession(clientA, appSessionId);
+const close: AppStateUpdateV1 = {
+  appSessionId, intent: AppStateUpdateIntent.Close, version: session.version + 1n,
+  allocations: session.allocations,                     // must restate current state exactly
+  sessionData: JSON.stringify({ intent: 'close' }),
+};
+const cp = packAppStateUpdateV1(close);
+await clientA.submitAppState(close, [
+  await sign.A.signMessage(cp), await sign.B.signMessage(cp), await sign.C.signMessage(cp),
+]);
+// allocations release back to each participant's channel, withdrawable on-chain.
+```
+
+## Gotchas
+
+- ESM only: `"type": "module"`.
+- The funding prerequisite (Step 0) is mandatory; `submitAppSessionDeposit` fails on an unfunded account (sandbox error: `no channel state to advance`). Check `getBalances(wallet)` first.
+- `intent` is a number on the wire (`Operate=0, Deposit=1, Withdraw=2, Close=3`). Docs that show strings are wrong.
+- Creation must meet quorum: multi-party create needs multiple signatures, not one.
+- `version` must be exactly `session.version + 1n`; re-read live before signing and retry on collision, re-collecting signatures.
+- `Operate` restates every non-zero allocation with per-asset totals unchanged; `Close` restates the current allocation exactly.
+- Read decimals from `client.getAssets(chainId)` rather than hardcoding; the same symbol differs per chain. `yusd` is sandbox; production uses `usdc`/`usdt`.
+- Weights: equal + quorum = sum is unanimous and safe. A subset summing to quorum can settle without the rest - fine for a trusted operator, dangerous between adversaries.


### PR DESCRIPTION
# Yellow Settlement Room — Agent Skill

An [Internet Court](https://github.com/internet-court/internet-court-skill) skill for **Yellow Network Protocol**, written for AI agents as the users.

A settlement room is a Yellow **app session**: many agents pool funds in one shared ledger, reallocate between themselves off-chain at machine speed with no gas per step, and co-sign one final split that releases back on-chain. It is the multilateral *settlement rail* beneath a deal.

**N agents, one session, one settlement** - the shape a bilateral escrow cannot express. Every method in the skill is from the official `@yellow-org/sdk` lifecycle example; the flow is that example generalised from two participants to N.

## Where it sits in the stack

| Need | Use |
|---|---|
| Several agents pool funds, reallocate off-chain, settle one split | **this skill** |
| A subjective dispute decided by an independent jury | **GenLayer** (verdict-informed cooperative settlement) |
| A bilateral, one-shot deal needing trustless on-chain escrow with a refund timeout | **Alkahest** |
| Pay per request against a spending allowance | **x402 / ERC-7710** |

It composes with the others; it does not replace them.

## Contents

- [`yellow-settlement-room/SKILL.md`](yellow-settlement-room/SKILL.md)
- [`yellow-settlement-room/references/agent-lifecycle.md`](yellow-settlement-room/references/agent-lifecycle.md) - the full multiparty flow as runnable code

## Grounding

Real, runnable reference: `github.com/layer-3/docs`, `examples/nitrolite-v1-lifecycle` (two-party lifecycle against the Yellow sandbox). Docs: `docs.yellow.org/nitrolite/builder-toolkit`. Method lookups: `npx -y @yellow-org/sdk-mcp@^1`.

## Status

Built against `@yellow-org/sdk` v1 (Nitrolite v1). Ready for integration.

## License

MIT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guidance for creating and managing multiparty Yellow Network settlement sessions.
  * Documented session setup, funding, deposits, operations, withdrawals, closures, signatures, quorum rules, and failure scenarios.
  * Added a runnable three-participant lifecycle reference with setup requirements and practical examples.

* **Documentation**
  * Included guidance on trust boundaries, asset allocations, versioning, and common implementation pitfalls.
  * Added an MIT license for the settlement-room skill.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->