### PR TITLE
fix(yellow-settlement-room): distributed keys + funding rule (review)

### DIFF
--- a/agent-skills/yellow-settlement-room/SKILL.md
+++ b/agent-skills/yellow-settlement-room/SKILL.md
@@ -9,16 +9,18 @@ Use this skill when several AI agents need to hold funds together and settle one
 
 **The session holds N agents, not two.** A payment rail moves value from one payer to one payee; a swarm of agents settling over a rail needs a separate escrow per pair. One session settles all of them at once: one object, one deposit per agent, one final allocation. That is the shape to reach for when more than two agents have a stake in the same outcome.
 
-This skill covers the **app-session (virtual) layer** only. Every method here operates on funds that are *already in a participant's account balance at Yellow*. Getting funds there is a one-time on-chain step - see `## Prerequisite`. This skill never funds accounts; check a participant's balance first with `client.getBalances(wallet)`, and if it is short, stop and report it.
+This skill covers the **app-session (virtual) layer** only. It operates on funds that are *already in an account balance at Yellow*. A session opens with zero allocations, so not every participant needs funds - only a participant that makes a deposit does. Getting funds into an account is a one-time on-chain step, out of scope here - see `## Prerequisite`. This skill never funds accounts; before a participant deposits, check its balance with `client.getBalances(wallet)`, and if it is short, stop and report it.
 
 Package: `@yellow-org/sdk` (v1). A complete runnable reference is the official example at `github.com/layer-3/docs`, `examples/nitrolite-v1-lifecycle`; the flow below matches it exactly, generalised from two participants to N. For method lookups, the docs MCP: `npx -y @yellow-org/sdk-mcp@^1`.
 
 ## Core Model
 
 ```text
-Each agent has a FUNDED account at Yellow (prerequisite, on-chain, one-time)
+Each agent runs its own client with its own key (backend: private-key based)
   -> agents open one app session: N participants, signature weights, quorum
-  -> each agent deposits channel funds into the session
+     (opens with ZERO allocations; nobody needs funds yet)
+  -> a depositing agent commits its OWN funds into the session
+     (only depositors need a funded account; others can hold zero)
   -> agents reallocate between themselves (operate), each update co-signed to quorum
   -> withdraw / close: the final split releases back to channels, withdrawable on-chain
 ```
@@ -27,13 +29,14 @@ The session is an off-chain ledger hosted by the Yellow node. Its guarantee is s
 
 ## Design Rules
 
-- **Never fund accounts from this skill.** Funding happens once, on-chain, before a session. Check each participant's balance first with `client.getBalances(wallet)`; if it is short, stop and report the shortfall. Do not attempt `deposit`, `approveToken`, or `transfer` to self-fund.
+- **One agent, one key, one client.** Each agent signs only with its own key, from its own process. A backend service is private-key based; a frontend is wallet based. You cannot take several agents' private keys into one client. Holding multiple participants' keys in one process is valid only as a local test or an explicitly custodial server. See `## Roles and key separation`.
+- **Never fund accounts from this skill.** Funding happens once, on-chain, before a session. Only a participant that deposits needs funds; check its balance first with `client.getBalances(wallet)` and if it is short, stop and report the shortfall. Do not attempt `deposit`, `approveToken`, or `transfer` to self-fund.
 - **Never call an allocation "locked on-chain and enforceable."** Funds are committed out of a channel and governed by quorum, so no counterparty agent can take them - but releasing them still needs the node to co-sign. State both halves.
 - **Default to equal weights and unanimous quorum.** Only give a subset of agents combined weight >= quorum when that subset is intentionally trusted. See `## Weights and Quorum`.
 
-## Prerequisite: a funded account per participant
+## Prerequisite: a funded account for each depositor
 
-Each participant must already hold a funded account balance at Yellow for the asset. (An account is backed by an on-chain state channel, but you can treat it as the participant's balance.) That balance is the ceiling on what they can commit and the maximum they can lose. Check it before doing anything:
+A session is created with zero allocations, so not every participant needs funds. Only a participant that makes a deposit needs a funded account balance at Yellow for the asset. (An account is backed by an on-chain state channel, but you can treat it as the participant's balance.) That balance is the ceiling on what a depositor can commit and the most it can lose. Check a depositor's balance before it deposits:
 
 ```ts
 const balances = await client.getBalances(wallet);   // account balances at Yellow, per asset
@@ -63,7 +66,18 @@ const client = await Client.create(
 );
 ```
 
-There is no login handshake; authorization is per-call, from the signatures inside each payload. Each participant runs its own client.
+There is no login handshake; authorization is per-call, from the signatures inside each payload. **Each agent runs its own client with its own key, in its own process.** The examples below show several signers together for readability; in a real agent-to-agent deployment each agent constructs only its own signer and signs only its own part.
+
+## Roles and key separation
+
+Agent-to-agent means the keys are distributed. You cannot take several agents' private keys into one client. Model these roles:
+
+- **Each agent** holds its own key and runs its own client. A backend agent is private-key based; a frontend agent is wallet based. It signs only its own part of any state, in its own process.
+- **Proposer** (an agent, or a coordinating server): builds a state update, packs the hash, and asks each required signer to sign it.
+- **Signers** (the agents whose combined weight must meet quorum): each signs the packed hash with its own key and returns the signature.
+- **Submitter** (usually the proposer): collects the signatures and calls the Nitronode (`createAppSession` / `submitAppSessionDeposit` / `submitAppState`).
+
+A common topology: a Nitronode, agents connecting to a coordinating server (an app), and agents transacting agent-to-agent through shared sessions. The single-process code below co-locates keys only for readability and local testing; do not ship it that way.
 
 ## Open the session
 
@@ -73,9 +87,11 @@ import {
   packCreateAppSessionRequestV1, type AppDefinitionV1,
 } from '@yellow-org/sdk';
 
-// One session signer per participant. This is a plain wallet signer (type 0xa1).
-// Session keys exist as an optional friction-reducer for repeat approvals; they
-// are not required and are omitted here.
+// One session signer per participant, a plain wallet signer (type 0xa1).
+// LOCAL TEST ONLY: holding pkA, pkB, pkC in one process is a shortcut for a
+// smoke test or a custodial server. In a real deployment each agent builds ONLY
+// its own signer, in its own process, from its own key (see Roles and key
+// separation above). Session keys are an optional friction-reducer, omitted here.
 const signerA = new AppSessionWalletSignerV1(new EthereumMsgSigner(pkA));
 const signerB = new AppSessionWalletSignerV1(new EthereumMsgSigner(pkB));
 const signerC = new AppSessionWalletSignerV1(new EthereumMsgSigner(pkC));
@@ -119,17 +135,20 @@ All updates share one shape; `intent` is a **number**, not a string.
 import { AppStateUpdateIntent, packAppStateUpdateV1, type AppStateUpdateV1 } from '@yellow-org/sdk';
 import Decimal from 'decimal.js';
 
-// DEPOSIT (own endpoint): commit channel funds into the session.
+// DEPOSIT (own endpoint): a depositor commits its OWN funds into the session.
+// List ONLY the depositing participant in allocations; do not add zero-value
+// entries for participants who are not depositing here.
 const deposit: AppStateUpdateV1 = {
   appSessionId, intent: AppStateUpdateIntent.Deposit, version: session.version + 1n,
   allocations: [
     { participant: addrA, asset, amount: new Decimal('10') },
-    { participant: addrB, asset, amount: new Decimal('0') },
-    { participant: addrC, asset, amount: new Decimal('0') },
   ],
   sessionData: JSON.stringify({ intent: 'fund' }),
 };
 const dp = packAppStateUpdateV1(deposit);
+// The deposit state still needs signatures meeting quorum. Each agent signs the
+// hash with its OWN key in its OWN process; here they are shown together only for
+// readability. The submitter gathers the signatures and calls the node.
 await client.submitAppSessionDeposit(
   deposit, [await signerA.signMessage(dp), await signerB.signMessage(dp), await signerC.signMessage(dp)],
   asset, new Decimal('10'),                        // amount must equal the deposit allocation total
@@ -156,7 +175,7 @@ await client.submitAppState(operate, [ /* signatures summing to quorum */
 
 `Withdraw` (intent 2) may only decrease allocations and releases to channels. `Close` (intent 3) must restate the current allocation exactly, releases everything, and is terminal - never close while work or a review is outstanding. Both use `submitAppState` the same way.
 
-**Each participant collects its own signatures.** Pass one per signer until summed weight meets quorum; the protocol has no transport for gathering them across agents. Duplicate signers count once.
+**Signatures are collected across agents, off the wire.** The proposer builds the state and hash; each agent signs that hash with its own key in its own process; the submitter gathers the signatures until summed weight meets quorum and calls the node. The protocol provides no transport for this exchange - it is the caller's responsibility. Duplicate signers count once.
 
 ## Weights and Quorum
 
@@ -194,7 +213,7 @@ State this before any agent puts value at risk. Do not soften it.
 
 1. Which agents are in the session, and whether they cooperate or mutually distrust.
 2. Participant set with weights and quorum, and the arithmetic showing no coalition can rob a party.
-3. Each participant's funded balance confirmed via `getBalances(wallet)`, and its deposit as the max it can lose.
+3. Each depositor's funded balance confirmed via `getBalances(wallet)`, and its deposit as the max it can lose. Non-depositing participants need no funds.
 4. The happy path: open, deposit, operate, (withdraw), close - and the disagreement path, or an explicit statement that the room deadlocks.
 5. The trust disclosure from `## Trust Boundary`, in plain language, before any value moves.
 

--- a/agent-skills/yellow-settlement-room/SKILL.md
+++ b/agent-skills/yellow-settlement-room/SKILL.md
@@ -66,18 +66,32 @@ const client = await Client.create(
 );
 ```
 
-There is no login handshake; authorization is per-call, from the signatures inside each payload. **Each agent runs its own client with its own key, in its own process.** The examples below show several signers together for readability; in a real agent-to-agent deployment each agent constructs only its own signer and signs only its own part.
+There is no login handshake; authorization is per-call, from the signatures inside each payload. **Each agent runs its own client with its own key, in its own process.** The examples below show several signers together for readability; in a real agent-to-agent deployment each agent constructs only its own signer and signs the shared state hash with its own key.
 
 ## Roles and key separation
 
 Agent-to-agent means the keys are distributed. You cannot take several agents' private keys into one client. Model these roles:
 
-- **Each agent** holds its own key and runs its own client. A backend agent is private-key based; a frontend agent is wallet based. It signs only its own part of any state, in its own process.
-- **Proposer** (an agent, or a coordinating server): builds a state update, packs the hash, and asks each required signer to sign it.
+- **Each agent** holds its own key and runs its own client. A backend agent is private-key based; a frontend agent is wallet based. Every signer signs the **same** full-state hash independently with its own key, in its own process (this is independent co-signing, not partial or threshold signing).
+- **Proposer** (an agent, or a coordinating server): builds a state update, packs the hash, and sends that hash to each required signer.
 - **Signers** (the agents whose combined weight must meet quorum): each signs the packed hash with its own key and returns the signature.
 - **Submitter** (usually the proposer): collects the signatures and calls the Nitronode (`createAppSession` / `submitAppSessionDeposit` / `submitAppState`).
 
-A common topology: a Nitronode, agents connecting to a coordinating server (an app), and agents transacting agent-to-agent through shared sessions. The single-process code below co-locates keys only for readability and local testing; do not ship it that way.
+The cross-process pattern uses the same methods as the single-process code below:
+
+```ts
+// Proposer (any agent or a coordinating server): build the state, pack the hash.
+const hash = packAppStateUpdateV1(update);   // portable 0x string, safe to send over the wire
+
+// Each signer, in its OWN process with its OWN key:
+const mySig = await new AppSessionWalletSignerV1(new EthereumMsgSigner(myKey)).signMessage(hash);
+// ...return mySig to the proposer over your own transport (HTTP, queue, etc.)
+
+// Submitter: gather signatures until summed weight meets quorum, then submit once.
+await client.submitAppState(update, [sigFromA, sigFromB, sigFromC]);
+```
+
+The protocol carries no transport for moving the hash out and the signatures back; that is the integrator's to build. A common topology: a Nitronode, agents connecting to a coordinating server (an app), and agents transacting agent-to-agent through shared sessions. The single-process code below co-locates keys only for readability and local testing; do not ship it that way.
 
 ## Open the session
 
@@ -116,7 +130,7 @@ const created = await client.createAppSession(definition, sessionData, [
 // created.appSessionId, created.version, created.status
 ```
 
-The participant set is **immutable after creation**; no agent can be added later. Creation must meet quorum, so every participant that makes up the quorum co-signs the create request. Optionally `client.registerApp(appId, meta, true)` first; some nodes disable the registry (`apps.v1 group is disabled`) - continue without it.
+The participant set is **immutable after creation**; no agent can be added later. Creation must meet quorum, so every participant that makes up the quorum co-signs the create request.
 
 ## Read the live state
 
@@ -133,7 +147,7 @@ All updates share one shape; `intent` is a **number**, not a string.
 
 ```ts
 import { AppStateUpdateIntent, packAppStateUpdateV1, type AppStateUpdateV1 } from '@yellow-org/sdk';
-import Decimal from 'decimal.js';
+import { Decimal } from 'decimal.js';   // named import: default import is not constructable under NodeNext
 
 // DEPOSIT (own endpoint): a depositor commits its OWN funds into the session.
 // List ONLY the depositing participant in allocations; do not add zero-value

--- a/agent-skills/yellow-settlement-room/references/agent-lifecycle.md
+++ b/agent-skills/yellow-settlement-room/references/agent-lifecycle.md
@@ -2,6 +2,8 @@
 
 Real code, real method names, grounded in the official `@yellow-org/sdk` example at `github.com/layer-3/docs`, `examples/nitrolite-v1-lifecycle`. That example runs a two-party lifecycle against the Yellow sandbox; the flow below is the same API generalised to three participants. Nothing here is invented - every method appears in the official example.
 
+**Key separation.** In a real agent-to-agent deployment each agent runs its own client with its own key, in its own process, and signs only its own part. The three-signers-in-one-process code below co-locates keys purely for a readable local run or a custodial server; do not ship it that way. See the skill's `Roles and key separation` section.
+
 ## Setup
 
 ESM project, Node 20+.
@@ -12,11 +14,11 @@ ESM project, Node 20+.
   "dependencies": { "@yellow-org/sdk": "^1", "decimal.js": "^10", "viem": "^2" } }
 ```
 
-Environment per participant: a funded user wallet (Sepolia gas + the test asset), an RPC URL, and the Nitronode WS URL (`wss://nitronode-sandbox.yellow.org/v1/ws` for sandbox).
+Environment per participant: its own key, an RPC URL, and the Nitronode WS URL (`wss://nitronode-sandbox.yellow.org/v1/ws` for sandbox). Only participants that DEPOSIT also need a funded wallet (Sepolia gas + the test asset); non-depositing participants need neither gas nor the asset.
 
-## 0. Prerequisite: each participant's account must be funded
+## 0. Prerequisite: a funded account for each depositor
 
-App sessions operate on funds already in a participant's account balance at Yellow (an account is backed by an on-chain channel; treat it as the participant's balance). Funding is done once per participant and is a hard prerequisite - `submitAppSessionDeposit` fails without it. The funding calls, from the official example:
+A session opens with zero allocations, so not every participant needs funds. Only a participant that makes a deposit needs a funded account balance at Yellow (an account is backed by an on-chain channel; treat it as the participant's balance). Funding is done once, on-chain, and is a hard prerequisite for a depositor - `submitAppSessionDeposit` fails on an unfunded account. The funding calls, from the official example:
 
 ```ts
 await client.setHomeBlockchain(asset, chainId);
@@ -27,7 +29,7 @@ const txHash = await client.checkpoint(asset);        // finalizes on-chain
 
 For the exact funding sequence and any Node-specific transaction setup, follow the official `nitrolite-v1-lifecycle` example and the quickstart.
 
-**This skill assumes that prerequisite is already met.** It never funds accounts. Check a participant's balance first:
+**This skill assumes each depositor is already funded.** It never funds accounts. Check a depositor's balance before it deposits:
 
 ```ts
 const balances = await client.getBalances(wallet);    // account balances at Yellow, per asset
@@ -53,7 +55,10 @@ import {
   packCreateAppSessionRequestV1, type AppDefinitionV1,
 } from '@yellow-org/sdk';
 
-// One session signer per participant - a plain wallet signer (type 0xa1).
+// LOCAL TEST ONLY: co-locating pkA, pkB, pkC in one process is a shortcut for a
+// readable local run or a custodial server. In a real agent-to-agent deployment
+// each agent builds ONLY its own signer, in its own process, from its own key,
+// and signs only its own part.
 const sign = {
   A: new AppSessionWalletSignerV1(new EthereumMsgSigner(pkA)),
   B: new AppSessionWalletSignerV1(new EthereumMsgSigner(pkB)),
@@ -101,16 +106,18 @@ import Decimal from 'decimal.js';
 let session = await getSession(clientA, appSessionId);
 const clientBudget = new Decimal('10');
 
+// Only the DEPOSITING participant (the client) appears in allocations; do not
+// add zero-value entries for the others.
 const deposit: AppStateUpdateV1 = {
   appSessionId, intent: AppStateUpdateIntent.Deposit, version: session.version + 1n,
   allocations: [
     { participant: addrA, asset, amount: clientBudget },
-    { participant: addrB, asset, amount: new Decimal('0') },
-    { participant: addrC, asset, amount: new Decimal('0') },
   ],
   sessionData: JSON.stringify({ intent: 'fund' }),
 };
 const dp = packAppStateUpdateV1(deposit);
+// The deposit state still needs signatures meeting quorum; each agent signs the
+// hash with its own key (shown together here only for a local run).
 await clientA.submitAppSessionDeposit(
   deposit,
   [await sign.A.signMessage(dp), await sign.B.signMessage(dp), await sign.C.signMessage(dp)],
@@ -160,7 +167,8 @@ await clientA.submitAppState(close, [
 ## Gotchas
 
 - ESM only: `"type": "module"`.
-- The funding prerequisite (Step 0) is mandatory; `submitAppSessionDeposit` fails on an unfunded account (sandbox error: `no channel state to advance`). Check `getBalances(wallet)` first.
+- The funding prerequisite (Step 0) applies to depositors only; `submitAppSessionDeposit` fails on an unfunded account (sandbox error: `no channel state to advance`). Check `getBalances(wallet)` first. Non-depositing participants need no funds.
+- Distributed keys: in a real deployment each agent runs its own client and signs only its own part with its own key. The single-process code here is a readable local run, not a deployment pattern.
 - `intent` is a number on the wire (`Operate=0, Deposit=1, Withdraw=2, Close=3`). Docs that show strings are wrong.
 - Creation must meet quorum: multi-party create needs multiple signatures, not one.
 - `version` must be exactly `session.version + 1n`; re-read live before signing and retry on collision, re-collecting signatures.

--- a/agent-skills/yellow-settlement-room/references/agent-lifecycle.md
+++ b/agent-skills/yellow-settlement-room/references/agent-lifecycle.md
@@ -101,7 +101,7 @@ async function getSession(client, appSessionId: string) {
 
 ```ts
 import { AppStateUpdateIntent, packAppStateUpdateV1, type AppStateUpdateV1 } from '@yellow-org/sdk';
-import Decimal from 'decimal.js';
+import { Decimal } from 'decimal.js';   // named import: default is not constructable under NodeNext
 
 let session = await getSession(clientA, appSessionId);
 const clientBudget = new Decimal('10');


### PR DESCRIPTION
Applies the two most important corrections from protocol-team review (dimast-x and akushniruk) to the yellow-settlement-room skill.

## 1. Separate keys, distributed signing (agent-to-agent)
The examples held several participants' private keys in one process. That is only valid as a local test or a custodial server. In a real agent-to-agent deployment each agent runs its own client with its own key, in its own process, and signs only its own part.
- New **Roles and key separation** section (proposer / signers / submitter, plus the NODE + agents + coordinating-server topology).
- New design rule: one agent, one key, one client.
- Single-process code is now explicitly labelled LOCAL TEST ONLY in both files.
- Signature collection reworded as an across-the-wire exchange, not one process signing for all.

## 2. Funding rule
A session opens with zero allocations, so not every participant needs funds. Only a participant that makes a deposit needs a funded account.
- Prerequisite retitled and reworded (a funded account for each depositor, not per participant).
- Deposit payload no longer lists zero-value entries for non-depositing participants.
- Core Model, design rule, failure case, and checklist updated to match.

No API/method changes; documentation-accuracy only. Verified against @yellow-org/sdk v1 and the official nitrolite-v1-lifecycle example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that settlement sessions begin with no allocations and use funds already held by depositing participants.
  * Updated prerequisites to distinguish depositors from other participants.
  * Expanded guidance on proposer, signer, and submitter roles, including key separation for deployed environments.
  * Refined deposit, withdrawal, signing, and lifecycle examples to reflect depositor-only allocations.
  * Added clearer notes on funding validation, signature collection, and local testing limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->